### PR TITLE
Improve User Guide sidebar ordering

### DIFF
--- a/content/en/user-manual/2D/index.md
+++ b/content/en/user-manual/2D/index.md
@@ -1,7 +1,7 @@
 ---
 title: 2D
 template: usermanual-page.tmpl.html
-position: 11
+position: 17
 ---
 
 The PlayCanvas Engine is designed to make creating 3D games and applications fast and simple. However, we also support a number of great features for creating 2D games. With PlayCanvas' 2D features you get all the benefits of a powerful 3D engine but for 2D games.

--- a/content/en/user-manual/animation/anim-component.md
+++ b/content/en/user-manual/animation/anim-component.md
@@ -1,7 +1,7 @@
 ---
 title: Anim Component
 template: usermanual-page.tmpl.html
-position: 4
+position: 1
 ---
 
 Click here to learn how to use the [Anim Component](/en/user-manual/packs/components/anim/).

--- a/content/en/user-manual/animation/anim-events.md
+++ b/content/en/user-manual/animation/anim-events.md
@@ -1,7 +1,7 @@
 ---
 title: Anim Events
 template: usermanual-page.tmpl.html
-position: 4
+position: 5
 ---
 
 Anim events can be used to trigger event listeners during the playback of an animation. Each event is associated with a specified frame of the animation asset it is attached to. When the playback of the animation reaches that frame, the event will fire and the associated event listener is called.

--- a/content/en/user-manual/animation/anim-layer-masking.md
+++ b/content/en/user-manual/animation/anim-layer-masking.md
@@ -4,7 +4,7 @@ template: usermanual-page.tmpl.html
 position: 4
 ---
 
-When creating complex animation behaviour for your game objects, it is often necessary to isolate the playback of certain animations to specific bones in each object's model. This is particularly useful when animating characters that need to carry out multiple actions at the same time. This can be achieved in PlayCanvas by creating an a mask for a given [animation layer](/en/user-manual/animation/anim-state-graph-assets/#layers/) in your anim component.
+When creating complex animation behavior for your game objects, it is often necessary to isolate the playback of certain animations to specific bones in each object's model. This is particularly useful when animating characters that need to carry out multiple actions at the same time. This can be achieved in PlayCanvas by creating an a mask for a given [animation layer](/en/user-manual/animation/anim-state-graph-assets/#layers/) in your anim component.
 
 ### Creating a mask
 

--- a/content/en/user-manual/animation/index.md
+++ b/content/en/user-manual/animation/index.md
@@ -1,7 +1,7 @@
 ---
 title: Animation
 template: usermanual-page.tmpl.html
-position: 10.5
+position: 15
 ---
 
 PlayCanvas provides a powerful state-based animation system which can be used to animate character models and other arbitrary scene object models. Users can work with any of their .FBX animation assets. These can be organized using animation state machines to easily control the animated behavior of scene models at runtime.

--- a/content/en/user-manual/api/branch-list.md
+++ b/content/en/user-manual/api/branch-list.md
@@ -1,7 +1,7 @@
 ---
 title: Branches - List branches
 template: usermanual-page.tmpl.html
-position: 10.5
+position: 11
 ---
 
 ## Route URL

--- a/content/en/user-manual/api/index.md
+++ b/content/en/user-manual/api/index.md
@@ -1,7 +1,7 @@
 ---
 title: REST API
 template: usermanual-page.tmpl.html
-position: 15
+position: 22
 ---
 
 <div class="alert alert-info">

--- a/content/en/user-manual/api/job-get.md
+++ b/content/en/user-manual/api/job-get.md
@@ -1,7 +1,7 @@
 ---
 title: Jobs - Get job
 template: usermanual-page.tmpl.html
-position: 11
+position: 12
 ---
 
 ## Route URL

--- a/content/en/user-manual/api/project-archive.md
+++ b/content/en/user-manual/api/project-archive.md
@@ -1,7 +1,7 @@
 ---
 title: Projects - Archive project
 template: usermanual-page.tmpl.html
-position: 12
+position: 13
 ---
 
 ## Route URL

--- a/content/en/user-manual/api/scene-list.md
+++ b/content/en/user-manual/api/scene-list.md
@@ -1,7 +1,7 @@
 ---
 title: Scenes - List scenes
 template: usermanual-page.tmpl.html
-position: 20
+position: 14
 ---
 
 ## Route URL

--- a/content/en/user-manual/assets/animation.md
+++ b/content/en/user-manual/assets/animation.md
@@ -1,7 +1,7 @@
 ---
 title: Animation
 template: usermanual-page.tmpl.html
-position: 9
+position: 4
 ---
 
 An Animation asset is used to play a single animation on a 3D model. Animations are imported by uploading 3D scenes (such as FBX files) which contain animation data. The animation data is extracted from the uploaded file by the [asset pipeline][asset_pipeline] and a [Target Asset][target_asset] is created to use in game.

--- a/content/en/user-manual/assets/audio.md
+++ b/content/en/user-manual/assets/audio.md
@@ -1,7 +1,7 @@
 ---
 title: Audio
 template: usermanual-page.tmpl.html
