### PR TITLE
Fixed a number of broken links in docs

### DIFF
--- a/content/en/tutorials/custom-shaders.md
+++ b/content/en/tutorials/custom-shaders.md
@@ -284,7 +284,7 @@ CustomShader.prototype.update = function(dt) {
 
 Here is the complete script. Remember you'll need to create vertex shader and fragment shader assets in order for it to work.
 
-[1]: /engine/api/stable/symbols/pc.Shader.html
+[1]: https://developer.playcanvas.com/en/api/pc.Shader.html
 [2]: /user-manual/scripting/script-attributes/
 [3]: /user-manual/graphics/physical-rendering/physical-materials/
 [project]: https://playcanvas.com/project/406044/overview/tutorial-custom-shaders

--- a/content/en/tutorials/custom-shaders.md
+++ b/content/en/tutorials/custom-shaders.md
@@ -284,7 +284,7 @@ CustomShader.prototype.update = function(dt) {
 
 Here is the complete script. Remember you'll need to create vertex shader and fragment shader assets in order for it to work.
 
-[1]: https://developer.playcanvas.com/en/api/pc.Shader.html
+[1]: /api/pc.Shader.html
 [2]: /user-manual/scripting/script-attributes/
 [3]: /user-manual/graphics/physical-rendering/physical-materials/
 [project]: https://playcanvas.com/project/406044/overview/tutorial-custom-shaders

--- a/content/en/user-manual/assets/models/building.md
+++ b/content/en/user-manual/assets/models/building.md
@@ -148,10 +148,10 @@ You should use the standard material types in Maya: lambert, blinn and phong. Th
 ![Maya material editor][11]
 
 [1]: http://wiki.polycount.com/wiki/Tools
-[2]: http://cgcookie.com/blender/
+[2]: https://cgcookie.com/learn-blender
 [3]: /images/user-manual/assets/models/building/blender-logo.jpg
 [4]: http://blender.org
-[5]: http://usa.autodesk.com/adsk/servlet/pc/item?id=10775855&siteID=123112
+[5]: https://www.autodesk.com/developer-network/platform-technologies/fbx-converter-archives
 [6]: http://www.blenderguru.com/
 [7]: /images/user-manual/assets/models/building/max-material-editor.jpg
 [8]: /images/user-manual/assets/models/building/wall-norm.jpg

--- a/content/en/user-manual/packs/components/element.md
+++ b/content/en/user-manual/packs/components/element.md
@@ -34,8 +34,8 @@ The text element renders a string of text using a [font asset][5].
     <tr><th>Property</th><th>Description</th></tr>
     <tr><td>Type</td><td>The type of Element: Group, Image or Text</td></tr>
     <tr><td>Preset</td><td>Choosing a layout preset will automatically set the Anchor and Pivot properties to a preset value.</td></tr>
-    <tr><td>Anchor</td><td>Determine where the element calculates its position in relation to. See the <a href="/user-manual/user-interface/layout">Layout</a> section for more information.</td></tr>
-    <tr><td>Pivot</td><td>Determine where the pivot point of the Element is. (0,0) is bottom left, (1,1) is top right. See the <a href="/user-manual/user-interface/layout">Layout</a> section for more information.</td></tr>
+    <tr><td>Anchor</td><td>Determine where the element calculates its position in relation to. See the <a href="/user-manual/user-interface/elements/#anchor">Elements#Anchor</a> section for more information.</td></tr>
+    <tr><td>Pivot</td><td>Determine where the pivot point of the Element is. (0,0) is bottom left, (1,1) is top right. See the <a href="/user-manual/user-interface/elements/#pivot">Elements#Pivot</a> section for more information.</td></tr>
     <tr><td>Size</td><td>The width and height of the Element. This may be automatically calculated depending on other settings</td></tr>
     <tr><td>Margin</td><td>The distance from the edge of the element to the Anchor. This is only available when the Anchor is split (non-equal in one axis).</td></tr>
     <tr><td>Use Input</td><td>If enabled, this Element is added to the list of elements that check for input and fire input related events.</td></tr>

--- a/content/en/user-manual/packs/components/element.md
+++ b/content/en/user-manual/packs/components/element.md
@@ -34,13 +34,13 @@ The text element renders a string of text using a [font asset][5].
     <tr><th>Property</th><th>Description</th></tr>
     <tr><td>Type</td><td>The type of Element: Group, Image or Text</td></tr>
     <tr><td>Preset</td><td>Choosing a layout preset will automatically set the Anchor and Pivot properties to a preset value.</td></tr>
-    <tr><td>Anchor</td><td>Determine where the element calculates its position in relation to. See the [Layout][4] section for more information.</td></tr>
-    <tr><td>Pivot</td><td>Determine where the pivot point of the Element is. (0,0) is bottom left, (1,1) is top right. See the [Layout][4] section for more information.</td></tr>
+    <tr><td>Anchor</td><td>Determine where the element calculates its position in relation to. See the <a href="/user-manual/user-interface/layout">Layout</a> section for more information.</td></tr>
+    <tr><td>Pivot</td><td>Determine where the pivot point of the Element is. (0,0) is bottom left, (1,1) is top right. See the <a href="/user-manual/user-interface/layout">Layout</a> section for more information.</td></tr>
     <tr><td>Size</td><td>The width and height of the Element. This may be automatically calculated depending on other settings</td></tr>
     <tr><td>Margin</td><td>The distance from the edge of the element to the Anchor. This is only available when the Anchor is split (non-equal in one axis).</td></tr>
     <tr><td>Use Input</td><td>If enabled, this Element is added to the list of elements that check for input and fire input related events.</td></tr>
-    <tr><td>Layers</td><td>The Layers to render this element into. More on Layers [here][7]</td></tr>
-    <tr><td>Batch Group</td><td>The Batch Group that this model belongs to. More on Batching [here][8].</td></tr>
+    <tr><td>Layers</td><td>The Layers to render this element into. More on Layers <a href="/user-manual/graphics/layers">here</a></td></tr>
+    <tr><td>Batch Group</td><td>The Batch Group that this model belongs to. More on Batching <a href="/user-manual/optimization/batching">here</a>.</td></tr>
 </table>
 
 ## Image Component Properties
@@ -54,7 +54,7 @@ The text element renders a string of text using a [font asset][5].
     <tr><td>Texture</td><td>The texture asset displayed</td></tr>
     <tr><td>Color</td><td>The color to tint the element.</td></tr>
     <tr><td>Opacity</td><td>The transparency of the element.</td></tr>
-    <tr><td>Layers</td><td>The Layers to render this element into. More on Layers [here][7]</td></tr>
+    <tr><td>Layers</td><td>The Layers to render this element into. More on Layers <a href="/user-manual/graphics/layers">here</a></td></tr>
 </table>
 
 ## Text Component Properties
@@ -72,7 +72,7 @@ The text element renders a string of text using a [font asset][5].
     <tr><td>Color</td><td>The color to tint the font.</td></tr>
     <tr><td>Opacity</td><td>The transparency of the element.</td></tr>
     <tr><td>Wrap Lines</td><td>Enable text wrapping. Any text that overflows the width of the text element will be wrapped to the next line.</td></tr>
-    <tr><td>Layers</td><td>The Layers to render this element into. More on Layers [here][7]</td></tr>
+    <tr><td>Layers</td><td>The Layers to render this element into. More on Layers <a href="/user-manual/graphics/layers">here</a></td></tr>
 </table>
 
 [0]: /user-manual/user-interface

--- a/content/en/user-manual/packs/components/rigidbody.md
+++ b/content/en/user-manual/packs/components/rigidbody.md
@@ -42,4 +42,4 @@ You can control a Rigid Body component's properties using a [script component][5
 [3]: /images/user-manual/scenes/components/component-rigid-body-kinematic.png
 [4]: /user-manual/packs/components/collision/
 [5]: /user-manual/packs/components/script
-[6]: /engine/api/stable/symbols/pc.RigidBodyComponent.html
+[6]: /api/pc.RigidBodyComponent.html

--- a/content/en/user-manual/publishing/playable-ads/ironsource-mraid-playable-ads.md
+++ b/content/en/user-manual/publishing/playable-ads/ironsource-mraid-playable-ads.md
@@ -137,7 +137,7 @@ Follow the process on submitting the playable ad from [ironSource's documentatio
 [2]: https://github.com/playcanvas/playcanvas-rest-api-tools#converting-a-project-into-a-single-html-file
 [4]: https://tinypng.com/
 [5]: https://playcanvas.com/project/775981/overview/cube-jump-mraid
-[6]: is-playable-ad-cube-jump.zip
+[6]: /downloads/is-playable-ad-cube-jump.zip
 [7]: https://github.com/playcanvas/playcanvas-rest-api-tools#setup
 [mraid-api]: https://www.iab.com/guidelines/mraid/
 [guid-generator]: https://www.guidgenerator.com/

--- a/content/en/user-manual/xr/optimizing-webxr.md
+++ b/content/en/user-manual/xr/optimizing-webxr.md
@@ -43,6 +43,6 @@ PlayCanvas comes with a built in profiler tool. In the Editor use the Launch Pro
 [Many more optimization guidelines][4] are available.
 
 [1]: /user-manual/graphics/lighting/runtime-lightmaps/
-[2]: https://chrome.google.com/webstore/detail/webgl-insight/djdcbmfacaaocoomokenoalbomllhnko
+[2]: https://github.com/3Dparallax/insight
 [3]: /user-manual/optimization/profiler/
 [4]: /user-manual/optimization/guidelines/

--- a/faq_to_json.js
+++ b/faq_to_json.js
@@ -52,7 +52,7 @@ m.build(function (err, results) {
     // process results
     for (var key in results) {
         // remove html file
-        fs.unlink(path.join(__dirname, 'build/' + key));
+        fs.unlinkSync(path.join(__dirname, 'build/' + key));
 
         var html = results[key].contents.toString('utf-8');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,6 @@
 {
   "name": "developer.playcanvas.com",
-<<<<<<< HEAD
-  "version": "1.5.0",
-=======
-  "version": "1.6.0",
->>>>>>> master
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
HTML tables require `<a href>` style links
Some API links were broken from tutorials and user manual
Some external links were broken