### PR TITLE
[FIX] Hyperlinks in table markdown

### DIFF
--- a/content/en/index.md
+++ b/content/en/index.md
@@ -11,21 +11,21 @@ We have a [growing section][5] of more tutorials and code samples to learn and u
 
 |   | Tutorial Section   |
 |---|---|
-| ![Keepy Up Tutorial Thumbnail][6] | Start making your first game with our [Keepy Up][7] tutorial series. It covers all the major features including [Scene Setup][8], [processing user Input][9] and [creating the User Interface][10]. |
-| ![Physics Tutorial Thumbnail][11] | Experiment with physics with [Collisions, Triggers][12] and [Forces][13].|
-| ![Input Tutorial Thumbnail][14] | Detect input from [Keyboard][15], [Mouse][16] and [Touch screens][17]. |
-| ![User Interface Tutorial Thumbnail][18] | Create wonderful menus and HUDs with the [User Interface][19] system. |
-| ![Audio Tutorial Thumbnail][20] | Immerse the user with [Positional Audio][21] |
+| ![Keepy Up Tutorial Thumbnail](/images/user-manual/frontpage/keepy_up_tutorial_thumb.png) | Start making your first game with our [Keepy Up](/tutorials/keepyup-part-one/) tutorial series. It covers all the major features including [Scene Setup](/tutorials/keepyup-part-one/), [processing user Input](/tutorials/keepyup-part-four/) and [creating the User Interface](/tutorials/keepyup-part-six/). |
+| ![Physics Tutorial Thumbnail](/images/user-manual/frontpage/physics_tutorial_thumb.png) | Experiment with physics with [Collisions, Triggers](/tutorials/collision-and-triggers/) and [Forces](/tutorials/Using-forces-on-rigid-bodies/).|
+| ![Input Tutorial Thumbnail](/images/user-manual/frontpage/input_tutorial_thumb.png) | Detect input from [Keyboard](/tutorials/keyboard-input/), [Mouse](/tutorials/mouse-input/) and [Touch screens](/tutorials/basic-touch-input/). |
+| ![User Interface Tutorial Thumbnail](/images/user-manual/frontpage/ui_tutorial_thumb.png) | Create wonderful menus and HUDs with the [User Interface](/tutorials/ui-elements-buttons/) system. |
+| ![Audio Tutorial Thumbnail](/images/user-manual/frontpage/audio_tutorial_thumb.png) | Immerse the user with [Positional Audio](/tutorials/basic-audio/) |
 
-For the complete PlayCanvas Engine reference, refer to our [API Reference][22] section. 
+For the complete PlayCanvas Engine reference, refer to our [API Reference][6] section. 
 
-Want to see how whole projects have been designed and built? The [Explore Section][23] lists our community's public projects which you can learn from.
+Want to see how whole projects have been designed and built? The [Explore Section][7] lists our community's public projects which you can learn from.
 
 ---
 
 # Getting Help
 
-Our [PlayCanvas Forum][24] is the best place to ask for help, talk about your game, show off your latest project, seek out new team members or offer your assistance to others.
+Our [PlayCanvas Forum][8] is the best place to ask for help, talk about your game, show off your latest project, seek out new team members or offer your assistance to others.
 
 We have an active community of users and the PlayCanvas team is always on hand to help.
 
@@ -33,32 +33,16 @@ We have an active community of users and the PlayCanvas team is always on hand t
 
 # Feature Requests and Reporting Bugs
 
-Want a new feature or seeing something that isn't behaving as it should? Add it to our [Editor][25] or [Engine][26] issue trackers and we will get to it as soon as we can.
+Want a new feature or seeing something that isn't behaving as it should? Add it to our [Editor][9] or [Engine][10] issue trackers and we will get to it as soon as we can.
 
 [1]: /user-manual
 [2]: /user-manual/designer/
 [3]: /user-manual/scripting/
 [4]: /user-manual/version-control/
 [5]: /tutorials/