-position: 10
+position: 5
 ---
 
 Audio assets are sound files which can be played back using the Audiosource component.

--- a/content/en/user-manual/assets/css.md
+++ b/content/en/user-manual/assets/css.md
@@ -1,7 +1,7 @@
 ---
 title: CSS
 template: usermanual-page.tmpl.html
-position: 11
+position: 6
 ---
 
 A CSS asset contains CSS code. You can create a new CSS asset in the Editor or by uploading a file with a .css extension.

--- a/content/en/user-manual/assets/cubemaps.md
+++ b/content/en/user-manual/assets/cubemaps.md
@@ -1,7 +1,7 @@
 ---
-title: Cubemaps
+title: Cubemap
 template: usermanual-page.tmpl.html
-position: 5
+position: 7
 ---
 
 Cubemaps are a special type of texture asset. They are formed from 6 texture assets where each texture represents the face of a cube. They typically have two uses:

--- a/content/en/user-manual/assets/finding.md
+++ b/content/en/user-manual/assets/finding.md
@@ -1,6 +1,7 @@
 ---
 title: Finding Assets
 template: usermanual-page.tmpl.html
+position: 18
 ---
 
 ## Where can I get 3D models/Sound FX/Music for PlayCanvas?

--- a/content/en/user-manual/assets/fonts.md
+++ b/content/en/user-manual/assets/fonts.md
@@ -1,7 +1,7 @@
 ---
-title: Fonts
+title: Font
 template: usermanual-page.tmpl.html
-position: 13
+position: 8
 ---
 
 A Font asset contains an image with all the characters of the font that the user chose to include, and data related to how each character should be displayed. Font assets are used to render text using an [Element][1] component of type Text. To render text, add an Element component to an Entity set its type to Text and drag and drop the Font asset to the Font slot of the Element component.

--- a/content/en/user-manual/assets/html.md
+++ b/content/en/user-manual/assets/html.md
@@ -1,7 +1,7 @@
 ---
 title: HTML
 template: usermanual-page.tmpl.html
-position: 10
+position: 9
 ---
 
 An HTML asset contains HTML code. The code can either be a full HTML page or just partial HTML. You can create a new HTML asset in the Editor or by uploading a file with an .html extension.

--- a/content/en/user-manual/assets/index.md
+++ b/content/en/user-manual/assets/index.md
@@ -1,7 +1,7 @@
 ---
 title: Assets
 template: usermanual-page.tmpl.html
-position: 6
+position: 10
 ---
 
 Assets are resources that are available to use in your game. Assets can be of various different content types, for example, 3D models or audio files. They come in two different forms: Source and Target.

--- a/content/en/user-manual/assets/materials/index.md
+++ b/content/en/user-manual/assets/materials/index.md
@@ -1,7 +1,7 @@
 ---
 title: Materials
 template: usermanual-page.tmpl.html
-position: 6
+position: 10
 ---
 
 Every surface on a 3D model is rendered using a material. The material defines the properties of that surface, such as its color, shininess, bumpiness.

--- a/content/en/user-manual/assets/materials/index.md
+++ b/content/en/user-manual/assets/materials/index.md
@@ -1,5 +1,5 @@
 ---
-title: Materials
+title: Material
 template: usermanual-page.tmpl.html
 position: 10
 ---

--- a/content/en/user-manual/assets/materials/phong-material.md
+++ b/content/en/user-manual/assets/materials/phong-material.md
@@ -1,7 +1,7 @@
 ---
 title: Phong Material
 template: usermanual-page.tmpl.html
-position: 8
+position: 2
 ---
 
 The Phong Material is our legacy shading model. We recommend you use the Physical Shading model unless you have specific reasons not to.

--- a/content/en/user-manual/assets/materials/physical-material.md
+++ b/content/en/user-manual/assets/materials/physical-material.md
@@ -1,7 +1,7 @@
 ---
 title: Physical Material
 template: usermanual-page.tmpl.html
-position: 7
+position: 1
 ---
 
 The Physical Material represents the most advanced and highest quality shading model available in PlayCanvas. We recommend you use the Physical shading model.

--- a/content/en/user-manual/assets/models/index.md
+++ b/content/en/user-manual/assets/models/index.md
@@ -1,7 +1,7 @@
 ---
-title: Models
+title: Model
 template: usermanual-page.tmpl.html
-position: 4
+position: 11
 ---
 
 3D models and animations are imported into PlayCanvas by uploading scene files from a [3D modeling application][1] such as [Blender][2], 3D Studio Max or Maya.

--- a/content/en/user-manual/assets/sprites.md
+++ b/content/en/user-manual/assets/sprites.md
@@ -1,7 +1,7 @@
 ---
 title: Sprite
 template: usermanual-page.tmpl.html
-position: 15
+position: 13
 ---
 
 A Sprite is a 2D graphic that can be rendered into Scene. A Sprite Asset is a reference to a [Texture Atlas][1] and a sequence of frames from that atlas. In this way a sprite can either represent a single image (taken out of the atlas) or a flip-book style animation (multiple frames from the atlas).

