### PR TITLE
Remove px from img attributes

### DIFF
--- a/content/en/tutorials/basic-materials.md
+++ b/content/en/tutorials/basic-materials.md
@@ -45,8 +45,8 @@ Changing the color of the material is a good start, but you'll quickly want more
 
 Download & save these sample textures:
 
-<a href="/downloads/proto_orange.png"><img loading="lazy" style="float:left;" src="/downloads/proto_orange.png" width="128px" alt="Sample diffuse map texture"></a>
-<a href="/downloads/proto_gray_n.png"><img loading="lazy" style="padding-left: 20px; margin: 0px" src="/downloads/proto_gray_n.png" width="128px" alt="Sample normal map texture"></a>
+<a href="/downloads/proto_orange.png"><img loading="lazy" style="float:left;" src="/downloads/proto_orange.png" alt="Sample diffuse map texture" width="128"></a>
+<a href="/downloads/proto_gray_n.png"><img loading="lazy" style="padding-left: 20px; margin: 0px" src="/downloads/proto_gray_n.png" alt="Sample normal map texture" width="128"></a>
 
 Then upload them to your project by dragging the files into the Editor.
 

--- a/content/en/tutorials/collision-and-triggers.md
+++ b/content/en/tutorials/collision-and-triggers.md
@@ -51,7 +51,7 @@ For this demo, the important property is the **Type**. You can pick one of three
 
 The first Entity we need in this tutorial is the green block that forms the ground.
 
-<img loading="lazy" src="/images/tutorials/collision/ground_setup.png" width="300px">
+<img loading="lazy" src="/images/tutorials/collision/ground_setup.png" width="300">
 
 You can see in the attribute panel, that it has *render*, *collision* and *rigidbody* components. We've increased the Entity and the *collision* box properties so that it is nice and large. And we've also slightly increased the friction and restitution properties. This means that the surface is slightly rougher and slightly bouncier than the defaults.
 
@@ -98,7 +98,7 @@ In this case, when the trigger is fired, we reset the penetrating Entity back up
 
 We've set the ground to **Static**, now we'll create the falling objects and make sure they are **Dynamic**.
 
-<img loading="lazy" src="/images/tutorials/collision/box_setup.png" width="300px">
+<img loading="lazy" src="/images/tutorials/collision/box_setup.png" width="300">
 
 This is the *rigidbody* and *collision* setup for the box component, the sphere and capsule are setup in the same way.
 

--- a/content/en/tutorials/light-halos.md
+++ b/content/en/tutorials/light-halos.md
@@ -25,7 +25,7 @@ This texture will form the basis of the glow.
 
 ### Material
 
-<img loading="lazy" src="/images/tutorials/intermediate/light-halos/material.png" height="600px">
+<img loading="lazy" src="/images/tutorials/intermediate/light-halos/material.png" height="600">
 
 The material for the light halo uses the blob texture in the emissive slot. Use the **tint** property to set the color of your halo. We've also enabled blending in the Opacity slot and it also uses the blob texture with **Color Channel** set to **R**.
 

--- a/content/en/tutorials/real-time-multiplayer.md
+++ b/content/en/tutorials/real-time-multiplayer.md
@@ -98,11 +98,11 @@ This will log whatever data is sent to the server when `playerJoined` is emitted
 
 For this demo, we’re aiming to have players move around with others in real time, so we'll need to create an environment. Start by create an entity to use as a ground, and add a collision box and static rigidbody. Here is what the settings on the ground entity should look like:
 
-<img loading="lazy" src="/images/tutorials/multiplayer/ground_entity.png" width="360px">
+<img loading="lazy" src="/images/tutorials/multiplayer/ground_entity.png" width="360">
 
 Next we’ll need a player to control. Create a new capsule and call it `Player`. add a dynamic rigidbody and collision box, and change the rigid body settings to match the picture below.
 
-<img loading="lazy" src="/images/tutorials/multiplayer/player_entity.png" width="360px">
+<img loading="lazy" src="/images/tutorials/multiplayer/player_entity.png" width="360">
 
 Duplicate the player entity and rename it as 'Other'. Uncheck the `Enabled` box on this new entity so that it's disabled to begin with.  This is the entity we'll be using to simulate other players in the game.
 

