### PR TITLE
Added deprecated to animation tutorial and reference the Colyseus tutorial

### DIFF
--- a/content/en/tutorials/anim-blending.md
+++ b/content/en/tutorials/anim-blending.md
@@ -10,6 +10,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 *Click on screen to focus, then press the 'p' key to blend to a punch animation*
 
 This tutorial illustrates the basics of animation blending.
+
 Objects in your scene may be animated; machines or characters are good examples of things that you might want to animate. Generally, when 3D content is created, individual animations are authored and these animations are typically referred to as cycles (because they loop). For example, a human character could have an idle cycle, a walk cycle, a run cycle and so on. As a PlayCanvas developer, you'll want a mechanism to play these animations back on your animated object. Additionally, you do not want these animations to 'pop' as one is switched for another. To remedy this, you should use animation blending which implements a smooth transition from one animation to another. This dramatically improves the visual fidelity of your animated object.
 Let's examine how this is achieved via PlayCanvas...
 

--- a/content/en/tutorials/animation-blending.md
+++ b/content/en/tutorials/animation-blending.md
@@ -1,9 +1,11 @@
 ---
-title: Animation Blending
+title: Animation Blending (Deprecated)
 template: tutorial-page.tmpl.html
 tags: animation
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405874/A8B1FE-image-75.jpg
 ---
+
+<div class="alert alert-info">This tutorial uses the deprecated Model and Animation components. Please refer to the <a href="/tutorials/anim-blending/">Anim State Graph Blending tutorial</a> instead.</div>
 
 <iframe src="https://playcanv.as/p/HI8kniOx/" ></iframe>
 

--- a/content/en/tutorials/real-time-multiplayer.md
+++ b/content/en/tutorials/real-time-multiplayer.md
@@ -5,6 +5,8 @@ tags: multiplayer, networking
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406048/507186-image-75.jpg
 ---
 
+<div class="alert alert-info">We recommend using the multiplayer Colyseus service instead of building your own server as shown below. We have a <a href="/tutorials/real-time-multiplayer-colyseus.md">Colyseus with PlayCanvas tutorial here.</a></div>
+
 <iframe src="https://playcanv.as/p/XFp1Ty3X/" ></iframe>
 *Use WASD to move the player around. If you only see one capsule, try opening this page in another tab or on another computer.*
 


### PR DESCRIPTION
Made it clearer that the tutorial for the animation blending tutorial is old/deprecated and referenced the Colyseus multiplayer tutorial in the current real time multiplayer tutorial since it is much more scalable feature wise.

![image](https://user-images.githubusercontent.com/16639049/151029199-789e7c45-0891-4917-b846-a12616751e39.png)

![image](https://user-images.githubusercontent.com/16639049/151029244-3da37d2a-c1ec-4fc1-b065-57ada02e102a.png)

![image](https://user-images.githubusercontent.com/16639049/151029352-c1fbf4ad-26d6-400d-a4d3-382286a086b4.png)