--- a/content/en/user-manual/assets/templates.md
+++ b/content/en/user-manual/assets/templates.md
@@ -1,7 +1,7 @@
 ---
 title: Template
 template: usermanual-page.tmpl.html
-position: 16
+position: 14
 ---
 
 A Template (also called a Prefab) is an Asset that contains a piece of an Entity hierarchy. It has a root Entity and can have any number of children. A Template is a reusable Entity that you can instantiate dynamically at runtime or place multiple instances of it in your Scene. When you change the Template Asset all instances of the Template will also change.

--- a/content/en/user-manual/assets/texture-atlas.md
+++ b/content/en/user-manual/assets/texture-atlas.md
@@ -1,7 +1,7 @@
 ---
 title: Texture Atlas
 template: usermanual-page.tmpl.html
-position: 14
+position: 16
 ---
 
 ![Texture Atlas][1]

--- a/content/en/user-manual/assets/textures/index.md
+++ b/content/en/user-manual/assets/textures/index.md
@@ -1,7 +1,7 @@
 ---
-title: Textures
+title: Texture
 template: usermanual-page.tmpl.html
-position: 4
+position: 15
 ---
 
 A texture is an image that can be assigned to a [material][1] and then applied to a graphical primitive.

--- a/content/en/user-manual/assets/wasm-modules.md
+++ b/content/en/user-manual/assets/wasm-modules.md
@@ -6,7 +6,7 @@ position: 17
 
 Wasm Modules (also known was WebAssembly Modules) contain compiled executable code for the web.
 
-A wasm module comprises three parts:
+A Wasm module comprises three parts:
 * the binary executable file
 * the JavaScript glue code file
 * an optional fallback asm.js
@@ -22,7 +22,7 @@ Once the files have been added to the project, select the Wasm Module to display
 Name must match the module name defined in the glue and fallback script. This name is used to instantiate the module at load time.
 
 ### Glue script
-This is the JavaScript glue code required to execute wasm code.
+This is the JavaScript glue code required to execute Wasm code.
 
 ### Fallback script
 This is the optional fallback asm.js script to use when WebAssembly is not supported.

--- a/content/en/user-manual/assets/wasm-modules.md
+++ b/content/en/user-manual/assets/wasm-modules.md
@@ -1,5 +1,5 @@
 ---
-title: Wasm Modules
+title: Wasm Module
 template: usermanual-page.tmpl.html
 position: 17
 ---

--- a/content/en/user-manual/billing/index.md
+++ b/content/en/user-manual/billing/index.md
@@ -1,7 +1,7 @@
 ---
 title: Billing
 template: usermanual-page.tmpl.html
-position: 18
+position: 24
 ---
 
 ## Auto-renewal of Subscriptions

--- a/content/en/user-manual/creating-account.md
+++ b/content/en/user-manual/creating-account.md
@@ -1,7 +1,7 @@
 ---
 title: Creating an Account
 template: usermanual-page.tmpl.html
-position: 1.7
+position: 3
 ---
 
 ## Sign Up

--- a/content/en/user-manual/dashboard/index.md
+++ b/content/en/user-manual/dashboard/index.md
@@ -1,7 +1,7 @@
 ---
 title: Dashboard
 template: usermanual-page.tmpl.html
-position: 3
+position: 7
 ---
 
 ![Dashboard][1]

--- a/content/en/user-manual/designer/asset-library.md
+++ b/content/en/user-manual/designer/asset-library.md
@@ -1,7 +1,7 @@
 ---
 title: Asset Library
 template: usermanual-page.tmpl.html
-position: 7
+position: 6
 ---
 
 ## Store

--- a/content/en/user-manual/designer/assets.md
+++ b/content/en/user-manual/designer/assets.md
@@ -1,7 +1,7 @@
 ---
 title: Assets
 template: usermanual-page.tmpl.html
-position: 6
+position: 5
 ---
 
 The Assets Panel manages all of the Assets that are available in your project. From here, you can create, upload, delete, inspect and edit any Asset.

--- a/content/en/user-manual/designer/editor-api.md
+++ b/content/en/user-manual/designer/editor-api.md
@@ -1,7 +1,7 @@
 ---
 title: Editor API
 template: usermanual-page.tmpl.html
-position: 11
+position: 10
 ---
 
 <div class="alert alert-info">

--- a/content/en/user-manual/designer/index.md
+++ b/content/en/user-manual/designer/index.md
@@ -1,7 +1,7 @@
 ---
 title: Editor
 template: usermanual-page.tmpl.html
-position: 4
+position: 8
 ---
 
 The PlayCanvas Editor is a visual editing tool which you use to create and edit the [Scenes][1] and [Entities][2] that make up your game.

--- a/content/en/user-manual/designer/keyboard-shortcuts.md
+++ b/content/en/user-manual/designer/keyboard-shortcuts.md
@@ -1,7 +1,7 @@
 ---
 title: Keyboard Shortcuts
 template: usermanual-page.tmpl.html
