### PR TITLE
Queries are autofilled in the search bar on search results

### DIFF
--- a/public/js/page-utils.js
+++ b/public/js/page-utils.js
@@ -386,7 +386,7 @@
 
         // add query strings to the search bar if we were searching
         // to save user from retyping a search
-        // Not: supported on IE
+        // Note: not supported on IE
         if (window.URLSearchParams) {
             var urlSearchParams = new URLSearchParams(window.location.search);
             if (urlSearchParams) {

--- a/public/js/page-utils.js
+++ b/public/js/page-utils.js
@@ -383,5 +383,18 @@
                 flags[i].classList.add("inactive");
             }
         }
+
+        // add query strings to the search bar if we were searching
+        // to save user from retyping a search
+        // Not: supported on IE
+        if (window.URLSearchParams) {
+            var urlSearchParams = new URLSearchParams(window.location.search);
+            if (urlSearchParams) {
+                var searchQuery = urlSearchParams.get('q');
+                if (searchQuery) {
+                    search.value = searchQuery;
+                }
+            }
+        }
     });
 })();


### PR DESCRIPTION
This saves having to retype the whole query if you want to make a tweak to the search results/query

https://user-images.githubusercontent.com/16639049/181546850-a6f32ad3-f941-4510-b1c8-b7cce2b1c5f7.mp4


