### PR TITLE
Updated shader chunk migration for engine 1.65

### DIFF
--- a/content/en/user-manual/graphics/shader-chunk-migrations.md
+++ b/content/en/user-manual/graphics/shader-chunk-migrations.md
@@ -29,6 +29,89 @@ By doing this you will no longer see warning messages in the console.
 
 The following tables break down the chunk changes by Engine release.
 
+### *Engine v1.65*
+
+In 1.62, global variables used to pass the values between the front end back end chunks were grouped into structures LitShaderArguments, IridescenceArgs, ClearcoatArgs and SheenArgs. Those were causing multiple compatibility issues on Android devices, and so in 1.65, these are being converted back to global variables. For example `litShaderArgs.albedo` is now `litArgs_albedo`.
+
+These are the new global variables:
+
+```c
+// Surface albedo absorbance
+vec3 litArgs_albedo;
+
+// Transparency
+float litArgs_opacity;
+
+// Emission color
+vec3 litArgs_emission;
+
+// Normal direction in world space
+vec3 litArgs_worldNormal;
+
+// Ambient occlusion amount, range [0..1]
+float litArgs_ao;
+
+// Light map color
+vec3 litArgs_lightmap;
+
+// Light map direction
+vec3 litArgs_lightmapDir;
+
+// Surface metalness factor, range [0..1]
+float litArgs_metalness;
+
+// The f0 specularity factor
+vec3 litArgs_specularity;
+
+// Specularity intensity factor, range [0..1]
+float litArgs_specularityFactor;
+
+// The microfacet glossiness factor, range [0..1]
+float litArgs_gloss;
+
+// Glossiness of the sheen layer, range [0..1]
+float litArgs_sheen_gloss;
+
+// The color of the f0 specularity factor for the sheen layer
+vec3 litArgs_sheen_specularity;
+
+// Transmission factor (refraction), range [0..1]
+float litArgs_transmission;
+
+// Uniform thickness of medium, used by transmission, range [0..inf]
+float litArgs_thickness;
+
+// Index of refraction
+float litArgs_ior;
+
+// Iridescence effect intensity, range [0..1]
+float litArgs_iridescence_intensity;
+
+// Thickness of the iridescent microfilm layer, value is in nanometers, range [0..1000]
+float litArgs_iridescence_thickness;
+
+// The normal used for the clearcoat layer
+vec3 litArgs_clearcoat_worldNormal;
+
+// Intensity of the clearcoat layer, range [0..1]
+float litArgs_clearcoat_specularity;
+
+// Glossiness of clearcoat layer, range [0..1]
+float litArgs_clearcoat_gloss;
+```
+
+These are the chunk that had their signature changed to accept individual members, instead of the whole structures:
+- endPS
+- metalnessModulatePS
+- outputAlphaPS
+- outputAlphaPremulPS
+- fresnelSchlickPS
+- iridescenceDiffractionPS
+- lightmapAddPS
+- lightmapDirAddPS
+- refractionCubePS
+- refractionDynamicPS
+
 ### *Engine v1.62*
 
 In PlayCanvas, we have two sets of shader chunks, one set we refer to as the shader frontend, which provide values for the arguments passed to our lighting algorithm, also called the shader backend. 


### PR DESCRIPTION
Based on https://github.com/playcanvas/engine/pull/5463 and https://github.com/playcanvas/engine/pull/5564

<img width="738" alt="Screenshot 2023-08-15 at 15 27 04" src="https://github.com/playcanvas/developer.playcanvas.com/assets/59932779/be0867a2-b432-422c-a123-521f495880fa">
<img width="739" alt="Screenshot 2023-08-15 at 15 27 19" src="https://github.com/playcanvas/developer.playcanvas.com/assets/59932779/e729e3d0-80a3-4324-a454-0fec9e218af2">
