### PR TITLE
Getting started section to top of tutorials page

### DIFF
--- a/content/en/tutorials/anim-blending.md
+++ b/content/en/tutorials/anim-blending.md
@@ -1,7 +1,7 @@
 ---
 title: Anim State Graph Blending
 layout: tutorial-page.hbs
-tags: animation
+tags: animation,basics
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405874/A8B1FE-image-75.jpg
 ---
 

--- a/content/en/tutorials/changing-scenes.md
+++ b/content/en/tutorials/changing-scenes.md
@@ -1,7 +1,7 @@
 ---
 title: Changing Scenes
 layout: tutorial-page.hbs
-tags: loading,scenes
+tags: loading,scenes,basics
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/437633/BCF404-image-75.jpg
 ---
 

--- a/content/en/tutorials/entity-picking.md
+++ b/content/en/tutorials/entity-picking.md
@@ -1,7 +1,7 @@
 ---
 title: Entity Picking
 layout: tutorial-page.hbs
-tags: raycast
+tags: raycast,basics,physics
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405856/DS51PO-image-75.jpg
 ---
 

--- a/content/en/tutorials/using-assets.md
+++ b/content/en/tutorials/using-assets.md
@@ -1,7 +1,7 @@
 ---
 title: Using the Asset Registry
 layout: tutorial-page.hbs
-tags: loading, assets
+tags: loading, assets, basics
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406036/U2FYM6-image-75.jpg
 ---
 

--- a/content/en/user-manual/physics/forces-and-impulses.md
+++ b/content/en/user-manual/physics/forces-and-impulses.md
@@ -1,6 +1,7 @@
 ---
 title: Forces and Impulses
 layout: usermanual-page.hbs
+tags: physics,basics
 position: 2
 ---
 

