### PR TITLE
Add watch build commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ On Windows:
     cd developer.playcanvas.com
     node node_modules/http-server/bin/http-server build
 
+## Use 'watch' for quick iteration
+
+The watch build command will automatically build the site when changes are made in the `content` directory.
+
+    cd developer.playcanvas.com
+    npm install
+    npm run watch:osx
+
+On Windows:
+
+    cd developer.playcanvas.com
+    npm install
+    npm run watch:windows
+
 ## How to deploy
 
 Deployment is made by pushing to default branch

--- a/package-lock.json
+++ b/package-lock.json
@@ -297,6 +297,14 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
       "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
     },
+    "exec-sh": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+      "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+      "requires": {
+        "merge": "^1.2.0"
+      }
+    },
     "extend": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
@@ -950,6 +958,11 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.0.tgz",
       "integrity": "sha512-EkE7RW6KcXfMHy2PA7Jg0YJE1l8UPEZE8k45tylzmZM30/r1M1MUXWQfJlrSbsTeh7m/XTwHbWUENvAJZpp1YA=="
     },
+    "merge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
+    },
     "metalsmith": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/metalsmith/-/metalsmith-2.3.0.tgz",
@@ -1465,6 +1478,15 @@
       "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
       "requires": {
         "wrap-fn": "^0.1.0"
+      }
+    },
+    "watch": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-1.0.2.tgz",
+      "integrity": "sha1-NApxe952Vyb6CqB9ch4BR6VR3ww=",
+      "requires": {
+        "exec-sh": "^0.2.0",
+        "minimist": "^1.2.0"
       }
     },
     "win-fork": {

--- a/package.json
+++ b/package.json
@@ -30,9 +30,12 @@
     "metalsmith-permalinks": "2.2.0",
     "metalsmith-static": "0.0.5",
     "metalsmith-templates": "0.7.0",
-    "request": "2.88.2"
+    "request": "2.88.2",
+    "watch": "1.0.2"
   },
   "scripts": {
+    "watch:osx": "watch 'npm run build' content --interval=3 --wait=5 --ignoreDotFiles --filter='watch-filter.js'",
+    "watch:windows": "watch \"npm run build\" content --interval=3 --wait=5 --ignoreDotFiles --filter=\"watch-filter.js\"",
     "build": "node build.js",
     "serve": "http-server build -a localhost -p 51000"
   }

--- a/watch-filter.js
+++ b/watch-filter.js
@@ -1,0 +1,17 @@
+/**
+ * @param  {string} f Filename
+ * @param  {object} stat File System @see {@link http://nodejs.org/api/fs.html File System}
+ */
+
+const ignoreList = [
+    'content/_tutorial_contents_legacy.json',
+    'content/_tutorial_contents.json',
+    'content/_usermanual_contents.json'
+];
+
+const filter = function (f, stat) {
+    var include = (stat.isFile() && !ignoreList.some(filename => filename === f)) || stat.isDirectory();
+    return include;
+};
+
+module.exports = filter;


### PR DESCRIPTION
On OSX, use `npm run watch:osx` to watch the contents folder for changes and build automatically.