-position: 12
+position: 11
 ---
 
 ## Camera Controls

--- a/content/en/user-manual/designer/loading-screen.md
+++ b/content/en/user-manual/designer/loading-screen.md
@@ -1,7 +1,7 @@
 ---
 title: Loading Screen
 template: usermanual-page.tmpl.html
-position: 9
+position: 8
 ---
 
 If you want to create a custom loading screen, you can go to the [Scene Settings][1] and click **Create Default** in the *Loading Screen* section. If you already have a valid loading screen script you can drag and drop it on the loading screen panel or click on **Select Existing**:

--- a/content/en/user-manual/designer/scenes.md
+++ b/content/en/user-manual/designer/scenes.md
@@ -1,7 +1,7 @@
 ---
 title: Scenes
 template: usermanual-page.tmpl.html
-position: 10
+position: 9
 ---
 
 ## Scenes

--- a/content/en/user-manual/designer/settings.md
+++ b/content/en/user-manual/designer/settings.md
@@ -1,7 +1,7 @@
 ---
 title: Settings
 template: usermanual-page.tmpl.html
-position: 8
+position: 7
 ---
 
 The Settings panel lets you set up various properties. It is accessed using the 'cog' button in the bottom left of the Editor (on the [Toolbar][1]).

--- a/content/en/user-manual/engine-only/index.md
+++ b/content/en/user-manual/engine-only/index.md
@@ -1,7 +1,7 @@
 ---
 title: Engine-Only Users
 template: usermanual-page.tmpl.html
-position: 16
+position: 23
 ---
 
 The vast majority of PlayCanvas developers build applications with the Editor. But it is also possible to build applications using just the PlayCanvas Engine, the open source JavaScript runtime which powers all PlayCanvas apps.

--- a/content/en/user-manual/glossary.md
+++ b/content/en/user-manual/glossary.md
@@ -1,7 +1,7 @@
 ---
 title: Glossary
 template: usermanual-page.tmpl.html
-position: 19
+position: 25
 ---
 
 Here is an overview of some of the terms we use to describe the PlayCanvas Engine and Tools.

--- a/content/en/user-manual/graphics/index.md
+++ b/content/en/user-manual/graphics/index.md
@@ -1,7 +1,7 @@
 ---
 title: Graphics
 template: usermanual-page.tmpl.html
-position: 8
+position: 14
 ---
 
 PlayCanvas incorporates an advanced graphics engine. Internally it uses the WebGL API to draw graphical primitives to the screen.

--- a/content/en/user-manual/graphics/layers/index.md
+++ b/content/en/user-manual/graphics/layers/index.md
@@ -1,7 +1,7 @@
 ---
 title: Layers
 template: usermanual-page.tmpl.html
-position: 4.5
+position: 4
 ---
 
 ## Layers Overview

--- a/content/en/user-manual/graphics/physical-rendering/image-based-lighting.md
+++ b/content/en/user-manual/graphics/physical-rendering/image-based-lighting.md
@@ -1,7 +1,7 @@
 ---
 title: Image Based Lighting
 template: usermanual-page.tmpl.html
-position: 0
+position: 2
 ---
 
 To get best results with Physically Based Rendering in PlayCanvas you can use the technique called Image Based Lighting or IBL, it allows to use pre-rendered image data as source information for ambient and reflection light.

--- a/content/en/user-manual/graphics/physical-rendering/index.md
+++ b/content/en/user-manual/graphics/physical-rendering/index.md
@@ -1,7 +1,7 @@
 ---
 title: Physically Based Rendering
 template: usermanual-page.tmpl.html
-position: 4
+position: 3
 ---
 
 ![Star-Lord][1]

--- a/content/en/user-manual/graphics/posteffects/fxaa.md
+++ b/content/en/user-manual/graphics/posteffects/fxaa.md
@@ -1,7 +1,7 @@
 ---
 title: FXAA Effect
 template: usermanual-page.tmpl.html
-position: 4
+position: 3
 ---
 
 Fast Approximate Anti-Aliasing (FXAA) is an anti-aliasing algorithm created by NVIDIA. It provides an easy and fast way to add anti-aliasing to your scene.

--- a/content/en/user-manual/graphics/posteffects/hue_saturation.md
+++ b/content/en/user-manual/graphics/posteffects/hue_saturation.md
@@ -1,7 +1,7 @@
 ---
 title: Hue-Saturation Effect
 template: usermanual-page.tmpl.html
-position: 3
+position: 4
 ---
 
 The hue-saturation effect allows you to modify the hue and saturation of the rendered image.

--- a/content/en/user-manual/made-with-playcanvas.md
+++ b/content/en/user-manual/made-with-playcanvas.md
@@ -1,7 +1,7 @@
 ---
 title: Made with PlayCanvas
 template: usermanual-page.tmpl.html
-position: 1.6
+position: 2
 ---
 
 Below is our showcase video of some of the best WebGL browser games and experiences made with PlayCanvas.