--- a/layouts/partials/tutorial-list.hbs
+++ b/layouts/partials/tutorial-list.hbs
@@ -1,6 +1,12 @@
 {{#with pages}}
 {{#lang-selector "en"}}{{/lang-selector}}
 {{#with en}}
+<h1 id="getting-started-title">Getting Started</h1>
+<div id="getting-started-content" class="tutorial-cloud">
+    {{#each basics}}
+    <a class="tutorial-cloud-item" data-tags="{{tags}}" href="{{url}}"><img class="thumb" src="{{thumbUrl}}" alt="{{{title}}}" loading="lazy">{{{title}}}</a>
+    {{/each}}
+</div>
 <h1>Tutorials</h1>
 <div id="no-tutorials-message" class="hidden">No tutorials yet! Let us know what you would like to see here on the <a href="https://forum.playcanvas.com/" target="_blank" rel="noopener">forums</a>.</div>
 <div class="tutorial-cloud">
@@ -18,6 +24,12 @@
 {{#lang-selector-close}}{{/lang-selector-close}}
 {{#lang-selector "ja"}}{{/lang-selector}}
 {{#with ja}}
+<h1 id="getting-started-title">Getting Started</h1>
+<div id="getting-started-content" class="tutorial-cloud">
+    {{#each basics}}
+    <a class="tutorial-cloud-item" data-tags="{{tags}}" href="{{url}}"><img class="thumb" src="{{thumbUrl}}" alt="{{{title}}}" loading="lazy">{{{title}}}</a>
+    {{/each}}
+</div>
 <h1>Tutorials</h1>
 <div id="no-tutorials-message" class="hidden">No tutorials yet! Let us know what you would like to see here on the <a href="https://forum.playcanvas.com/" target="_blank" rel="noopener">forums</a>.</div>
 <div class="tutorial-cloud">
@@ -35,6 +47,12 @@
 {{#lang-selector-close}}{{/lang-selector-close}}
 {{#lang-selector "ru"}}{{/lang-selector}}
 {{#with ru}}
+<h1 id="getting-started-title">Getting Started</h1>
+<div id="getting-started-content" class="tutorial-cloud">
+    {{#each basics}}
+    <a class="tutorial-cloud-item" data-tags="{{tags}}" href="{{url}}"><img class="thumb" src="{{thumbUrl}}" alt="{{{title}}}" loading="lazy">{{{title}}}</a>
+    {{/each}}
+</div>
 <h1>Tutorials</h1>
 <div id="no-tutorials-message" class="hidden">No tutorials yet! Let us know what you would like to see here on the <a href="https://forum.playcanvas.com/" target="_blank" rel="noopener">forums</a>.</div>
 <div class="tutorial-cloud">
@@ -52,6 +70,12 @@
 {{#lang-selector-close}}{{/lang-selector-close}}
 {{#lang-selector "zh"}}{{/lang-selector}}
 {{#with zh}}
+<h1 id="getting-started-title">Getting Started</h1>
+<div id="getting-started-content" class="tutorial-cloud">
+    {{#each basics}}
+    <a class="tutorial-cloud-item" data-tags="{{tags}}" href="{{url}}"><img class="thumb" src="{{thumbUrl}}" alt="{{{title}}}" loading="lazy">{{{title}}}</a>
+    {{/each}}
+</div>
 <h1>Tutorials</h1>
 <div id="no-tutorials-message" class="hidden">No tutorials yet! Let us know what you would like to see here on the <a href="https://forum.playcanvas.com/" target="_blank" rel="noopener">forums</a>.</div>
 <div class="tutorial-cloud">

--- a/lib/tutorials/index.js
+++ b/lib/tutorials/index.js
@@ -157,6 +157,11 @@ module.exports = function makePlugin(dir) {
 
                         // add unique tag for tutorials
                         tutorialsIndex[lang][filepath].tags.push('_tutorial');
+
+                        // if it's tagged as basics, add it to the Getting Started section
+                        if (file.tags.find(element => element === 'basics')) {
+                            tutorialsIndex[lang][filepath].tags.push('_basics');
+                        }
                     }
                 }
 
@@ -214,18 +219,23 @@ module.exports = function makePlugin(dir) {
                     };
 
                     for (const lang in tutorialsIndex) {
-                        context.pages[lang] = {
+                        const pages = {
                             tutorials: [],
-                            projectDemos: []
+                            projectDemos: [],
+                            basics: []
                         };
                         // Add all the tutorial pages to the language
                         for (const key in tutorialsIndex[lang]) {
-                            context.pages[lang].tutorials.push(tutorialsIndex[lang][key]);
+                            const page = tutorialsIndex[lang][key];
+                            pages.tutorials.push(page);
+                            if (page.tags.find(element => element === 'basics')) {
+                                pages.basics.push(page);
+                            }
                         }
 
                         // Add all the project demos to the language
                         for (const key in projectDemosIndex[lang]) {
-                            context.pages[lang].projectDemos.push(projectDemosIndex[lang][key]);
+                            pages.projectDemos.push(projectDemosIndex[lang][key]);
                         }
 
                         const comparePages = (a, b) => {
@@ -238,8 +248,11 @@ module.exports = function makePlugin(dir) {
                             return 0;
                         };
 
-                        context.pages[lang].tutorials.sort(comparePages);
-                        context.pages[lang].projectDemos.sort(comparePages);
+                        pages.tutorials.sort(comparePages);
+                        pages.projectDemos.sort(comparePages);
+                        pages.basics.sort(comparePages);
+
+                        context.pages[lang] = pages;
                     }
 
                     // tutorial main page filters

--- a/public/js/page-utils.js
+++ b/public/js/page-utils.js
@@ -238,6 +238,17 @@
                 }
             });
 
+            // Hide the Getting Started section if there's a filter in place
+            var gettingStartedTitle = document.getElementById('getting-started-title');
+            var gettingStartedContent = document.getElementById('getting-started-content');
+            if (tutorials.tags.length > 0) {
+                gettingStartedTitle.classList.add('hidden');
+                gettingStartedContent.classList.add('hidden');
+            } else {
+                gettingStartedTitle.classList.remove('hidden');
+                gettingStartedContent.classList.remove('hidden');
+            }
+
             var noTutorialsMessage = document.getElementById('no-tutorials-message');
             if (noTutorialsMessage) {
                 if (tutorialEnabledCount > 0) {


### PR DESCRIPTION
It only is shown if there are no filters selected, ie

It shows any tutorials tags as 'basics' and the idea is that if a new user comes to PlayCanvas, it is more obvious which tutorials they should focus on first.

<img width="1198" alt="image" src="https://user-images.githubusercontent.com/16639049/175773329-8661fac7-cca3-4d07-aa77-a28a28a6e26b.png">

If a filter is selected, then it is hidden
<img width="1170" alt="image" src="https://user-images.githubusercontent.com/16639049/175773341-5d9e9662-de25-457c-ac3c-572359ab726d.png">
