### PR TITLE
Updated links

### DIFF
--- a/content/en/user-manual/assets/finding.md
+++ b/content/en/user-manual/assets/finding.md
@@ -20,7 +20,7 @@ Asset marketplaces are online libraries of content that you can download, either
     <tr><td><a href="http://www.cgtrader.com/">CGTrader</a></td><td></td><td>&#x2713;</td><td></td></tr>
     <tr><td><a href="https://www.gamedevmarket.net?ally=O0I9alFp">Game Dev Market</a></td><td>&#x2713;</td><td>&#x2713;</td><td>&#x2713;</td></tr>
     <tr><td><a href="https://gamesounds.xyz/">GameSounds.xyz</a></td><td></td><td></td><td>&#x2713;</td></tr>
-    <tr><td><a href="https://kenney.nl/">Kenney</a></td>&#x2713;<td></td><td>&#x2713;</td><td>&#x2713;</td></tr>
+    <tr><td><a href="https://kenney.nl/">Kenney</a></td><td>&#x2713;</td><td>&#x2713;</td><td>&#x2713;</td></tr>
     <tr><td><a href="http://www.mixamo.com/">Mixamo</a></td><td></td><td>&#x2713;</td><td></td></tr>
     <tr><td><a href="http://www.playonloop.com/music-loops-category/videogame/">PlayOnLoop</a></td><td></td><td></td><td>&#x2713;</td></tr>
     <tr><td><a href="http://www.opengameart.org/">Open Game Art</a></td><td>&#x2713;</td><td>&#x2713;</td><td>&#x2713;</td></tr>

--- a/content/en/user-manual/assets/finding.md
+++ b/content/en/user-manual/assets/finding.md
@@ -18,15 +18,13 @@ Asset marketplaces are online libraries of content that you can download, either
     <tr><td><a href="http://www.3dmodels-textures.com/">3D Models Textures</a></td><td></td><td>&#x2713;</td><td>&#x2713;</td></tr>
     <tr><td><a href="http://www.blendswap.com/">BlendSwap</a></td><td></td><td>&#x2713;</td><td></td></tr>
     <tr><td><a href="http://www.cgtrader.com/">CGTrader</a></td><td></td><td>&#x2713;</td><td></td></tr>
-    <tr><td><a href="http://www.frogames.net/">Fro Games</a></td><td></td><td>&#x2713;</td><td></td></tr>
     <tr><td><a href="https://www.gamedevmarket.net?ally=O0I9alFp">Game Dev Market</a></td><td>&#x2713;</td><td>&#x2713;</td><td>&#x2713;</td></tr>
+    <tr><td><a href="https://gamesounds.xyz/">GameSounds.xyz</a></td><td></td><td></td><td>&#x2713;</td></tr>
     <tr><td><a href="http://www.mixamo.com/">Mixamo</a></td><td></td><td>&#x2713;</td><td></td></tr>
     <tr><td><a href="http://www.playonloop.com/music-loops-category/videogame/">PlayOnLoop</a></td><td></td><td></td><td>&#x2713;</td></tr>
-    <tr><td><a href="http://www.propsplanet.com/">Props Planet</a></td><td></td><td>&#x2713;</td><td></td></tr>
     <tr><td><a href="http://www.opengameart.org/">Open Game Art</a></td><td>&#x2713;</td><td>&#x2713;</td><td>&#x2713;</td></tr>
     <tr><td><a href="http://www.soundbible.com/">Sound Bible</a></td><td></td><td></td><td>&#x2713;</td></tr>
     <tr><td><a href="http://www.turbosquid.com/">Turbosquid</a></td><td>&#x2713;</td><td>&#x2713;</td><td>&#x2713;</td></tr>
-    <tr><td><a href="http://www.yobi3d.com/">Yobi3D</a></td><td></td><td>&#x2713;</td><td></td></tr>
 </table>
 
 ## Procedural Generation Tools

--- a/content/en/user-manual/assets/finding.md
+++ b/content/en/user-manual/assets/finding.md
@@ -20,6 +20,7 @@ Asset marketplaces are online libraries of content that you can download, either
     <tr><td><a href="http://www.cgtrader.com/">CGTrader</a></td><td></td><td>&#x2713;</td><td></td></tr>
     <tr><td><a href="https://www.gamedevmarket.net?ally=O0I9alFp">Game Dev Market</a></td><td>&#x2713;</td><td>&#x2713;</td><td>&#x2713;</td></tr>
     <tr><td><a href="https://gamesounds.xyz/">GameSounds.xyz</a></td><td></td><td></td><td>&#x2713;</td></tr>
+    <tr><td><a href="https://kenney.nl/">Kenney</a></td>&#x2713;<td></td><td>&#x2713;</td><td>&#x2713;</td></tr>
     <tr><td><a href="http://www.mixamo.com/">Mixamo</a></td><td></td><td>&#x2713;</td><td></td></tr>
     <tr><td><a href="http://www.playonloop.com/music-loops-category/videogame/">PlayOnLoop</a></td><td></td><td></td><td>&#x2713;</td></tr>
     <tr><td><a href="http://www.opengameart.org/">Open Game Art</a></td><td>&#x2713;</td><td>&#x2713;</td><td>&#x2713;</td></tr>


### PR DESCRIPTION
Removes broken links to website, adds new website;

- Removal of Fro Games (Unity Asset Store exclusive)
- Removal of Props Planet (Offline, webdomain for sale)
- Removal of Yobi3D (Closed on January 31st, 2019)
- Added GameSounds.xyz (Offers a lot of free/open source audio packs)
- Added Kenney.nl (Contains sprites, models and more all public domain)