--- a/content/en/user-manual/optimization/batching.md
+++ b/content/en/user-manual/optimization/batching.md
@@ -1,7 +1,7 @@
 ---
 title: Batching
 template: usermanual-page.tmpl.html
-position: 3
+position: 4
 ---
 
 Batching is the process of combining multiple mesh instances together into a single mesh instance, so that they can all be rendered in a single GPU draw call. PlayCanvas provides a handy feature on the [Model][7], [Sprite][9] and [Element][10] components that lets you assign these components to batch groups which give the engine hints on how to combine meshes to reduce the overall draw call count.

--- a/content/en/user-manual/optimization/hardware-instancing.md
+++ b/content/en/user-manual/optimization/hardware-instancing.md
@@ -1,7 +1,7 @@
 ---
 title: Hardware Instancing
 template: usermanual-page.tmpl.html
-position: 3
+position: 5
 ---
 
 Hardware instancing is a rendering technique which allows the GPU to render multiple identical meshes in a small number of draw calls. Each instance of the mesh can have a different limited amount of state (for example, position or color). It's a technique suitable to drawing objects such as trees or bullets, say.

--- a/content/en/user-manual/optimization/index.md
+++ b/content/en/user-manual/optimization/index.md
@@ -1,7 +1,7 @@
 ---
 title: Performance
 template: usermanual-page.tmpl.html
-position: 12
+position: 19
 ---
 
 Your PlayCanvas apps are likely to run on a broad spectrum of device types. Anything from a high end desktop PC all the way down to a low end smartphone. To ensure that you achieve the best possible performance for your app, there are some guidelines to follow. PlayCanvas also provides tools to help your find and eliminate performance bottlenecks.

--- a/content/en/user-manual/optimization/load-time.md
+++ b/content/en/user-manual/optimization/load-time.md
@@ -1,7 +1,7 @@
 ---
 title: Optimizing Load Time
 template: usermanual-page.tmpl.html
-position: 5
+position: 7
 ---
 
 Optimizing isn't just related to improving frame rate. Fast load times are also critical. The faster your app loads, the more likely your users will stick around to experience it. Aim to have your app load in less than 5 seconds to prevent users from churning.

--- a/content/en/user-manual/optimization/mini-stats.md
+++ b/content/en/user-manual/optimization/mini-stats.md
@@ -1,7 +1,7 @@
 ---
 title: Mini Stats
 template: usermanual-page.tmpl.html
-position: 6
+position: 3
 ---
 
 Mini stats is a lightweight graphical display of an application's key performance statistics. It shows draw call count, frame time, CPU load and (where supported) GPU load.

--- a/content/en/user-manual/optimization/runtime-devicepixelratio.md
+++ b/content/en/user-manual/optimization/runtime-devicepixelratio.md
@@ -1,7 +1,7 @@
 ---
 title: Device Pixel Ratio
 template: usermanual-page.tmpl.html
-position: 4
+position: 6
 ---
 
 Device pixel ratio is the the ratio between the physical pixels on a the hardware screen and the logical pixels (related to the physical size of the screen, also known as CSS resolution).

--- a/content/en/user-manual/optimization/troubleshooting-performance.md
+++ b/content/en/user-manual/optimization/troubleshooting-performance.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting Performance
 template: usermanual-page.tmpl.html
-position: 4
+position: 8
 ---
 
 Here are some tips to help you uncover common performance problems

--- a/content/en/user-manual/organizations/creating-organizations.md
+++ b/content/en/user-manual/organizations/creating-organizations.md
@@ -1,7 +1,7 @@
 ---
 title: Creating Organizations
 template: usermanual-page.tmpl.html
-position: 2
+position: 1
 ---
 
 There are various ways to create an Organization. Any organizations you are part of will appear next to your name on your profile like so:

--- a/content/en/user-manual/organizations/index.md
+++ b/content/en/user-manual/organizations/index.md
@@ -1,7 +1,7 @@
 ---
 title: Organizations
 template: usermanual-page.tmpl.html
-position: 3
+position: 6
 ---
 
 Organizations offer a way for businesses and large projects to manage many users. They can have multiple administrators and permissions can be handled on a per project basis.

--- a/content/en/user-manual/organizations/managing-organizations.md
+++ b/content/en/user-manual/organizations/managing-organizations.md
@@ -1,7 +1,7 @@
 ---
 title: Managing Organizations
 template: usermanual-page.tmpl.html
-position: 3
+position: 2
 ---
 
 ### Permissions

--- a/content/en/user-manual/packs/components/animation.md
+++ b/content/en/user-manual/packs/components/animation.md
@@ -1,7 +1,7 @@
 ---
 title: Animation
 template: usermanual-page.tmpl.html
-position: 1
+position: 2
 ---
 
 The Animation component enables an entity to specify which animations can be applied to the model assigned to its Model component.

--- a/content/en/user-manual/packs/components/audiolistener.md
+++ b/content/en/user-manual/packs/components/audiolistener.md
@@ -1,7 +1,7 @@
 ---
 title: Audio Listener
 template: usermanual-page.tmpl.html