-[6]: /images/user-manual/frontpage/keepy_up_tutorial_thumb.png
-[7]: /tutorials/keepyup-part-one/
-[8]: /tutorials/keepyup-part-one/
-[9]: /tutorials/keepyup-part-four/
-[10]: /tutorials/keepyup-part-six/
-[11]: /images/user-manual/frontpage/physics_tutorial_thumb.png
-[12]: /tutorials/collision-and-triggers/
-[13]: /tutorials/Using-forces-on-rigid-bodies/
-[14]: /images/user-manual/frontpage/input_tutorial_thumb.png
-[15]: /tutorials/keyboard-input/
-[16]: /tutorials/mouse-input/
-[17]: /tutorials/basic-touch-input/
-[18]: /images/user-manual/frontpage/ui_tutorial_thumb.png
-[19]: /tutorials/ui-elements-buttons/
-[20]: /images/user-manual/frontpage/audio_tutorial_thumb.png
-[21]: /tutorials/basic-audio/
-[22]: /api/
-[23]: https://playcanvas.com/explore/plays
-[24]: https://forum.playcanvas.com/
-[25]: https://github.com/playcanvas/editor/issues
-[26]: https://github.com/playcanvas/engine/issues
+[6]: /api/
+[7]: https://playcanvas.com/explore/plays
+[8]: https://forum.playcanvas.com/
+[9]: https://github.com/playcanvas/editor/issues
+[10]: https://github.com/playcanvas/engine/issues
 

--- a/content/en/user-manual/assets/finding.md
+++ b/content/en/user-manual/assets/finding.md
@@ -14,38 +14,27 @@ If you've got other suggestions for this page. Then let us know on the [forum][1
 
 Asset marketplaces are online libraries of content that you can download, either for free or for a fee, and add to your PlayCanvas game.
 
