### PR TITLE
Remove `metalsmith-metadata` plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "marked": "^4.0.12",
         "metalsmith": "^2.4.2",
         "metalsmith-headings-identifier": "0.0.11",
-        "metalsmith-metadata": "0.0.4",
         "metalsmith-static": "0.0.5",
         "node-fetch": "^2.6.6",
         "sass": "^1.49.9",
@@ -2663,37 +2662,6 @@
       "dependencies": {
         "cheerio": "^0.19.0",
         "lodash": "^3.10.1"
-      }
-    },
-    "node_modules/metalsmith-metadata": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/metalsmith-metadata/-/metalsmith-metadata-0.0.4.tgz",
-      "integrity": "sha1-07ByWcZqDNPGGFDV5jI6JbLBCA4=",
-      "dev": true,
-      "dependencies": {
-        "js-yaml": "^3.2.7"
-      }
-    },
-    "node_modules/metalsmith-metadata/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/metalsmith-metadata/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/metalsmith-static": {
@@ -6160,36 +6128,6 @@
       "requires": {
         "cheerio": "^0.19.0",
         "lodash": "^3.10.1"
-      }
-    },
-    "metalsmith-metadata": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/metalsmith-metadata/-/metalsmith-metadata-0.0.4.tgz",
-      "integrity": "sha1-07ByWcZqDNPGGFDV5jI6JbLBCA4=",
-      "dev": true,
-      "requires": {
-        "js-yaml": "^3.2.7"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "dev": true,
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        }
       }
     },
     "metalsmith-static": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "marked": "^4.0.12",
     "metalsmith": "^2.4.2",
     "metalsmith-headings-identifier": "0.0.11",
-    "metalsmith-metadata": "0.0.4",
     "metalsmith-static": "0.0.5",
     "node-fetch": "^2.6.6",
     "sass": "^1.49.9",


### PR DESCRIPTION
This PR removes the dependency on the `metalsmith-metadata` plugin and instead relies on the core [`metadata`](https://www.metalsmith.io/api/#Metalsmith+metadata) function available in the Metalsmith API.

The PR also:
* removes the concurrency limit of 10 (default is infinity)
* tidies up Metalsmith function chain