-position: 2
+position: 3
 ---
 
 The Audio Listener component specifies the listener's position in 3D space. All 3D audio playback will be relative to this position.

--- a/content/en/user-manual/packs/components/button.md
+++ b/content/en/user-manual/packs/components/button.md
@@ -1,7 +1,7 @@
 ---
 title: Button
 template: usermanual-page.tmpl.html
-position: 3
+position: 4
 ---
 
 The Button Component is a convenient shortcut for creating User Interface buttons for use with [Screen][1] and [Element][2] Components.

--- a/content/en/user-manual/packs/components/camera.md
+++ b/content/en/user-manual/packs/components/camera.md
@@ -1,7 +1,7 @@
 ---
 title: Camera
 template: usermanual-page.tmpl.html
-position: 4
+position: 5
 ---
 
 The Camera component enables an entity to render a scene from a certain viewpoint.

--- a/content/en/user-manual/packs/components/collision.md
+++ b/content/en/user-manual/packs/components/collision.md
@@ -1,7 +1,7 @@
 ---
 title: Collision
 template: usermanual-page.tmpl.html
-position: 5
+position: 6
 ---
 
 The Collision component assigns a collision volume to the entity. The component interface dynamically displays different attributes based on the 'Type' attribute.

--- a/content/en/user-manual/packs/components/element.md
+++ b/content/en/user-manual/packs/components/element.md
@@ -1,7 +1,7 @@
 ---
 title: Element
 template: usermanual-page.tmpl.html
-position: 6
+position: 7
 ---
 
 An Element component when in a hierarchy with a Screen Component ancestor is used to build user interfaces made up of 2D components such as images and text. The Element provides layout properties such as anchors and a pivot point.

--- a/content/en/user-manual/packs/components/layout-child.md
+++ b/content/en/user-manual/packs/components/layout-child.md
@@ -1,7 +1,7 @@
 ---
 title: Layout Child
 template: usermanual-page.tmpl.html
-position: 7
+position: 8
 ---
 
 The LayoutChild component enables an element that is controlled by a LayoutGroup component to override the default behavior of the Layout Group.

--- a/content/en/user-manual/packs/components/layout-group.md
+++ b/content/en/user-manual/packs/components/layout-group.md
@@ -1,7 +1,7 @@
 ---
 title: Layout Group
 template: usermanual-page.tmpl.html
-position: 8
+position: 9
 ---
 
 The LayoutGroup component enables an entity to specify the size and position of child Element Components.

--- a/content/en/user-manual/packs/components/light.md
+++ b/content/en/user-manual/packs/components/light.md
@@ -1,7 +1,7 @@
 ---
 title: Light
 template: usermanual-page.tmpl.html
-position: 9
+position: 10
 ---
 
 The Light component attaches a dynamic light source to the Entity. The 'Type' property determines what kind of light is attached and what other properties are available.

--- a/content/en/user-manual/packs/components/model.md
+++ b/content/en/user-manual/packs/components/model.md
@@ -1,7 +1,7 @@
 ---
 title: Model
 template: usermanual-page.tmpl.html
-position: 10
+position: 11
 ---
 
 The Model component enables an entity to render a primitive shape or a model asset.

--- a/content/en/user-manual/packs/components/particlesystem.md
+++ b/content/en/user-manual/packs/components/particlesystem.md
@@ -1,7 +1,7 @@
 ---
 title: Particle System
 template: usermanual-page.tmpl.html
-position: 11
+position: 12
 ---
 
 The Particle System component specifies a particle emitter in 3D space.

--- a/content/en/user-manual/packs/components/render.md
+++ b/content/en/user-manual/packs/components/render.md
@@ -1,7 +1,7 @@
 ---
 title: Render
 template: usermanual-page.tmpl.html
-position: 12
+position: 13
 ---
 
 The render component enables an entity to render a primitive shape or a render asset.

--- a/content/en/user-manual/packs/components/rigidbody.md
+++ b/content/en/user-manual/packs/components/rigidbody.md
@@ -1,7 +1,7 @@
 ---
 title: Rigid Body
 template: usermanual-page.tmpl.html
-position: 13
+position: 14
 ---
 
 The Rigid Body component enables an entity to participate in the scene's physics simulation. This allows the movement of an entity to be simulated realistically. The component interface dynamically displays different attributes based on the 'Type' attribute.

--- a/content/en/user-manual/packs/components/screen.md
+++ b/content/en/user-manual/packs/components/screen.md
@@ -1,7 +1,7 @@
 ---
 title: Screen
 template: usermanual-page.tmpl.html
-position: 14
+position: 15
 ---
 
 The Screen component defines the area and rendering of a user interface. Children added to a Screen component should all have an Element component

--- a/content/en/user-manual/packs/components/script.md
+++ b/content/en/user-manual/packs/components/script.md
@@ -1,7 +1,7 @@
 ---
 title: Script
 template: usermanual-page.tmpl.html