-| Provider                | 2D Art   | 3D Art   | Audio    |
-|-------------------------|----------|----------|----------|
-| [3D Models Textures][2] |          | &#x2713; | &#x2713; |
-| [BlendSwap][3]          |          | &#x2713; |          |
-| [CGTrader][4]           |          | &#x2713; |          |
-| [Game Dev Market][5]    | &#x2713; | &#x2713; | &#x2713; |
-| [GameSounds.xyz][6]     |          |          | &#x2713; |
-| [Kenney][7]             | &#x2713; | &#x2713; | &#x2713; |
-| [Mixamo][8]             |          | &#x2713; |          |
-| [PlayOnLoop][9]         |          |          | &#x2713; |
-| [Open Game Art][10]     | &#x2713; | &#x2713; | &#x2713; |
-| [Sound Bible][11]       |          |          | &#x2713; |
-| [Turbosquid][12]        | &#x2713; | &#x2713; | &#x2713; |
+| Provider                                                                 | 2D Art   | 3D Art   | Audio    |
+|--------------------------------------------------------------------------|----------|----------|----------|
+| [3D Models Textures](https://www.3dmodels-textures.com/)                 |          | &#x2713; | &#x2713; |
+| [BlendSwap](https://www.blendswap.com/)                                  |          | &#x2713; |          |
+| [CGTrader](https://www.cgtrader.com/)                                    |          | &#x2713; |          |
+| [Game Dev Market](https://www.gamedevmarket.net?ally=O0I9alFp)           | &#x2713; | &#x2713; | &#x2713; |
+| [GameSounds.xyz](https://gamesounds.xyz/)                                |          |          | &#x2713; |
+| [Kenney](https://kenney.nl/)                                             | &#x2713; | &#x2713; | &#x2713; |
+| [Mixamo](https://www.mixamo.com/)                                        |          | &#x2713; |          |
+| [PlayOnLoop](https://www.playonloop.com/music-loops-category/videogame/) |          |          | &#x2713; |
+| [Open Game Art](https://opengameart.org/)                                | &#x2713; | &#x2713; | &#x2713; |
+| [Sound Bible](https://soundbible.com/)                                   |          |          | &#x2713; |
+| [Turbosquid](https://www.turbosquid.com/)                                | &#x2713; | &#x2713; | &#x2713; |
 
 ## Procedural Generation Tools
 
 There are tools available that can generate game assets procedurally. Here are some good examples:
 
-* [Sound FX Generator][13]
-* [Spacescape Skybox Generator][14]
+* [Sound FX Generator][2]
+* [Spacescape Skybox Generator][3]
 
 [1]: https://forum.playcanvas.com/
-[2]: https://www.3dmodels-textures.com/
-[3]: https://www.blendswap.com/
-[4]: https://www.cgtrader.com/
-[5]: https://www.gamedevmarket.net?ally=O0I9alFp
-[6]: https://gamesounds.xyz/
-[7]: https://kenney.nl/
-[8]: https://www.mixamo.com/
-[9]: https://www.playonloop.com/music-loops-category/videogame/
-[10]: https://opengameart.org/
-[11]: https://soundbible.com/
-[12]: https://www.turbosquid.com/
-[13]: https://www.bfxr.net/
-[14]: http://alexcpeterson.com/spacescape
+[2]: https://www.bfxr.net/
+[3]: http://alexcpeterson.com/spacescape

--- a/content/en/user-manual/introduction.md
+++ b/content/en/user-manual/introduction.md
@@ -73,16 +73,16 @@ PlayCanvas was always designed to be plugin free, running natively in the browse
 
 At the time of writing, the browser requirements are currently as follows:
 
-| Browser       | Version | Win      | macOS    | Linux    | Chrome OS | Android  | iOS      |
-|---------------|---------|----------|----------|----------|-----------|----------|----------|
-| [Chrome][9]   | 9.0+    | &#x2713; | &#x2713; | &#x2713; | &#x2713;  | &#x2713; | &#x2713; |
-| [Safari][10]  | 8.0+    |          | &#x2713; |          |           |          | &#x2713; |
-| [Firefox][11] | 4.0+    | &#x2713; | &#x2713; | &#x2713; |           | &#x2713; | &#x2713; |
-| [Edge][12]    | 12.0+   | &#x2713; |          |          |           |          |          |
-| [IE][13]      | 11.0+   | &#x2713; |          |          |           |          |          |
-| [Opera][14]   | 12.0+   | &#x2713; | &#x2713; | &#x2713; |           | &#x2713; |          |
+| Browser                                     | Version | Win      | macOS    | Linux    | Chrome OS | Android  | iOS      |
+|---------------------------------------------|---------|----------|----------|----------|-----------|----------|----------|
+| [Chrome](https://www.google.com/chrome/)    | 9.0+    | &#x2713; | &#x2713; | &#x2713; | &#x2713;  | &#x2713; | &#x2713; |
+| [Safari](https://www.apple.com/safari/)     | 8.0+    |          | &#x2713; |          |           |          | &#x2713; |
+| [Firefox](https://www.mozilla.org/firefox/) | 4.0+    | &#x2713; | &#x2713; | &#x2713; |           | &#x2713; | &#x2713; |
+| [Edge](https://www.microsoft.com/edge)      | 12.0+   | &#x2713; |          |          |           |          |          |
+| Internet Explorer                           | 11.0+   | &#x2713; |          |          |           |          |          |
+| [Opera](https://www.opera.com/)             | 12.0+   | &#x2713; | &#x2713; | &#x2713; |           | &#x2713; |          |
 
-If you are in doubt as to whether your browser supports WebGL (required to run PlayCanvas), visit [this page][15]. If you see a spinning cube, you are all set!
+If you are in doubt as to whether your browser supports WebGL (required to run PlayCanvas), visit [this page][9]. If you see a spinning cube, you are all set!
 
 [1]: /images/user-manual/introduction/workflow-assets.jpg
 [2]: /images/user-manual/introduction/workflow-create-scene.jpg
@@ -92,10 +92,4 @@ If you are in doubt as to whether your browser supports WebGL (required to run P
 [6]: /user-manual/assets
 [7]: /user-manual/publishing
 [8]: /user-manual/glossary/#dom
-[9]: https://www.google.com/chrome/
-[10]: https://www.apple.com/safari/
-[11]: https://www.mozilla.org/firefox/
-[12]: https://www.microsoft.com/edge
-[13]: https://www.microsoft.com/en-us/download/internet-explorer.aspx
-[14]: https://www.opera.com/
-[15]: https://get.webgl.org/
+[9]: https://get.webgl.org/

--- a/content/en/user-manual/packs/components/index.md
+++ b/content/en/user-manual/packs/components/index.md
@@ -8,40 +8,22 @@ Components define behaviors that are attached to Entities. An Entity is a contai
 
 There are many different Components defined in the PlayCanvas Engine. You can add a Component to an Entity using the PlayCanvas Editor. The properties exposed by Components are listed in the Attribute Editor when you select an Entity.
 
-| Component             | Description |
-|-----------------------|-------------|
-| [Anim][1]             | Specifies the anim state graph and animation assets that can run on the model specified by the entity's render component. |
-| [Animation][2]        | Specifies the animation assets that can run on the model specified by the entity's model component. |
-| [Audio Listener][3]   | Specifies the location of the listener for 3D audio playback. |
-| [Button][4]           | Create a user interface button. |
-| [Camera][5]           | Renders the scene from the location of the entity. |
-| [Collision][6]        | Assigns a collision volume to the entity. |
-| [Element][7]          | Defines a user interface element. |
-| [Layout Child][8]     | Override default Layout Group properties for one element. |
-| [Layout Group][9]     | Automatically set position and scale of child user interface elements. |
-| [Light][10]           | Attach a dynamic light source to the Entity. |
-| [Model][11]           | Renders a 3D model at the location of the entity. |
-| [Particle System][12] | Attach a particle system to the Entity. |
-| [Rigid Body][13]      | Adds the entity to the scene's physical simulation. |
-| [Screen][14]          | Defines the area and rendering of a user interface. |
-| [Script][15]          | Allows the entity to run JavaScript fragments to implement custom behavior. |
-| [Sound][16]           | Plays audio assets. |
-| [Sprite][17]          | Render 2D graphics at the location of the entity. |
-
-[1]: /user-manual/packs/components/anim
-[2]: /user-manual/packs/components/animation
-[3]: /user-manual/packs/components/audiolistener
-[4]: /user-manual/packs/components/button
-[5]: /user-manual/packs/components/camera
-[6]: /user-manual/packs/components/collision
-[7]: /user-manual/packs/components/element
-[8]: /user-manual/packs/components/layout-child
-[9]: /user-manual/packs/components/layout-group
-[10]: /user-manual/packs/components/light
-[11]: /user-manual/packs/components/model
-[12]: /user-manual/packs/components/particlesystem
-[13]: /user-manual/packs/components/rigidbody
-[14]: /user-manual/packs/components/screen
-[15]: /user-manual/packs/components/script
-[16]: /user-manual/packs/components/sound
-[17]: /user-manual/packs/components/sprite
+| Component                                                       | Description |
+|-----------------------------------------------------------------|-------------|
+| [Anim](/user-manual/packs/components/anim)                      | Specifies the anim state graph and animation assets that can run on the model specified by the entity's render component. |
+| [Animation](/user-manual/packs/components/animation)            | Specifies the animation assets that can run on the model specified by the entity's model component. |
+| [Audio Listener](/user-manual/packs/components/audiolistener)   | Specifies the location of the listener for 3D audio playback. |
+| [Button](/user-manual/packs/components/button)                  | Create a user interface button. |
+| [Camera](/user-manual/packs/components/camera)                  | Renders the scene from the location of the entity. |
+| [Collision](/user-manual/packs/components/collision)            | Assigns a collision volume to the entity. |
+| [Element](/user-manual/packs/components/element)                | Defines a user interface element. |
+| [Layout Child](/user-manual/packs/components/layout-child)      | Override default Layout Group properties for one element. |
+| [Layout Group](/user-manual/packs/components/layout-group)      | Automatically set position and scale of child user interface elements. |
+| [Light](/user-manual/packs/components/light)                    | Attach a dynamic light source to the Entity. |
+| [Model](/user-manual/packs/components/model)                    | Renders a 3D model at the location of the entity. |
+| [Particle System](/user-manual/packs/components/particlesystem) | Attach a particle system to the Entity. |
+| [Rigid Body](/user-manual/packs/components/rigidbody)           | Adds the entity to the scene's physical simulation. |
+| [Screen](/user-manual/packs/components/screen)                  | Defines the area and rendering of a user interface. |
+| [Script](/user-manual/packs/components/script)                  | Allows the entity to run JavaScript fragments to implement custom behavior. |
+| [Sound](/user-manual/packs/components/sound)                    | Plays audio assets. |
+| [Sprite](/user-manual/packs/components/sprite)                  | Render 2D graphics at the location of the entity. |

--- a/content/en/user-manual/physics/ammo-alternatives.md
+++ b/content/en/user-manual/physics/ammo-alternatives.md
@@ -8,23 +8,17 @@ ammo.js is perhaps the most popular and well known JavaScript physics engine. It
 
 As it happens, there are several alternatives to ammo.js:
 
-| Physics Engine | JS       | WASM     | 2D       | 3D       | PlayCanvas Integration |
-|----------------|----------|----------|----------|----------|------------------------|
-| [box2d.js][1]  | &#x2713; | &#x2713; | &#x2713; |          |                        |
-| [Matter.js][2] | &#x2713; |          | &#x2713; |          |                        |
-| [p2.js][3]     | &#x2713; |          | &#x2713; |          | [Yes][6]               |
-| [cannon.js][4] | &#x2713; |          |          | &#x2713; |                        |
-| [Oimo.js][5]   | &#x2713; |          |          | &#x2713; |                        |
+| Physics Engine                                     | JS       | WASM     | 2D       | 3D       | PlayCanvas Integration                                |
+|----------------------------------------------------|----------|----------|----------|----------|-------------------------------------------------------|
+| [box2d.js](https://github.com/kripken/box2d.js)    | &#x2713; | &#x2713; | &#x2713; |          |                                                       |
+| [Matter.js](https://github.com/liabru/matter-js)   | &#x2713; |          | &#x2713; |          |                                                       |
+| [p2.js](https://github.com/schteppe/p2.js)         | &#x2713; |          | &#x2713; |          | [Yes](https://github.com/playcanvas/playcanvas-p2.js) |
+| [cannon.js](https://github.com/schteppe/cannon.js) | &#x2713; |          |          | &#x2713; |                                                       |
+| [Oimo.js](https://github.com/lo-th/Oimo.js)        | &#x2713; |          |          | &#x2713; |                                                       |
 
 While there is currently only one existing PlayCanvas integration for the p2.js engine, it should be straightforward to create additional integrations for the other engines listed using a similar approach.
 
-In December 2018, Nvidia open sourced the [PhysX][7] physics engine. While there is no JS/WASM port of PhysX yet, it is perhaps the most competitive physics runtime compared to Bullet/ammo.js. When a web port becomes available, it will be added to the table above.
+In December 2018, Nvidia open sourced the [PhysX][1] physics engine. While there is no JS/WASM port of PhysX yet, it is perhaps the most competitive physics runtime compared to Bullet/ammo.js. When a web port becomes available, it will be added to the table above.
 
-[1]: https://github.com/kripken/box2d.js
-[2]: https://github.com/liabru/matter-js
-[3]: https://github.com/schteppe/p2.js
-[4]: https://github.com/schteppe/cannon.js
-[5]: https://github.com/lo-th/Oimo.js
-[6]: https://github.com/playcanvas/playcanvas-p2.js
-[7]: https://github.com/NVIDIAGameWorks/PhysX
+[1]: https://github.com/NVIDIAGameWorks/PhysX
 


### PR DESCRIPTION
Fixes #381 

Seems the build process can't handle reference style links in table markdown. I'm not sure if this is a bug in Marked, but for now, I'm just inlining the links to fix the problem.