### PR TITLE
Update the FAQ

### DIFF
--- a/content/en/faq/add_component.md
+++ b/content/en/faq/add_component.md
@@ -1,10 +1,10 @@
 ---
 title: Add a component
-keywords: entity, add, component, behaviour
+keywords: entity, add, component, behavior
 ---
 
 ## How do I add a component?
 
 To add a **component** to an Entity, select the Entity and then click **Add Component** in the **Inspector** or right click on the Entity and select a component from the Add Component context menu.
 
-<a class="docs" href="http://developer.playcanvas.com/en/user-manual/packs/components/" target="_blank">View User Manual</a>
+[Learn more](https://developer.playcanvas.com/en/user-manual/packs/components/)

--- a/content/en/faq/add_script.md
+++ b/content/en/faq/add_script.md
@@ -1,12 +1,12 @@
 ---
 title: Add a script
-keywords: script, code, create, javascript, behaviour
+keywords: script, code, create, javascript, behavior
 ---
 
 ## How do I add a script?
 
 <img src="https://playcanvas.com/static-assets/instructions/add-new-script.gif"/>
 
-You can use javascript to control the behavior of entities. Add a script component, and create a new script.
+You can use JavaScript to control the behavior of entities. Select any entity, add a script component and create a new script asset.
 
-<a class="docs" href="http://developer.playcanvas.com/en/user-manual/scripting/creating-new/" target="_blank">View User Manual</a>
+[Learn more](https://developer.playcanvas.com/en/user-manual/scripting/creating-new/)

--- a/content/en/faq/change_background.md
+++ b/content/en/faq/change_background.md
@@ -1,14 +1,12 @@
 ---
 title: Change the background color
-keywords: camera, color, background, colour, sky
+keywords: camera, color, background, color, sky
 ---
 
 ## How do I change the background color?
 
-To change the background color of your scene. You should update the Clear Color property of the camera in your scene.
+To change the background color of your scene, you should update the Clear Color property of the camera in your scene.
 
-You could also try and adding a [skybox][1] to your scene
+You could also try and adding a [skybox](https://developer.playcanvas.com/en/user-manual/assets/cubemaps/) to your scene.
 
-<a class="docs" href="http://developer.playcanvas.com/en/user-manual/packs/components/camera/" target="_blank">View User Manual</a>
-
-[1]: http://developer.playcanvas.com/en/user-manual/assets/cubemaps/
+[Learn more](https://developer.playcanvas.com/en/user-manual/packs/components/camera/)

--- a/content/en/faq/change_color.md
+++ b/content/en/faq/change_color.md
@@ -1,9 +1,9 @@
 ---
-title: Change the color of a model
+title: Change the material of a model
 keywords: asset, material, create, color, surface, normal, specular
 ---
 
-## How do I change the color of a model?
+## How do I change the material of a model?
 
 <img src="https://playcanvas.com/static-assets/instructions/change_material.gif"/>
 
@@ -11,4 +11,4 @@ Every surface on a 3D model is rendered using a **material**. The material defin
 
 You can create a new material and drag and drop it on your model or you can select its existing materials and edit their properties in the Inspector.
 
-<a class="docs" href="http://developer.playcanvas.com/en/user-manual/assets/materials/" target="_blank">View User Manual</a>
+[Learn more](https://developer.playcanvas.com/en/user-manual/assets/materials/)

--- a/content/en/faq/create_cubemap.md
+++ b/content/en/faq/create_cubemap.md
@@ -11,4 +11,4 @@ Cubemaps are a special type of texture asset. They are formed from 6 texture ass
 
 To create a cubemap click on the **<span class="font-icon">&#57632;</span> Add** button in the Assets panel and select **New Cubemap**. Then drag 6 textures in the cubemap inspector. To take advantage of Physically Based Rendering make sure you click **Prefilter** after setting the 6 textures.
 
-<a class="docs" href="http://developer.playcanvas.com/en/user-manual/assets/cubemaps/" target="_blank">View User Manual</a>
+[Learn more](https://developer.playcanvas.com/en/user-manual/assets/cubemaps/)

--- a/content/en/faq/create_light.md
+++ b/content/en/faq/create_light.md
@@ -7,4 +7,4 @@ keywords: component, light, sun, shadows, directional, spot, point
 
 You can create a light by adding a **Light** component to an Entity. You can also right click on an Entity and select New Entity / Directional Light to create a new directional light and similarly for spot lights and point lights.
 
-<a class="docs" href="http://developer.playcanvas.com/en/user-manual/packs/components/light/" target="_blank">View User Manual</a>
+[Learn more](https://developer.playcanvas.com/en/user-manual/packs/components/light/)

--- a/content/en/faq/create_material.md
+++ b/content/en/faq/create_material.md
@@ -9,4 +9,4 @@ Every surface on a 3D model is rendered using a **material**. The material defin
 
 To create a material click on the **<span class="font-icon">&#57632;</span> Add** button in the Assets panel and then select **New Material**.
 
-<a class="docs" href="http://developer.playcanvas.com/en/user-manual/assets/materials/" target="_blank">View User Manual</a>
+[Learn more](https://developer.playcanvas.com/en/user-manual/assets/materials/)

--- a/content/en/faq/create_shader.md
+++ b/content/en/faq/create_shader.md
@@ -7,6 +7,4 @@ keywords: asset, shader, create, material
 
 You can create a new shader asset from the asset panel. Click **Add Asset -> Shader**.
 
-To use your shader on a material take a look at our [custom shader tutorial][1].
-
-[1]: http://developer.playcanvas.com/en/tutorials/advanced/custom-shaders/
+[View tutorial](http://developer.playcanvas.com/en/tutorials/custom-shaders/)

--- a/content/en/faq/create_shape.md
+++ b/content/en/faq/create_shape.md
@@ -7,9 +7,8 @@ keywords: component, model, box, sphere, cylinder, cone, cube, plane, shape, pri
 
 <img src="https://playcanvas.com/static-assets/instructions/new_box.gif"/>
 
-You can add primitive shapes like boxes, spheres and others by adding a **Model Component** on an Entity and changing its type to the desired shape.
+You can add primitive shapes like boxes, spheres and others by adding a **Render Component** on an Entity and changing its type to the desired shape.
 
 You can also right click on an Entity and select New Entity/Box to add a box (similarly for other shapes).
 
-
-<a class="docs" href="http://developer.playcanvas.com/en/user-manual/packs/components/model/" target="_blank">View User Manual</a>
+[Learn more](https://developer.playcanvas.com/en/user-manual/packs/components/render/)

--- a/content/en/faq/create_skybox.md
+++ b/content/en/faq/create_skybox.md
@@ -5,6 +5,6 @@ keywords: skybox, cubemap, create, asset, pbr, physical
 
 ## How do I create a skybox?
 
-To create a skybox for your scene you first need to create a <a href="http://developer.playcanvas.com/en/user-manual/assets/cubemaps/" target="_blank">Cubemap asset</a>. Then you can drag and drop the Cubemap inside the 3D viewport, or you can go to the <a href="http://developer.playcanvas.com/en/user-manual/designer/settings/#skybox" target="_blank">Scene Settings</a> and drag the Cubemap in the Skybox field.
+To create a skybox for your scene you first need to create a [Cubemap asset](http://developer.playcanvas.com/en/user-manual/assets/cubemaps/). Then you can drag and drop the Cubemap inside the 3D viewport, or you can go to the Scene Settings and drag the Cubemap in the Skybox field.
 
-<a class="docs" href="http://developer.playcanvas.com/en/user-manual/designer/settings/#skybox" target="_blank">View User Manual</a>
+[Learn more](https://developer.playcanvas.com/en/user-manual/designer/settings/#skybox)

--- a/content/en/faq/play_animation.md
+++ b/content/en/faq/play_animation.md
@@ -5,8 +5,6 @@ keywords: component, animation, model, 3d, fbx
 
 ## How do I play an animation?
 
-<iframe src="https://www.youtube.com/embed/2MAxwOYLnh0?list=PL0KdXFF26E4Bpjx5R3B8LH6blmU-h3JLV?controls=2&showinfo=0" width="560" height="315" allowFullScreen style="max-width:100%"></iframe>
-
-To play an animation of a 3D model you need to create an Entity with a <a href="http://developer.playcanvas.com/en/user-manual/packs/components/model/" target="_blank">Model Component</a> and an <a href="http://developer.playcanvas.com/en/user-manual/packs/components/animation/" target="_blank">Animation Component</a>. The **Model Component** will render your model and the **Animation Component** will play animations.
+To play an animation of a 3D model you need to create an Entity with a [Model Component](https://developer.playcanvas.com/en/user-manual/packs/components/model/) and an [Animation Component](https://developer.playcanvas.com/en/user-manual/packs/components/animation/). The **Model Component** will render your model and the **Animation Component** will play animations.
 
 To render the model drag a model Asset in the Asset field of the Model Component. To play animations drag Animation Assets on the Assets field of the Animation Component.

--- a/content/en/faq/play_sound.md
+++ b/content/en/faq/play_sound.md
@@ -1,12 +1,12 @@
 ---
 title: Play a sound
-keywords: component, sound, audio, music, audiosource, audiolistener
+keywords: component, sound, audio, music, audiolistener
 ---
 
 ## How do I play a sound?
 
-To play sounds you need to add a <a href="http://developer.playcanvas.com/en/user-manual/packs/components/sound/" target="_blank">Sound</a> component to an Entity. Then you can create slots to play <a href="http://developer.playcanvas.com/en/user-manual/assets/audio/" target="_blank">Audio assets</a>. Simply click "Add Slot" and drag an Audio Asset on the Asset field. In order to hear the sounds you also need to add an <a href="http://developer.playcanvas.com/en/user-manual/packs/components/audiolistener/" target="_blank">AudioListener</a> component to an Entity - usually to the Camera Entity.
+To play sounds you need to add a [Sound component](https://developer.playcanvas.com/en/user-manual/packs/components/sound/) to an Entity. Then you can create slots to play [Audio assets](https://developer.playcanvas.com/en/user-manual/assets/audio/). Simply click "Add Slot" and drag an Audio Asset on the Asset field. In order to hear the sounds you also need to add an [AudioListener component](https://developer.playcanvas.com/en/user-manual/packs/components/audiolistener/) to an Entity - usually to the Camera Entity.
 
 You can create Audio assets by dragging audio files from your computer into the Assets panel.
 
-<a class="docs" href="https://developer.playcanvas.com/en/tutorials/basic-audio/" target="_blank">View Tutorial</a>
+[View tutorial](https://developer.playcanvas.com/en/tutorials/basic-audio/)

--- a/content/en/faq/remove_component.md
+++ b/content/en/faq/remove_component.md
@@ -1,6 +1,6 @@
 ---
 title: Remove a component
-keywords: entity, remove, component, behaviour
+keywords: entity, remove, component, behavior
 ---
 
 

--- a/content/en/faq/render_model.md
+++ b/content/en/faq/render_model.md
@@ -9,4 +9,4 @@ keywords: component, model, 3d, fbx, mesh
 
 To render a 3D model you need to add a **Model Component** to an Entity and drag a **Model Asset** on the Asset field. Alternatively you can drag and drop a Model Asset from the Assets Panel into the 3D Viewport.
 
-<a class="docs" href="http://developer.playcanvas.com/en/user-manual/packs/components/model/" target="_blank">View User Manual</a>
+[Learn more](https://developer.playcanvas.com/en/user-manual/packs/components/model/)

--- a/content/en/faq/upload_asset.md
+++ b/content/en/faq/upload_asset.md
@@ -7,4 +7,4 @@ keywords: asset, new, create, upload
 
 To upload Assets simply drag and drop files from your computer into the Assets panel. Your files will be processed by the server and will appear shortly after in the Assets Panel.
 
-<a class="docs" href="http://developer.playcanvas.com/en/user-manual/assets/" target="_blank">View User Manual</a>
+[Learn more](https://developer.playcanvas.com/en/user-manual/assets/importing/)

--- a/content/en/faq/use_physics.md
+++ b/content/en/faq/use_physics.md
@@ -5,8 +5,8 @@ keywords: component, physics, collision, collider, rigid, body, gravity, ammo, t
 
 ## How do I use physics?
 
-To give physical properties to an Entity you need to add a <a href="http://developer.playcanvas.com/en/user-manual/packs/components/collision/" target="_blank">Collision</a> component to it and a <a href="http://developer.playcanvas.com/en/user-manual/packs/components/rigidbody/" target="_blank">RigidBody</a> component. The Collision component gives a physical shape to the Entity and the RigidBody component makes the Entity be simulated by the physics engine.
+To give physical properties to an Entity you need to add a [Collision component](https://developer.playcanvas.com/en/user-manual/packs/components/collision/) to it and a [RigidBody component](https://developer.playcanvas.com/en/user-manual/packs/components/rigidbody/). The Collision component gives a physical shape to the Entity and the RigidBody component makes the Entity be simulated by the physics engine.
 
-You can change the built-in <a href="http://developer.playcanvas.com/en/user-manual/designer/settings/#gravity" target="_blank">gravity</a> from the <a href="http://developer.playcanvas.com/en/user-manual/designer/settings/" target="_blank">Scene Settings</a>.
+You can change the default [gravity](https://developer.playcanvas.com/en/user-manual/designer/settings/#gravity) in the Scene Settings.
 
-<a class="docs" href="https://developer.playcanvas.com/en/tutorials/collision-and-triggers/" target="_blank">View Tutorial</a>
+[View tutorial](https://developer.playcanvas.com/en/tutorials/collision-and-triggers/)

--- a/content/en/faq/use_shadows.md
+++ b/content/en/faq/use_shadows.md
@@ -7,4 +7,4 @@ keywords: real-time, shadows, light, realism, pbr
 
 Real-time shadows are rendered for each light source that has **Cast Shadows** enabled. To enable shadows, select an Entity with a Light component and enable Cast Shadows. You also need to enable Cast Shadows on any Model components in your scene.
 
-<a class="docs" href="http://developer.playcanvas.com/en/user-manual/graphics/lighting/shadows/" target="_blank">View User Manual</a>
+[Learn more](https://developer.playcanvas.com/en/user-manual/graphics/lighting/shadows/)

--- a/content/en/user-manual/graphics/posteffects/vignette.md
+++ b/content/en/user-manual/graphics/posteffects/vignette.md
@@ -19,4 +19,4 @@ The built-in vignette effect has the following attributes:
 * **Offset**: Controls the offset of the effect.
 * **Darkness**: Controls the darkness of the effect.
 
-[1]: http://en.wikipedia.org/wiki/Vignetting
+[1]: https://en.wikipedia.org/wiki/Vignetting

--- a/faq_to_json.js
+++ b/faq_to_json.js
@@ -88,6 +88,13 @@ m.build((err, results) => {
 
         let html = results[key].contents.toString('utf-8');
 
+        // links clicked in the Editor should open a new tab
+        html = html.replace('<a href=', '<a target="_blank" href=');
+
+        // style buttons in the Editor
+        html = html.replace('>Learn more<', ' class="docs">View User Manual<');
+        html = html.replace('>View tutorial<', ' class="docs">View Tutorial<');
+
         // add close button
         html += '\n<button class="close">GOT IT</button>';
 


### PR DESCRIPTION
Fix lots of problems with the FAQ:

* Convert all UK spelling to US spelling.
* Only open a new tab when viewing a FAQ in the Editor (not the User Guide).
* Fix some broken links.
* Make sure all links are https instead of http.