-position: 15
+position: 16
 ---
 
 The Script component enables an entity to run user-supplied scripts. In this way, the user can write script (using the JavaScript language) that runs when the entity is instantiated and updated on a per-frame basis.

--- a/content/en/user-manual/packs/components/scrollbar.md
+++ b/content/en/user-manual/packs/components/scrollbar.md
@@ -1,7 +1,7 @@
 ---
 title: Scrollbar
 template: usermanual-page.tmpl.html
-position: 16
+position: 17
 ---
 
 The Scrollbar component defines a scrolling control for a [Scrollview][1] component.

--- a/content/en/user-manual/packs/components/scrollview.md
+++ b/content/en/user-manual/packs/components/scrollview.md
@@ -1,7 +1,7 @@
 ---
 title: Scrollview
 template: usermanual-page.tmpl.html
-position: 17
+position: 18
 ---
 
 The Scrollview component defines a scrollable area in a user interface. A scrollview can be scrolled via [Scrollbar][1] components.

--- a/content/en/user-manual/packs/components/sound.md
+++ b/content/en/user-manual/packs/components/sound.md
@@ -1,7 +1,7 @@
 ---
 title: Sound
 template: usermanual-page.tmpl.html
-position: 18
+position: 19
 ---
 
 The Sound component controls playback of audio samples.

--- a/content/en/user-manual/packs/components/sprite.md
+++ b/content/en/user-manual/packs/components/sprite.md
@@ -1,7 +1,7 @@
 ---
 title: Sprite
 template: usermanual-page.tmpl.html
-position: 19
+position: 20
 ---
 
 The Sprite Component renders and animates [Sprite Assets][1] into the scene.

--- a/content/en/user-manual/packs/index.md
+++ b/content/en/user-manual/packs/index.md
@@ -1,7 +1,7 @@
 ---
 title: Scenes
 template: usermanual-page.tmpl.html
-position: 5
+position: 9
 ---
 
 Scenes contain the Entity hierarchy which lists the order and structure of all Entities in your scene. They are edited using the PlayCanvas Editor.

--- a/content/en/user-manual/physics/index.md
+++ b/content/en/user-manual/physics/index.md
@@ -1,7 +1,7 @@
 ---
 title: Physics
 template: usermanual-page.tmpl.html
-position: 11
+position: 16
 ---
 
 Most video games you have ever played will have some form of physics. The player expects objects to fall under the influence of gravity. For objects to collide instead of pass through each other. For a sound to play if two objects collide. And so on.

--- a/content/en/user-manual/profile/index.md
+++ b/content/en/user-manual/profile/index.md
@@ -1,7 +1,7 @@
 ---
 title: Profile
 template: usermanual-page.tmpl.html
-position: 2
+position: 5
 ---
 
 Your profile page is the public place for showing off your PlayCanvas games.

--- a/content/en/user-manual/publishing/index.md
+++ b/content/en/user-manual/publishing/index.md
@@ -1,7 +1,7 @@
 ---
 title: Publishing
 template: usermanual-page.tmpl.html
-position: 14
+position: 21
 ---
 
 Once you have built your game, you will no doubt want to publish it and allow people to enjoy its majesty! PlayCanvas makes things very easy for you to target just about any operating system or app store.

--- a/content/en/user-manual/publishing/playable-ads/fb-playable-ads.md
+++ b/content/en/user-manual/publishing/playable-ads/fb-playable-ads.md
@@ -1,7 +1,7 @@
 ---
 title: Facebook Playable Ad
 template: usermanual-page.tmpl.html
-position: 3
+position: 1
 ---
 
 PlayCanvas supports the [Facebook Playable Ad][1] formats and requirements via an [official external tool on GitHub][2].

--- a/content/en/user-manual/publishing/playable-ads/index.md
+++ b/content/en/user-manual/publishing/playable-ads/index.md
@@ -1,7 +1,7 @@
 ---
 title: Playable Ads
 template: usermanual-page.tmpl.html
-position: 3
+position: 4
 ---
 
 We are currently supporting the following playable ad networks:

--- a/content/en/user-manual/publishing/playable-ads/ironsource-mraid-playable-ads.md
+++ b/content/en/user-manual/publishing/playable-ads/ironsource-mraid-playable-ads.md
@@ -1,7 +1,7 @@
 ---
 title: ironSource Playable Ad (MRAID)
 template: usermanual-page.tmpl.html
-position: 9
+position: 3
 ---
 
 PlayCanvas supports the ironSource MRAID Playable Ad format and requirements via an [official external tool on GitHub][2].

--- a/content/en/user-manual/publishing/playable-ads/snapchat-playable-ads.md
+++ b/content/en/user-manual/publishing/playable-ads/snapchat-playable-ads.md
@@ -1,7 +1,7 @@
 ---
 title: Snapchat Playable Ad
 template: usermanual-page.tmpl.html
-position: 6
+position: 2
 ---
 
 PlayCanvas supports the Snapchat Playable Ad format and requirements via an [official external tool on GitHub][2].

