### PR TITLE
Beautify generated HTML

### DIFF
--- a/.htmlvalidate.json
+++ b/.htmlvalidate.json
@@ -2,7 +2,6 @@
     "extends": ["html-validate:recommended"],
     "rules": {
         "no-inline-style": "off",
-        "no-trailing-whitespace": "off",
         "wcag/h37": "off"
     }
 }

--- a/build.js
+++ b/build.js
@@ -7,6 +7,7 @@ const Metalsmith = require('metalsmith');
 const layouts    = require('@metalsmith/layouts');
 const markdown   = require('@metalsmith/markdown');
 const permalinks = require('@metalsmith/permalinks');
+const beautify   = require('metalsmith-beautify');
 const msStatic   = require('metalsmith-static');
 const navbuilder = require('./lib/nav-builder-plugin/index');
 const locale     = require('./lib/locale/index');
@@ -155,6 +156,7 @@ Metalsmith(__dirname)
     .use(i18nout()({
         data: localization
     }))
+    .use(beautify())
     .build(function (err) {
         if (err) throw err;
         console.log('Build complete!');

--- a/content/en/tutorials/animated-textures.md
+++ b/content/en/tutorials/animated-textures.md
@@ -19,7 +19,7 @@ The square plane in the example uses the script `scrolling-texture.js` to consta
 ScrollingTexture.prototype.update = function(dt) {
     var velocity = ScrollingTexture.tmpVec2;
     var offset = ScrollingTexture.tmpOffset;
-    
+
     // Calculate how much to offset the texture
     // Speed * dt
     velocity.set(this.speed.x, this.speed.y);
@@ -28,7 +28,7 @@ ScrollingTexture.prototype.update = function(dt) {
     // Update the diffuse and normal map offset values
     offset.copy(this.material.diffuseMapOffset);
     offset.add(velocity);
-    
+
     this.material.diffuseMapOffset = offset;
     this.material.normalMapOffset = offset;
     this.material.update();

--- a/content/en/tutorials/keepyup-part-six.md
+++ b/content/en/tutorials/keepyup-part-six.md
@@ -40,18 +40,18 @@ UiMenu.attributes.add("overlay", {type: "entity"});
 
 // initialize code called once per entity
 UiMenu.prototype.initialize = function() {
-    this.on('enable', this.onEnable, this);    
+    this.on('enable', this.onEnable, this);
     this.on('disable', this.onDisable, this);
-    
+
     this.onEnable();
 };
 
 UiMenu.prototype.onEnable = function () {
-    // Listen for clicks on the background    
-    
+    // Listen for clicks on the background
+
     this.overlay.enabled = true;
     this.overlay.element.on("click", this.start, this);
-    
+
     if (this.ball) {
         this.ball.model.meshInstances[0].material.depthTest = false;
     }
@@ -69,6 +69,7 @@ UiMenu.prototype.start = function (e) {
     e.stopPropagation();
 };
 ```
+
 First we have set up an attribute with a reference to the overlay element. The overlay element is a full screen element which tints the screen green. We also use this to detect input as we only care about the user clicking on the full screen.
 
 When the Entity is enabled we display the full screen overlay by enabling it and then we start listening for the click event. When the Entity is disabled we stop listening for the event and we hide the overlay. When an event is triggered we fire a "ui:start" event which the main game script is listening for and that triggers a change of game state.

--- a/content/en/tutorials/ui-elements-progress.md
+++ b/content/en/tutorials/ui-elements-progress.md
@@ -52,7 +52,7 @@ ProgressBar.attributes.add('progressImage', {type: 'entity'});
 ProgressBar.attributes.add('progressImageMaxWidth', {type: 'number'});
 
 ProgressBar.prototype.initialize = function() {
-    // use our own rect object to set the size of 
+    // use our own rect object to set the size of
     // the progress bar
     this.imageRect = this.progressImage.element.rect.clone();
 

--- a/content/en/user-manual/your-first-app.md
+++ b/content/en/user-manual/your-first-app.md
@@ -73,12 +73,12 @@ var Movement = pc.createScript('movement');
 
 // initialize code called once per entity
 Movement.prototype.initialize = function() {
-    
+
 };
 
 // update code called every frame
 Movement.prototype.update = function(dt) {
-    
+
 };
 ```
 
@@ -89,7 +89,7 @@ var Movement = pc.createScript('movement');
 
 // initialize code called once per entity
 Movement.prototype.initialize = function() {
-    
+
 };
 
 // update code called every frame

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "linkinator": "^4.1.2",
         "marked": "^4.2.12",
         "metalsmith": "^2.5.1",
+        "metalsmith-beautify": "^0.2.0",
         "metalsmith-static": "0.0.5",
         "node-fetch": "^2.6.7",
         "sass": "^1.58.1",
@@ -354,6 +355,12 @@
       "version": "2.29.0",
       "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.29.0.tgz",
       "integrity": "sha512-g5QiLIfbg3pLuYUJPlisNKY+epQJTcMDsOnVNkscrDP1oi7vmJnzOANYJI/1pZcVJ6umUkBv3aFtlg1UvUHGzA==",
+      "dev": true
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "node_modules/accepts": {
@@ -1063,6 +1070,16 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
@@ -1275,6 +1292,52 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/editorconfig": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.19.0",
+        "lru-cache": "^4.1.5",
+        "semver": "^5.6.0",
+        "sigmund": "^1.0.1"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/editorconfig/node_modules/lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/editorconfig/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/editorconfig/node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -2857,6 +2920,26 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/js-beautify": {
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.7.tgz",
+      "integrity": "sha512-5SOX1KXPFKx+5f6ZrPsIPEY7NwKeQz47n3jm2i+XeHx9MoRsfQenlOP13FQhWvg8JRS0+XLO6XYUQ2GX+q+T9A==",
+      "dev": true,
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^0.15.3",
+        "glob": "^8.0.3",
+        "nopt": "^6.0.0"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-sdsl": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
@@ -3040,6 +3123,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ]
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -3161,6 +3254,26 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/metalsmith-beautify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/metalsmith-beautify/-/metalsmith-beautify-0.2.0.tgz",
+      "integrity": "sha512-YDOQBm/NIkxcYxVQoaGVvPGWBxUPMS9fTEHY7KEcKKBSeD/rpwRdOv89MV744UDVDSeh4wrd4Q8PezjePhO+5Q==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^0.8.1",
+        "js-beautify": "^1.6.0",
+        "lodash": "~2.4.1"
+      }
+    },
+    "node_modules/metalsmith-beautify/node_modules/debug": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
+      "integrity": "sha512-HlXEJm99YsRjLJ8xmuz0Lq8YUwrv7hAJkTEr6/Em3sUlSUNl0UdFA+1SrY4fnykeq1FVkUEUtwRGHs9VvlYbGA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/metalsmith-static": {
@@ -3354,6 +3467,21 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nopt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
+      "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+      "dev": true,
+      "dependencies": {
+        "abbrev": "^1.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/normalize-package-data": {
@@ -3660,6 +3788,18 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true
+    },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+      "dev": true
     },
     "node_modules/punycode": {
       "version": "1.4.1",
@@ -4319,6 +4459,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
+      "dev": true
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -5365,6 +5511,12 @@
       "integrity": "sha512-g5QiLIfbg3pLuYUJPlisNKY+epQJTcMDsOnVNkscrDP1oi7vmJnzOANYJI/1pZcVJ6umUkBv3aFtlg1UvUHGzA==",
       "dev": true
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -5880,6 +6032,16 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
@@ -6027,6 +6189,48 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "editorconfig": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.19.0",
+        "lru-cache": "^4.1.5",
+        "semver": "^5.6.0",
+        "sigmund": "^1.0.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
+          "dev": true
+        }
+      }
     },
     "emoji-regex": {
       "version": "9.2.2",
@@ -7190,6 +7394,18 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "js-beautify": {
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.7.tgz",
+      "integrity": "sha512-5SOX1KXPFKx+5f6ZrPsIPEY7NwKeQz47n3jm2i+XeHx9MoRsfQenlOP13FQhWvg8JRS0+XLO6XYUQ2GX+q+T9A==",
+      "dev": true,
+      "requires": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^0.15.3",
+        "glob": "^8.0.3",
+        "nopt": "^6.0.0"
+      }
+    },
     "js-sdsl": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
@@ -7332,6 +7548,12 @@
         "p-locate": "^5.0.0"
       }
     },
