### PR TITLE
Update tutorial plugin for metalsmith

### DIFF
--- a/lib/tutorials/index.mjs
+++ b/lib/tutorials/index.mjs
@@ -152,7 +152,7 @@ export default function makePlugin(dir) {
 
                         tutorialsIndex[lang][filepath] = {
                             title: file.title,
-                            url: url.replace(lang, '').replace('index.html', ''),
+                            url: url.replace(lang, '').replace('index.html', '').replace('.html', '/'),
                             tags: file.tags,
                             thumbUrl: file.thumb
                         };


### PR DESCRIPTION
Fixes issue introduced with #522 which generated the wrong URL's in the tutorial cloud page.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
