### PR TITLE
fix(build): duplicate nav menu on tutorial pages

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -137,10 +137,6 @@ Metalsmith(__dirname)
         renderer: renderer
     }))
     .use(contents())
-    .use(tutorials('tutorials')())
-    .use(permalinks({
-        duplicates: 'error'
-    }))
     .use(i18n()({
         locales: [{
             file: 'content/ja/messages.json', locale: 'ja'
@@ -162,6 +158,10 @@ Metalsmith(__dirname)
         template: path.join(__dirname, 'layouts/partials/navigation.hbs'),
         contentPath: 'content/_shadereditor_contents.json',
         partialName: 'shader-editor-navigation'
+    }))
+    .use(tutorials('tutorials')())
+    .use(permalinks({
+        duplicates: 'error'
     }))
     .use(layouts({
         pattern: '**/*.html'


### PR DESCRIPTION
fix issue introduced in #522

The ordering of the plugins requires localization to run before tutorials.  Without it, both the english and localised nav menus are displayed in demo pages.

Aside from an updated billing email, this now produces an identical set of build files compared to those generated prior to updating plugins.  Confirmed with WinMerge.

Fixes duplicate nav menu on tutorial pages.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
