### PR TITLE
Fixed typo on Entity Picking tutorial

### DIFF
--- a/content/en/tutorials/intermediate/entity-picking.md
+++ b/content/en/tutorials/intermediate/entity-picking.md
@@ -40,7 +40,7 @@ PickerRaycast.prototype.onSelect = function (e) {
 
 ## Frame Buffer Picking
 
-Frame buffer based picking uses the [pc.Picker][3] class to render the scene to a internal buffer. When the mouse is clicked the color of the buffer at the mouse location is used to determine which mesh instance was selected. This has some advantages and disadvantages over the collision based method. Advantages include: using a rectangle to pick many items in a scene at once, this method doesn't have require the physics library to be included and active in your project. The main disadvantage is that this uses the `readPixels` method which stalls the graphics pipeline. This can have serious rendering performance implications particularly no mobile.
+Frame buffer based picking uses the [pc.Picker][3] class to render the scene to a internal buffer. When the mouse is clicked the color of the buffer at the mouse location is used to determine which mesh instance was selected. This has some advantages and disadvantages over the collision based method. Advantages include: using a rectangle to pick many items in a scene at once, this method doesn't have require the physics library to be included and active in your project. The main disadvantage is that this uses the `readPixels` method which stalls the graphics pipeline. This can have serious rendering performance implications particularly on mobile.
 
 ~~~javascript~~~
 var PickerFramebuffer = pc.createScript('pickerFramebuffer');


### PR DESCRIPTION
Fixed typo from "implications particularly no mobile." to "implications particularly on mobile."