--- a/content/en/user-manual/publishing/web/facebook.md
+++ b/content/en/user-manual/publishing/web/facebook.md
@@ -1,7 +1,7 @@
 ---
 title: Facebook
 template: usermanual-page.tmpl.html
-position: 7
+position: 6
 ---
 
 [Facebook][1] is an excellent place to publish PlayCanvas games in order to reach an enormous audience. Publishing games from PlayCanvas to Facebook is straightforward.

--- a/content/en/user-manual/scripting/communication.md
+++ b/content/en/user-manual/scripting/communication.md
@@ -1,7 +1,7 @@
 ---
 title: Communication
 template: usermanual-page.tmpl.html
-position: 6
+position: 5
 ---
 
 Events are a useful way of communicating between scripts in order to respond to things that happen without checking every frame.

--- a/content/en/user-manual/scripting/debugging.md
+++ b/content/en/user-manual/scripting/debugging.md
@@ -1,7 +1,7 @@
 ---
 title: Debugging
 template: usermanual-page.tmpl.html
-position: 7
+position: 8
 ---
 
 In order to create scripts for PlayCanvas, it is vital that you know how to access and use your browser's development tools.

--- a/content/en/user-manual/scripting/hot-reloading.md
+++ b/content/en/user-manual/scripting/hot-reloading.md
@@ -1,7 +1,7 @@
 ---
 title: Hot Reloading
 template: usermanual-page.tmpl.html
-position: 6
+position: 7
 ---
 
 When you are iterating on a complex project it can be frustrating to have to do a full page refresh every time you make a change to a script. Especially if it takes you a long time to get to the point where you are testing your code. That is where hot-swapping of code comes in.

--- a/content/en/user-manual/scripting/index.md
+++ b/content/en/user-manual/scripting/index.md
@@ -1,7 +1,7 @@
 ---
 title: Scripting
 template: usermanual-page.tmpl.html
-position: 7
+position: 11
 ---
 
 Scripts are how you make your PlayCanvas application interactive. They are written in regular **JavaScript** the same programming language that is used to program web pages.

--- a/content/en/user-manual/templates/index.md
+++ b/content/en/user-manual/templates/index.md
@@ -1,7 +1,7 @@
 ---
 title: Templates
 template: usermanual-page.tmpl.html
-position: 7.4
+position: 12
 ---
 
 Templates (or prefabs) allow you to speed up your development by creating Entities that are reusable. You can place multiple instances of a Template in your Scene and if you make any changes and apply them to the Template Asset, all instances of that Template will be updated.

--- a/content/en/user-manual/user-interface/index.md
+++ b/content/en/user-manual/user-interface/index.md
@@ -1,7 +1,7 @@
 ---
 title: User Interface
 template: usermanual-page.tmpl.html
-position: 9
+position: 18
 ---
 
 User Interfaces present a unique challenge for graphical applications. There are several options for building User Interfaces in PlayCanvas. 

--- a/content/en/user-manual/version-control/branch-workflows.md
+++ b/content/en/user-manual/version-control/branch-workflows.md
@@ -1,7 +1,7 @@
 ---
 title: Branch Workflows
 template: usermanual-page.tmpl.html
-position: 6
+position: 5
 ---
 
 There are many different ways that you can use branches to suit your project needs. Below we describe a few methods that are commonly used for different types of project.

--- a/content/en/user-manual/version-control/index.md
+++ b/content/en/user-manual/version-control/index.md
@@ -1,7 +1,7 @@
 ---
 title: Version Control
 template: usermanual-page.tmpl.html
-position: 7.5
+position: 13
 ---
 
 Once you've moved beyond the simplest of projects, you will find that version control becomes an important part of your application development process. Version Control is a catch-all term for a system that performs the following functions

--- a/content/en/user-manual/xr/index.md
+++ b/content/en/user-manual/xr/index.md
@@ -1,7 +1,7 @@
 ---
 title: XR
 template: usermanual-page.tmpl.html
-position: 13
+position: 20
 ---
 
 ![VR View][2]

--- a/content/en/user-manual/your-first-app.md
+++ b/content/en/user-manual/your-first-app.md
@@ -1,7 +1,7 @@
 ---
 title: Your First App
 template: usermanual-page.tmpl.html
-position: 1.8
+position: 4
 ---
 
 Developing applications in PlayCanvas is easy and fun. Let's spend a few minutes learning the basics. We'll recreate the following simple 3D app:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "developer.playcanvas.com",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "developer.playcanvas.com",
-  "version": "1.10.0",
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
The User Guide sidebar ordering is determined by a `position` attribute in each markdown file. This PR:

* Make every `position` attribute a sequential integer counting up from 1.
* Improves the ordering of some sidebar entries.
* Moves the material-related asset pages into a subfolder.
* Improves sidebar naming consistency - for example, by making all asset types singular under the Assets category.
* Fixes some minor spelling mistakes.

One reason for this PR is that the build process can actually order two sidebar entries randomly if they have the same value for the `position` attribute. This can make it hard to diff two builds of the User Guide after making a change (e.g. updating NPM modules).