--- a/content/en/tutorials/ui-elements-buttons.md
+++ b/content/en/tutorials/ui-elements-buttons.md
@@ -39,21 +39,21 @@ This is the easiest way to add a button to the scene as it creates the necessary
 
 If there is an existing Element that we would like to turn into a button, we can add Button component to it in the Inspector panel and configure it ourselves.
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/adding-button-via-inspector.gif" width="300px">
+<img loading="lazy" src="/images/tutorials/ui/buttons/adding-button-via-inspector.gif" width="300">
 
 Remember to enable Use Input on the Element component so the user can interact with it:
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/use-input-element.png" width="300px">
+<img loading="lazy" src="/images/tutorials/ui/buttons/use-input-element.png" width="300">
 
 And set the Image Entity property on the Button component to be same Entity that the Element component is on.
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/set-image-entity-button.png" width="300px">
+<img loading="lazy" src="/images/tutorials/ui/buttons/set-image-entity-button.png" width="300">
 
 ## Button setup
 
 Let's take a closer look at the first button in the example project:
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/button.png" width="300px">
+<img loading="lazy" src="/images/tutorials/ui/buttons/button.png" width="300">
 
 The button has 3 components:
 
@@ -63,19 +63,19 @@ The button has 3 components:
 
 The button Entity also has a Text Element as a child for showing text (this is optional depending on the style of your button).
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/text-element.png" width="300px">
+<img loading="lazy" src="/images/tutorials/ui/buttons/text-element.png" width="300">
 
 The Element's type is Image and it's anchored to the bottom of the screen.
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/bottom-anchor-pivot.png" width="300px">
+<img loading="lazy" src="/images/tutorials/ui/buttons/bottom-anchor-pivot.png" width="300">
 
 After anchoring the button we give it an offset from the bottom by simply moving it up.
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/offset-position.png" width="300px">
+<img loading="lazy" src="/images/tutorials/ui/buttons/offset-position.png" width="300">
 
 We also have Use Input enabled in order to interact with the button.
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/use-input-element.png" width="300px">
+<img loading="lazy" src="/images/tutorials/ui/buttons/use-input-element.png" width="300">
 
 ### Changing how the button looks on interaction
 
@@ -91,7 +91,7 @@ This can be done via two Transition Modes:
 
 Tinting the button color in each state is the easiest method to add some user feedback when they interact with it. In the project, the High Quality button has the following setup:
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/high-quality-button-setup.png" width="300px">
+<img loading="lazy" src="/images/tutorials/ui/buttons/high-quality-button-setup.png" width="300">
 
 With the following effect:
 
@@ -101,7 +101,7 @@ With the following effect:
 
 We can also change the sprite image of the button in the different states for cases where you may want the button to change shape or want to give a look of the button being 'pressed' into the screen. The Low Quality button has the following setup:
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/low-quality-button-setup.png" width="300px">
+<img loading="lazy" src="/images/tutorials/ui/buttons/low-quality-button-setup.png" width="300">
 
 With the following effect:
 
