### PR TITLE
Bold markdown text is now using the correct font

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -150,7 +150,7 @@
     color: rgba(255, 255, 255, 0.75);
   }
   header a:hover {
-    color: rgb(255, 255, 255);
+    color: white;
     text-decoration: none;
   }
   header .header-title {
@@ -191,7 +191,7 @@
     border-bottom: 2px solid rgba(255, 255, 255, 0.75);
   }
   header ul li.active a {
-    color: rgb(255, 255, 255);
+    color: white;
   }
   header .header-content {
     clear: both;
@@ -199,7 +199,7 @@
     padding: 20px 0px;
   }
   header .header-content h1 {
-    color: rgb(255, 255, 255);
+    color: white;
     font-size: 24px;
   }
   header .header-content img {
@@ -311,7 +311,7 @@
   }
   input.search:focus {
     outline: 0;
-    border-color: rgb(255, 255, 255);
+    border-color: white;
   }
 
   nav.regular {
@@ -601,6 +601,13 @@
   }
   .container main a:hover {
     text-decoration: underline;
+  }
+  .container main strong {
+    font-family: "Proxima Nova Bold", "Helvetica Neue", Arial, Helvetica, sans-serif;
+    font-weight: bold;
+    font-style: normal;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
   .container main img {
     display: block;

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -150,7 +150,7 @@
     color: rgba(255, 255, 255, 0.75);
   }
   header a:hover {
-    color: white;
+    color: rgb(255, 255, 255);
     text-decoration: none;
   }
   header .header-title {
@@ -191,7 +191,7 @@
     border-bottom: 2px solid rgba(255, 255, 255, 0.75);
   }
   header ul li.active a {
-    color: white;
+    color: rgb(255, 255, 255);
   }
   header .header-content {
     clear: both;
@@ -199,7 +199,7 @@
     padding: 20px 0px;
   }
   header .header-content h1 {
-    color: white;
+    color: rgb(255, 255, 255);
     font-size: 24px;
   }
   header .header-content img {
@@ -311,7 +311,7 @@
   }
   input.search:focus {
     outline: 0;
-    border-color: white;
+    border-color: rgb(255, 255, 255);
   }
 
   nav.regular {

--- a/sass/styles.scss
+++ b/sass/styles.scss
@@ -568,6 +568,10 @@
                 }
             }
 
+            strong {
+                @include font-bold();
+            }
+
             img {
                 display: block;
                 margin: 0 auto;


### PR DESCRIPTION
Fixes text that is bold in markdown but don't appear bold on the site

<img width="853" alt="image" src="https://user-images.githubusercontent.com/16639049/169293206-66b9300b-8838-4754-9ace-f372eeed9e67.png">
