### PR TITLE
Refactor heading anchors

### DIFF
--- a/build.js
+++ b/build.js
@@ -80,7 +80,7 @@ renderer.heading = (text, level) => {
         return `<h${level} id="${id}">${text} <a class='header-anchor font-icon' href='${href}'>&#xE368;</a></h${level}>`;
     }
     return `<h${level}>${text}</h${level}>`;
-}
+};
 
 // Store strings requested
 const localization = {};

--- a/build.js
+++ b/build.js
@@ -64,7 +64,7 @@ handlebars.registerHelper('locale-url', (locale, relativeUrl) => {
 
 const renderer = new marked.Renderer();
 
-// make external links to open as new tabs
+// Make external links open in a new tab
 renderer.link = (href, title, text) => {
     const external = href.startsWith('http') && href.indexOf('developer.playcanvas.com') === -1;
     if (external) {
@@ -83,7 +83,7 @@ renderer.heading = (text, level) => {
     return `<h${level}>${text}</h${level}>`;
 }
 
-// store strings requested
+// Store strings requested
 const localization = {};
 
 Metalsmith(__dirname)

--- a/build.js
+++ b/build.js
@@ -14,7 +14,6 @@ const i18n       = require('./lib/i18n/index');
 const i18nout    = require('./lib/i18n-out/index');
 const contents   = require('./lib/contents-json/index');
 const tutorials  = require('./lib/tutorials/index');
-const { render } = require('sass');
 
 let env = null;
 const args = process.argv.slice(2);

--- a/build.js
+++ b/build.js
@@ -65,7 +65,7 @@ const renderer = new marked.Renderer();
 
 // Ensure external links open in a new tab
 renderer.link = (href, title, text) => {
-    const external = href.startsWith('http') && href.indexOf('developer.playcanvas.com') === -1;
+    const external = href.startsWith('http') && !href.includes('playcanvas.com');
     if (external) {
         return `<a href="${href}" target="_blank">${text}</a>`;
     }

--- a/build.js
+++ b/build.js
@@ -63,7 +63,7 @@ handlebars.registerHelper('locale-url', (locale, relativeUrl) => {
 
 const renderer = new marked.Renderer();
 
-// Make external links open in a new tab
+// Ensure external links open in a new tab
 renderer.link = (href, title, text) => {
     const external = href.startsWith('http') && href.indexOf('developer.playcanvas.com') === -1;
     if (external) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "developer.playcanvas.com",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "developer.playcanvas.com",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "license": "MIT",
       "devDependencies": {
         "@metalsmith/layouts": "2.4.0",
@@ -20,7 +20,6 @@
         "linkinator": "^3.0.3",
         "marked": "^4.0.12",
         "metalsmith": "^2.4.2",
-        "metalsmith-headings-identifier": "0.0.11",
         "metalsmith-static": "0.0.5",
         "node-fetch": "^2.6.7",
         "sass": "^1.49.9",
@@ -515,12 +514,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-      "dev": true
-    },
     "node_modules/boxen": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
@@ -682,82 +675,6 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
-    },
-    "node_modules/cheerio": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
-      "integrity": "sha1-dy5wFfLuKZZQltcepBdbdas1SSU=",
-      "dev": true,
-      "dependencies": {
-        "css-select": "~1.0.0",
-        "dom-serializer": "~0.1.0",
-        "entities": "~1.1.1",
-        "htmlparser2": "~3.8.1",
-        "lodash": "^3.2.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cheerio/node_modules/dom-serializer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
-      "dev": true,
-      "dependencies": {
-        "domelementtype": "^1.3.0",
-        "entities": "^1.1.1"
-      }
-    },
-    "node_modules/cheerio/node_modules/domelementtype": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "dev": true
-    },
-    "node_modules/cheerio/node_modules/domhandler": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
-      "dev": true,
-      "dependencies": {
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/cheerio/node_modules/domutils": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true,
-      "dependencies": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/cheerio/node_modules/entities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "dev": true
-    },
-    "node_modules/cheerio/node_modules/htmlparser2": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
-      "dev": true,
-      "dependencies": {
-        "domelementtype": "1",
-        "domhandler": "2.3",
-        "domutils": "1.5",
-        "entities": "1.0",
-        "readable-stream": "1.1"
-      }
-    },
-    "node_modules/cheerio/node_modules/htmlparser2/node_modules/entities": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
-      "dev": true
     },
     "node_modules/chokidar": {
       "version": "3.5.3",
@@ -1101,12 +1018,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1128,42 +1039,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/css-select": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
-      "integrity": "sha1-sRIcpRhI3SZOIkTQWM7iVN7rRLA=",
-      "dev": true,
-      "dependencies": {
-        "boolbase": "~1.0.0",
-        "css-what": "1.0",
-        "domutils": "1.4",
-        "nth-check": "~1.0.0"
-      }
-    },
-    "node_modules/css-select/node_modules/domelementtype": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "dev": true
-    },
-    "node_modules/css-select/node_modules/domutils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
-      "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
-      "dev": true,
-      "dependencies": {
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
-      "integrity": "sha1-18wt9FGAZm+Z0rFEYmOUaeAPc2w=",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -2479,12 +2354,6 @@
       "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
       "dev": true
     },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2692,12 +2561,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-      "dev": true
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -2849,16 +2712,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/metalsmith-headings-identifier": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/metalsmith-headings-identifier/-/metalsmith-headings-identifier-0.0.11.tgz",
-      "integrity": "sha1-dLvv9SqPjHtwDuSBR2VJt9vo2os=",
-      "dev": true,
-      "dependencies": {
-        "cheerio": "^0.19.0",
-        "lodash": "^3.10.1"
       }
     },
     "node_modules/metalsmith-static": {
@@ -3176,15 +3029,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "dev": true,
-      "dependencies": {
-        "boolbase": "~1.0.0"
       }
     },
     "node_modules/on-headers": {
@@ -3565,18 +3409,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
       }
     },
     "node_modules/readdirp": {
@@ -4037,12 +3869,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -5034,12 +4860,6 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
-    "boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-      "dev": true
-    },
     "boxen": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
@@ -5153,83 +4973,6 @@
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
-      }
-    },
-    "cheerio": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
-      "integrity": "sha1-dy5wFfLuKZZQltcepBdbdas1SSU=",
-      "dev": true,
-      "requires": {
-        "css-select": "~1.0.0",
-        "dom-serializer": "~0.1.0",
-        "entities": "~1.1.1",
-        "htmlparser2": "~3.8.1",
-        "lodash": "^3.2.0"
-      },
-      "dependencies": {
-        "dom-serializer": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-          "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
-          "dev": true,
-          "requires": {
-            "domelementtype": "^1.3.0",
-            "entities": "^1.1.1"
-          }
-        },
-        "domelementtype": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-          "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-          "dev": true
-        },
-        "domhandler": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-          "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
-          "dev": true,
-          "requires": {
-            "domelementtype": "1"
-          }
-        },
-        "domutils": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-          "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-          "dev": true,
-          "requires": {
-            "dom-serializer": "0",
-            "domelementtype": "1"
-          }
-        },
-        "entities": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-          "dev": true
-        },
-        "htmlparser2": {
-          "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-          "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
-          "dev": true,
-          "requires": {
-            "domelementtype": "1",
-            "domhandler": "2.3",
-            "domutils": "1.5",
-            "entities": "1.0",
-            "readable-stream": "1.1"
-          },
-          "dependencies": {
-            "entities": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-              "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
-              "dev": true
-            }
-          }
-        }
       }
     },
     "chokidar": {
@@ -5510,12 +5253,6 @@
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
       "dev": true
     },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
