### PR TITLE
Fix sass command and remove hidden element

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "broken-link-checker": "0.7.8"
   },
   "scripts": {
-    "sass": "sass --no-source-map sass/styles.scss public/css/styles.css;",
+    "sass": "sass --no-source-map sass/styles.scss public/css/styles.css",
     "watch:osx": "watch 'npm run build' content --interval=3 --wait=5 --ignoreDotFiles --filter='watch-filter.js'",
     "watch:windows": "watch \"npm run build\" content --interval=3 --wait=5 --ignoreDotFiles --filter=\"watch-filter.js\"",
     "build": "node build.js",

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -193,9 +193,6 @@
   header ul li.active a {
     color: white;
   }
-  header .header-mobile-icon {
-    display: none;
-  }
   header .header-content {
     clear: both;
     margin: auto;

--- a/sass/styles.scss
+++ b/sass/styles.scss
@@ -116,10 +116,6 @@
             }
         }
 
-        .header-mobile-icon {
-            display: none;
-        }
-
         .header-content {
             clear: both;
             margin: auto;

--- a/templates/partials/header.tmpl.html
+++ b/templates/partials/header.tmpl.html
@@ -1,7 +1,6 @@
 <header>
     <nav class="content-width">
         <a href="/{{locale}}/" class="header-title"><img src="/images/header/PLAYMANUAL.png" alt="PlayCanvas Manual"></a>
-        <a class="header-mobile-icon" href="">icon</a>
         <ul class="header-menu">
             <li class="user-manual"><a href="/user-manual">{{#i18n}}User Manual{{/i18n}}</a></li>
             <li class="tutorials"><a href="/tutorials">{{#i18n}}Tutorials{{/i18n}}</a></li>


### PR DESCRIPTION
* Remove stray semi-colon from `sass` command.
* Remove hidden `a` element in `header` and associated CSS rule.