### PR TITLE
Added quotes around URL in REST API examples

### DIFF
--- a/content/en/user-manual/api/app-download.md
+++ b/content/en/user-manual/api/app-download.md
@@ -17,7 +17,7 @@ This will allow you to download an app which you can self host on your own serve
 ## Example
 
 ```none
-curl -H "Authorization: Bearer fdslkjlk32j2l3kj2lkj2lkj323rr" -H "Content-Type: application/json" -X POST -d '{"project_id": 9999999, "scenes": [9999999], "name": "My App"}' https://playcanvas.com/api/apps/download
+curl -H "Authorization: Bearer fdslkjlk32j2l3kj2lkj2lkj323rr" -H "Content-Type: application/json" -X POST -d '{"project_id": 9999999, "scenes": [9999999], "name": "My App"}' "https://playcanvas.com/api/apps/download"
 ```
 
 ## Parameters

--- a/content/en/user-manual/api/asset-create.md
+++ b/content/en/user-manual/api/asset-create.md
@@ -23,7 +23,7 @@ Create a new asset.
 ## Example
 
 ```none
-curl -H "Authorization: Bearer {accessToken}" -X POST -F 'name={name}' -F 'projectId={projectId}' -F 'parent={parent}' -F 'preload={preload}' -F 'file=@./script.js'  https://playcanvas.com/api/assets
+curl -H "Authorization: Bearer {accessToken}" -X POST -F 'name={name}' -F 'projectId={projectId}' -F 'parent={parent}' -F 'preload={preload}' -F 'file=@./script.js' "https://playcanvas.com/api/assets"
 ```
 
 HTTP Request

--- a/content/en/user-manual/api/asset-delete.md
+++ b/content/en/user-manual/api/asset-delete.md
@@ -17,7 +17,7 @@ Permanently delete an asset from a branch of your project. **Warning** deleting 
 ## Example
 
 ```none
-curl -H "Authorization: Bearer {accessToken}" -X DELETE https://playcanvas.com/api/assets/{assetId}?branchId={branchId}
+curl -H "Authorization: Bearer {accessToken}" -X DELETE "https://playcanvas.com/api/assets/{assetId}?branchId={branchId}"
 ```
 
 HTTP Request

--- a/content/en/user-manual/api/asset-file.md
+++ b/content/en/user-manual/api/asset-file.md
@@ -7,7 +7,7 @@ position: 7
 ## Route URL
 
 ```none
-GET https://playcanvas.com/api/assets/:assetId/file?branchId=:branchId
+GET https://playcanvas.com/api/assets/:assetId/file/:filename?branchId=:branchId
 ```
 
 ## Description
@@ -17,13 +17,13 @@ Get the details of a single asset
 ## Example
 
 ```none
-curl -H "Authorization: Bearer {accessToken}" https://playcanvas.com/api/assets/{assetId}/file?branchId={branchId}
+curl -H "Authorization: Bearer {accessToken}" "https://playcanvas.com/api/assets/{assetId}/file/{filename}?branchId={branchId}"
 ```
 
 HTTP Request
 
 ```text
-GET https://playcanvas.com/api/assets/{assetId}/file?branchId={branchId}
+GET https://playcanvas.com/api/assets/{assetId}/file/{filename}?branchId={branchId}
 Authorization: Bearer {accessToken}
 ```
 

--- a/content/en/user-manual/api/asset-list.md
+++ b/content/en/user-manual/api/asset-list.md
@@ -17,7 +17,7 @@ Get the details of all assets in a project for a specific branch
 ## Example
 
 ```none
-curl -H "Authorization: Bearer {accessToken}" https://playcanvas.com/api/projects/{projectId}/assets?branchId={branchId}
+curl -H "Authorization: Bearer {accessToken}" "https://playcanvas.com/api/projects/{projectId}/assets?branchId={branchId}"
 ```
 
 HTTP Request

--- a/content/en/user-manual/api/asset-update.md
+++ b/content/en/user-manual/api/asset-update.md
@@ -23,7 +23,7 @@ Update an existing asset's file.
 ## Example
 
 ```none
-curl -H "Authorization: Bearer {accessToken}" -X PUT -F 'file=@./script.js' https://playcanvas.com/api/assets/{assetId}
+curl -H "Authorization: Bearer {accessToken}" -X PUT -F 'file=@./script.js' "https://playcanvas.com/api/assets/{assetId}"
 ```
 
 ## Parameters

--- a/content/en/user-manual/api/branch-list.md
+++ b/content/en/user-manual/api/branch-list.md
@@ -17,7 +17,7 @@ Get a list of all open branches for a project
 ## Example
 
 ```none
-curl -H "Authorization: Bearer {accessToken}" https://playcanvas.com/api/projects/{projectId}/branches
+curl -H "Authorization: Bearer {accessToken}" "https://playcanvas.com/api/projects/{projectId}/branches"
 ```
 
 HTTP Request

--- a/content/en/user-manual/api/scene-list.md
+++ b/content/en/user-manual/api/scene-list.md
@@ -17,7 +17,7 @@ Get a list of all scenes for a project
 ## Example
 
 ```none
-curl -H "Authorization: Bearer {accessToken}" https://playcanvas.com/api/projects/{projectId}/scenes?branchId={branchId}
+curl -H "Authorization: Bearer {accessToken}" "https://playcanvas.com/api/projects/{projectId}/scenes?branchId={branchId}"
 ```
 
 HTTP Request


### PR DESCRIPTION
Also fixed the file endpoint as it needs a filename in the URL too

The quotes are needed otherwise some end points with the branch ids as params don't work without them