-    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -5531,41 +5268,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-      "dev": true
-    },
-    "css-select": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
-      "integrity": "sha1-sRIcpRhI3SZOIkTQWM7iVN7rRLA=",
-      "dev": true,
-      "requires": {
-        "boolbase": "~1.0.0",
-        "css-what": "1.0",
-        "domutils": "1.4",
-        "nth-check": "~1.0.0"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-          "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-          "dev": true
-        },
-        "domutils": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
-          "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
-          "dev": true,
-          "requires": {
-            "domelementtype": "1"
-          }
-        }
-      }
-    },
-    "css-what": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
-      "integrity": "sha1-18wt9FGAZm+Z0rFEYmOUaeAPc2w=",
       "dev": true
     },
     "debug": {
@@ -6548,12 +6250,6 @@
       "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
       "dev": true
     },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -6724,12 +6420,6 @@
         "p-locate": "^5.0.0"
       }
     },
-    "lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-      "dev": true
-    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -6839,16 +6529,6 @@
         "thunkify": "^2.1.2",
         "unyield": "0.0.1",
         "ware": "^1.3.0"
-      }
-    },
-    "metalsmith-headings-identifier": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/metalsmith-headings-identifier/-/metalsmith-headings-identifier-0.0.11.tgz",
-      "integrity": "sha1-dLvv9SqPjHtwDuSBR2VJt9vo2os=",
-      "dev": true,
-      "requires": {
-        "cheerio": "^0.19.0",
-        "lodash": "^3.10.1"
       }
     },
     "metalsmith-static": {
@@ -7094,15 +6774,6 @@
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         }
-      }
-    },
-    "nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "dev": true,
-      "requires": {
-        "boolbase": "~1.0.0"
       }
     },
     "on-headers": {
@@ -7380,18 +7051,6 @@
           "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
           "dev": true
         }
-      }
-    },
-    "readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "dev": true,
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
       }
     },
     "readdirp": {
@@ -7755,12 +7414,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
       "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
-      "dev": true
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
     "string-width": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "linkinator": "^3.0.3",
     "marked": "^4.0.12",
     "metalsmith": "^2.4.2",
-    "metalsmith-headings-identifier": "0.0.11",
     "metalsmith-static": "0.0.5",
     "node-fetch": "^2.6.7",
     "sass": "^1.49.9",


### PR DESCRIPTION
This PR removes the Metalsmith plugin [`metalsmith-headings-identifier`](https://www.npmjs.com/package/metalsmith-headings-identifier/v/0.0.2) and instead uses Marked to modify heading HTML. This removes a dependency from the `package.json` which has not been updated in 7 years. And while `metalsmith-headings-identifier` is quite opaque, the code is now much more obvious.

I've also tweaked the Marked code to generate hyperlinks. It used to be that any link other than to `developer.playcanvas.com` would open in a new tab. Now it's only links to anything other than `playcanvas.com`.