+    "lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -7420,6 +7642,25 @@
         "rimraf": "^3.0.2",
         "stat-mode": "^1.0.0",
         "ware": "^1.3.0"
+      }
+    },
+    "metalsmith-beautify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/metalsmith-beautify/-/metalsmith-beautify-0.2.0.tgz",
+      "integrity": "sha512-YDOQBm/NIkxcYxVQoaGVvPGWBxUPMS9fTEHY7KEcKKBSeD/rpwRdOv89MV744UDVDSeh4wrd4Q8PezjePhO+5Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^0.8.1",
+        "js-beautify": "^1.6.0",
+        "lodash": "~2.4.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
+          "integrity": "sha512-HlXEJm99YsRjLJ8xmuz0Lq8YUwrv7hAJkTEr6/Em3sUlSUNl0UdFA+1SrY4fnykeq1FVkUEUtwRGHs9VvlYbGA==",
+          "dev": true
+        }
       }
     },
     "metalsmith-static": {
@@ -7562,6 +7803,15 @@
       "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
+      }
+    },
+    "nopt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
+      "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+      "dev": true,
+      "requires": {
+        "abbrev": "^1.0.0"
       }
     },
     "normalize-package-data": {
@@ -7783,6 +8033,18 @@
           "dev": true
         }
       }
+    },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+      "dev": true
     },
     "punycode": {
       "version": "1.4.1",
@@ -8241,6 +8503,12 @@
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
+      "dev": true
     },
     "signal-exit": {
       "version": "3.0.7",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "linkinator": "^4.1.2",
     "marked": "^4.2.12",
     "metalsmith": "^2.5.1",
+    "metalsmith-beautify": "^0.2.0",
     "metalsmith-static": "0.0.5",
     "node-fetch": "^2.6.7",
     "sass": "^1.58.1",


### PR DESCRIPTION
Use [`metalsmith-beautify`](https://github.com/boushley/metalsmith-beautify) to reformat the HTML files generated by Metalsmith. This happens to remove all trailing whitespace which means that rule can be enabled in the `html-validate` tool config.