@@ -140,7 +140,7 @@ There are other events that can be listened to such as `mouseenter` and `mousele
 
 These events will only fire if Use Input is enabled on the Element component so make sure that has been ticked in the inspector.
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/use-input-element.png" width="300px">
+<img loading="lazy" src="/images/tutorials/ui/buttons/use-input-element.png" width="300">
 
 [1]: https://playcanvas.com/editor/scene/547900
 [2]: /user-manual/user-interface/elements/

--- a/content/en/tutorials/using-assets.md
+++ b/content/en/tutorials/using-assets.md
@@ -54,7 +54,7 @@ In this case we've declared three script attributes `a`, `b` and `c` which are a
 
 The **A** and **B** assets are marked as **preload** in this project. This means that during the loading screen, these assets are downloaded. They will be ready to use as soon as your application starts. When an asset is loaded, the loaded resource is available as `asset.resource` and we can assign the asset to the [render component asset property][8]. If `asset.loaded` is `false`, then the asset isn't loaded.
 
-<img loading="lazy" src="/images/tutorials/using_assets/using-assets-a-preload.png" width="360px">
+<img loading="lazy" src="/images/tutorials/using_assets/using-assets-a-preload.png" width="360">
 
 So, the `A` and `B` models are preloaded, which means we know they will be ready when we are running the application. This code checks if the space bar is pressed, and if so we change the render asset on the render component to be the resource property of the asset. In this case `asset.resource` will be a `pc.Render` object. For each different asset type (audio, texture, etc), the `asset.resource` property will be the relevant type.
 
@@ -79,7 +79,7 @@ if (app.keyboard.isPressed(pc.KEY_C)) {
 
 The **C** render asset is not marked as *preload*, so in the code above, you can see that we check if the resource is loaded before we use it. if `asset.loaded` is false, then the resource isn't loaded and we can't change the render component. If the **C** render asset is loaded then `this.c.resource` will be the `pc.Render` property and `asset.loaded` will be true, we'll be then able to assign it.
 
-<img loading="lazy" src="/images/tutorials/using_assets/using-assets-c-preload.png" width="360px">
+<img loading="lazy" src="/images/tutorials/using_assets/using-assets-c-preload.png" width="360">
 
 ```javascript
 if (this.app.keyboard.isPressed(pc.KEY_L)) {

--- a/content/en/user-manual/assets/import-pipeline/import-hierarchy.md
+++ b/content/en/user-manual/assets/import-pipeline/import-hierarchy.md
@@ -12,11 +12,11 @@ PlayCanvas supports importing models with their meshes as a hierarchy of entitie
 
 Open the 'Project Settings'
 
-<img loading="lazy" src="/images/user-manual/assets/import-pipeline/import-hierarchy/project-settings.png" width="480px">
+<img loading="lazy" src="/images/user-manual/assets/import-pipeline/import-hierarchy/project-settings.png" width="480">
 
 Scroll down to 'Asset Tasks' and enable 'Import Hierarchy':
 
-<img loading="lazy" src="/images/user-manual/assets/import-pipeline/import-hierarchy/asset-tasks.png" width="360px">
+<img loading="lazy" src="/images/user-manual/assets/import-pipeline/import-hierarchy/asset-tasks.png" width="360">
 
 ## Importing models
 

--- a/content/en/user-manual/assets/import-pipeline/index.md
+++ b/content/en/user-manual/assets/import-pipeline/index.md
@@ -16,7 +16,7 @@ When a source asset is uploaded that needs to be imported. PlayCanvas starts an 
 
 There are a variety of options available to tune the behavior of the import pipeline to suit your needs.
 
-<img loading="lazy" src="/images/user-manual/assets/import-pipeline/asset-tasks.png" width="360px">
+<img loading="lazy" src="/images/user-manual/assets/import-pipeline/asset-tasks.png" width="360">
 
 ### Search related assets
 

--- a/content/en/user-manual/packs/components/script.md
+++ b/content/en/user-manual/packs/components/script.md
@@ -10,7 +10,7 @@ The Script component can be enabled or disabled using the toggle in the top righ
 
 ![Script component][1]
 
-To create a new script, click on the <span class="font-icon" style="font-size: 18px">&#58468;</span> button in the Assets Panel and select New Script. Then type the name of the script in the popup and hit Enter.
+To create a new script, click on the <span class="font-icon" style="font-size: 18">&#58468;</span> button in the Assets Panel and select New Script. Then type the name of the script in the popup and hit Enter.
 
 <img loading="lazy" src="/images/user-manual/scenes/components/new-script.jpg">
 

--- a/content/en/user-manual/packs/index.md
+++ b/content/en/user-manual/packs/index.md
@@ -17,7 +17,7 @@ They are edited using the PlayCanvas Editor.
 
 The **Scene Hierarchy** is a graph of [Entities][entities] that can have [Components][components] to give these Entities behaviors such as having a mesh to render in the world or to play sound effects. They can also be given custom behavior with [scripts][scripts].
 
-<img loading="lazy" src="/images/user-manual/scenes/scene-hierarchy.png" width="400px">
+<img loading="lazy" src="/images/user-manual/scenes/scene-hierarchy.png" width="400">
 
 ## Scene Settings
 
@@ -34,7 +34,7 @@ The full list of Scene Settings are:
 * [Fog][settings-fog] (7)
 * [Lightmap properties][settings-lightmap] (8)
 
-<img loading="lazy" src="/images/user-manual/scenes/scene-settings.png" width="500px">
+<img loading="lazy" src="/images/user-manual/scenes/scene-settings.png" width="500">
 
 [entities]: /user-manual/packs/entities/
 [components]: /user-manual/packs/components/

--- a/content/en/user-manual/publishing/playable-ads/fb-playable-ads.md
+++ b/content/en/user-manual/publishing/playable-ads/fb-playable-ads.md
@@ -6,7 +6,7 @@ position: 1
 
 PlayCanvas supports the [Facebook Playable Ad][1] formats and requirements via an [official external tool on GitHub][2].
 
-<img loading="lazy" src="/images/user-manual/publishing/playable-ads/fb-playable-ads/bitmoji-creator.gif" width="185px" style="margin:0px 5px; display:inline;"> <img loading="lazy" src="/images/user-manual/publishing/playable-ads/fb-playable-ads/cube-jump.gif" width="185px" style="margin:0px 5px; display:inline;"> <img loading="lazy" src="/images/user-manual/publishing/playable-ads/fb-playable-ads/flappy-bird.gif" width="185px" style="margin:0px 5px; display:inline;">
+<img loading="lazy" src="/images/user-manual/publishing/playable-ads/fb-playable-ads/bitmoji-creator.gif" style="margin:0px 5px; display:inline;" width="185"> <img loading="lazy" src="/images/user-manual/publishing/playable-ads/fb-playable-ads/cube-jump.gif" style="margin:0px 5px; display:inline;" width="185"> <img loading="lazy" src="/images/user-manual/publishing/playable-ads/fb-playable-ads/flappy-bird.gif" style="margin:0px 5px; display:inline;" width="185">
 
 The tool can create both the single 2MB (uncompressed) HTML file and the 5MB (uncompressed) ZIP formats via the configuration options. Full specifications for Facebook Playable Ads can be found on their [help centre][3].
 

--- a/content/en/user-manual/publishing/playable-ads/ironsource-mraid-playable-ads.md
+++ b/content/en/user-manual/publishing/playable-ads/ironsource-mraid-playable-ads.md
@@ -42,7 +42,7 @@ ironSource have a fantastic test tool [here][ironsource-test-tool] which can be 
 
 Check that Testing mode and MRAID are both enabled on the page.
 
-<img loading="lazy" src="/images/user-manual/publishing/playable-ads/ironsource-playable-ads/ironsource-tool-options.png" width="600px">
+<img loading="lazy" src="/images/user-manual/publishing/playable-ads/ironsource-playable-ads/ironsource-tool-options.png" width="600">
 
 Set the following options in the `config.json` as shown below. This will produce a ZIP file with the asset data and PlayCanvas Engine code as separate files from the `index.html`.
 
@@ -71,7 +71,7 @@ We will need to serve the files from a HTTPS endpoint to test with the ironSourc
 
 Our recommended approach is to [host locally][host-locally] and use [ngrok][ngrok] to create a https tunnel to your computer that the app can access.
 
-<img loading="lazy" src="/images/user-manual/publishing/playable-ads/ironsource-playable-ads/ngrok.png" width="600px">
+<img loading="lazy" src="/images/user-manual/publishing/playable-ads/ironsource-playable-ads/ngrok.png" width="600">
 
 This will give a unique URL for the endpoint that we need to add to the `index.html` where it is referencing external files.
 
@@ -113,13 +113,13 @@ Test locally on your PC by double clicking on the `index.html` to ensure that it
 
 If it plays correctly on your PC, we can test on [ironSource's test tool][ironsource-test-tool] by copying the contents of `index.html` and pasting into MRAID tag area of the test tool.
 
-<img loading="lazy" src="/images/user-manual/publishing/playable-ads/ironsource-playable-ads/ironsource-tool-paste-mraid-tag.png" width="600px">
+<img loading="lazy" src="/images/user-manual/publishing/playable-ads/ironsource-playable-ads/ironsource-tool-paste-mraid-tag.png" width="600">
 
 Click on 'Test Ad' and once it renders, play the ad to reach a CTA button. After pressing the CTA button, the tool should show that all the tests have passed and give you an option to generate a code.
 
 This is used to test on device using their app that is available on both Android and iOS.
 
-<img loading="lazy" src="/images/user-manual/publishing/playable-ads/ironsource-playable-ads/ironsource-tool-generate-code.png" width="400px">
+<img loading="lazy" src="/images/user-manual/publishing/playable-ads/ironsource-playable-ads/ironsource-tool-generate-code.png" width="400">
 
 ### Final export for ironSource
 

--- a/content/en/user-manual/publishing/playable-ads/snapchat-playable-ads.md
+++ b/content/en/user-manual/publishing/playable-ads/snapchat-playable-ads.md
@@ -74,11 +74,11 @@ To test the ad on a device, we can use the Android app [Creative Preview][creati
 
 Our recommended approach is to [host locally][host-locally] and use [ngrok][ngrok] to create a https tunnel to your computer that the app can access.
 
-<img loading="lazy" src="/images/user-manual/publishing/playable-ads/snapchat-playable-ads/ngrok.png" width="600px">
+<img loading="lazy" src="/images/user-manual/publishing/playable-ads/snapchat-playable-ads/ngrok.png" width="600">
 
 Once this is setup, open Creative Preview app and create a new 'Display' ad with the following settings:
 
-<img loading="lazy" src="/images/user-manual/publishing/playable-ads/snapchat-playable-ads/creative-preview.png" width="300px">
+<img loading="lazy" src="/images/user-manual/publishing/playable-ads/snapchat-playable-ads/creative-preview.png" width="300">
 
 ### Export for Snapchat
 

--- a/content/en/user-manual/user-interface/safe-area.md
+++ b/content/en/user-manual/user-interface/safe-area.md
@@ -14,11 +14,11 @@ Developers will need to be mindful of any essential information that is needed f
 
 For example, the screenshot below looks fine on desktop in devtools mobile view.
 
-<img loading="lazy" src="/images/user-manual/user-interface/safe-area/desktop-view.png" width="500px">
+<img loading="lazy" src="/images/user-manual/user-interface/safe-area/desktop-view.png" width="500">
 
 However, when opened on a mobile device such as the iPhone X, the 'Left' text is rendered under the notch and the 'Bottom' text is rendered under the navigation bar.
 
-<img loading="lazy" src="/images/user-manual/user-interface/safe-area/mobile-view-render-under-notch.png" width="500px">
+<img loading="lazy" src="/images/user-manual/user-interface/safe-area/mobile-view-render-under-notch.png" width="500">
 
 ## Safe Area
 
@@ -26,25 +26,25 @@ To help developers, browsers on the these devices do support [environment variab
 
 We have a [project with a reusable script][safe-area-project] that takes those CSS values and applies them to an UI Group Element entity via resizing the margins.
 
-<img loading="lazy" src="/images/user-manual/user-interface/safe-area/mobile-view-safe-area.png" width="500px">
+<img loading="lazy" src="/images/user-manual/user-interface/safe-area/mobile-view-safe-area.png" width="500">
 
 The UI setup in the project has an Entity with a full screen Group Element named 'Safe Area'. This has the script 'mobileSafeArea' attached which contains the logic for fitting the Element within the safe area of the device.
 
-<img loading="lazy" src="/images/user-manual/user-interface/safe-area/hierarchy-layout.png" width="420px">
+<img loading="lazy" src="/images/user-manual/user-interface/safe-area/hierarchy-layout.png" width="420">
 
-<img loading="lazy" src="/images/user-manual/user-interface/safe-area/safe-area-entity-setup.png" width="420px">
+<img loading="lazy" src="/images/user-manual/user-interface/safe-area/safe-area-entity-setup.png" width="420">
 
 Any essential UI Elements can be placed as a child of the Safe Area Entity to be anchored relative to it.
 
-<img loading="lazy" src="/images/user-manual/user-interface/safe-area/hierarchy-essential-elements.png" width="420px">
+<img loading="lazy" src="/images/user-manual/user-interface/safe-area/hierarchy-essential-elements.png" width="420">
 
 To help with development, a debug setting can be enabled to simulate a safe area to preview what a UI layout would look like without needing a device.
 
-<img loading="lazy" src="/images/user-manual/user-interface/safe-area/debug-config.png" width="600px">
+<img loading="lazy" src="/images/user-manual/user-interface/safe-area/debug-config.png" width="600">
 
 The debug config can be edited with live updates in the launch tab too.
 
-<img loading="lazy" src="/images/user-manual/user-interface/safe-area/debug-config-runtime.gif" width="500px">
+<img loading="lazy" src="/images/user-manual/user-interface/safe-area/debug-config-runtime.gif" width="500">
 
 [env-mdn]: https://developer.mozilla.org/en-US/docs/Web/CSS/env()
 [safe-area-project]: https://playcanvas.com/project/828118/overview/mobile-ui-safe-areas


### PR DESCRIPTION
The `img` element `width` and `height` attributes should be integers _without_ `px`:

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width

I believe most (all?) browsers handle it OK anyway, but this PR rectifies the issue anyway.