### PR TITLE
Close void elements

### DIFF
--- a/.htmlvalidate.json
+++ b/.htmlvalidate.json
@@ -2,6 +2,7 @@
     "extends": ["html-validate:recommended"],
     "rules": {
         "no-inline-style": "off",
+        "void-style": "off",
         "wcag/h37": "off"
     }
 }

--- a/content/en/shader-editor/window-layout/graph-editor.md
+++ b/content/en/shader-editor/window-layout/graph-editor.md
@@ -10,7 +10,7 @@ The Graph Editor displays the currently selected graph. This is where nodes are 
 
 | How To | |
 |---|---|
-| Create a node | Drag an entry from the [Nodes Pane][2] and drop it on the Graph Editor work area.<br>Drag a sub-graph from the [Assets Pane][3] onto the Graph Editor work area. |
+| Create a node | Drag an entry from the [Nodes Pane][2] and drop it on the Graph Editor work area.<br />Drag a sub-graph from the [Assets Pane][3] onto the Graph Editor work area. |
 | Select a node | Left click the node. |
 | Delete a node | Select the node and either press delete key or use the node context menu 'Delete' option. |
 | Move a node | Left click and drag the node. |

--- a/content/en/shader-editor/window-layout/info-pane.md
+++ b/content/en/shader-editor/window-layout/info-pane.md
@@ -4,7 +4,7 @@ layout: shader-editor-page.hbs
 position: 1
 ---
 
-<img loading="lazy" src="/images/shader-editor/info-pane.png" style="float: right; padding: 20px; padding-top: 0px; border: 1px black;">
+<img loading="lazy" src="/images/shader-editor/info-pane.png" style="float: right; padding: 20px; padding-top: 0px; border: 1px black;" />
 
 The Info Pane shows helpful information for the UI element currently under the mouse cursor.
 

--- a/content/en/shader-editor/window-layout/inspector-pane/graph-inspector.md
+++ b/content/en/shader-editor/window-layout/inspector-pane/graph-inspector.md
@@ -4,7 +4,7 @@ layout: shader-editor-page.hbs
 position: 1
 ---
 
-<img loading="lazy" src="/images/shader-editor/inspector-pane-graph.png" style="float: right; padding: 20px; padding-top: 0px;">
+<img loading="lazy" src="/images/shader-editor/inspector-pane-graph.png" style="float: right; padding: 20px; padding-top: 0px;" />
 
 The Graph Inspector is where a graph's settings are configured.
 

--- a/content/en/shader-editor/window-layout/inspector-pane/material-inspector.md
+++ b/content/en/shader-editor/window-layout/inspector-pane/material-inspector.md
@@ -4,7 +4,7 @@ layout: shader-editor-page.hbs
 position: 3
 ---
 
-<img loading="lazy" src="/images/shader-editor/inspector-pane-material.png" style="float: right; padding: 20px; padding-top: 0px;">
+<img loading="lazy" src="/images/shader-editor/inspector-pane-material.png" style="float: right; padding: 20px; padding-top: 0px;" />
 
 The Material Inspector is where a material's settings are configured.
 

--- a/content/en/shader-editor/window-layout/inspector-pane/node-inspector.md
+++ b/content/en/shader-editor/window-layout/inspector-pane/node-inspector.md
@@ -4,7 +4,7 @@ layout: shader-editor-page.hbs
 position: 2
 ---
 
-<img loading="lazy" src="/images/shader-editor/inspector-pane-node.png" style="float: right; padding: 20px; padding-top: 0px;">
+<img loading="lazy" src="/images/shader-editor/inspector-pane-node.png" style="float: right; padding: 20px; padding-top: 0px;" />
 
 The Node Inspector is where a node's settings are configured.
 

--- a/content/en/shader-editor/window-layout/inspector-pane/texture-inspector.md
+++ b/content/en/shader-editor/window-layout/inspector-pane/texture-inspector.md
@@ -4,7 +4,7 @@ layout: shader-editor-page.hbs
 position: 4
 ---
 
-<img loading="lazy" src="/images/shader-editor/inspector-pane-texture.png" style="float: right; padding: 20px; padding-top: 0px;">
+<img loading="lazy" src="/images/shader-editor/inspector-pane-texture.png" style="float: right; padding: 20px; padding-top: 0px;" />
 
 The Texture Inspector is where textures are configured.
 

--- a/content/en/shader-editor/window-layout/nodes-pane.md
+++ b/content/en/shader-editor/window-layout/nodes-pane.md
@@ -4,7 +4,7 @@ layout: shader-editor-page.hbs
 position: 2
 ---
 
-<img loading="lazy" src="/images/shader-editor/nodes-pane.png" style="float: right; padding: 20px; padding-top: 0px;">
+<img loading="lazy" src="/images/shader-editor/nodes-pane.png" style="float: right; padding: 20px; padding-top: 0px;" />
 
 The Nodes Pane lists the built-in nodes available for constructing graphs. Nodes are grouped into sub-sections by category.
 

--- a/content/en/tutorials/Using-forces-on-rigid-bodies.md
+++ b/content/en/tutorials/Using-forces-on-rigid-bodies.md
@@ -71,7 +71,7 @@ We set up a basic scene with a spotlight, a cube (entity with model, rigidbody, 
 
 Some Editor settings were set to prevent the constant application of unbalanced forces (and so prevent a body from continuously accelerating and moving out of control). We enabled angular damping on the cube's attribute editor as well as friction on both the cube and floor. Linear damping is not used here, however it can be used to simulate air resistance, and of course decelerations can be applied as required via code.
 
-<img loading="lazy" src="/images/tutorials/forces/rigidbody_settings.jpg" alt="rigidbody_settings">
+<img loading="lazy" src="/images/tutorials/forces/rigidbody_settings.jpg" alt="rigidbody_settings" />
 
 ## Teleporting a Body
 

--- a/content/en/tutorials/basic-materials.md
+++ b/content/en/tutorials/basic-materials.md
@@ -45,8 +45,8 @@ Changing the color of the material is a good start, but you'll quickly want more
 
 Download & save these sample textures:
 
-<a href="/downloads/proto_orange.png"><img loading="lazy" style="float:left;" src="/downloads/proto_orange.png" alt="Sample diffuse map texture" width="128"></a>
-<a href="/downloads/proto_gray_n.png"><img loading="lazy" style="padding-left: 20px; margin: 0px" src="/downloads/proto_gray_n.png" alt="Sample normal map texture" width="128"></a>
+<a href="/downloads/proto_orange.png"><img loading="lazy" style="float:left;" src="/downloads/proto_orange.png" alt="Sample diffuse map texture" width="128" /></a>
+<a href="/downloads/proto_gray_n.png"><img loading="lazy" style="padding-left: 20px; margin: 0px" src="/downloads/proto_gray_n.png" alt="Sample normal map texture" width="128" /></a>
 
 Then upload them to your project by dragging the files into the Editor.
 

--- a/content/en/tutorials/collision-and-triggers.md
+++ b/content/en/tutorials/collision-and-triggers.md
@@ -51,7 +51,7 @@ For this demo, the important property is the **Type**. You can pick one of three
 
 The first Entity we need in this tutorial is the green block that forms the ground.
 
-<img loading="lazy" src="/images/tutorials/collision/ground_setup.png" width="300">
+<img loading="lazy" src="/images/tutorials/collision/ground_setup.png" width="300" />
 
 You can see in the attribute panel, that it has *render*, *collision* and *rigidbody* components. We've increased the Entity and the *collision* box properties so that it is nice and large. And we've also slightly increased the friction and restitution properties. This means that the surface is slightly rougher and slightly bouncier than the defaults.
 
@@ -98,7 +98,7 @@ In this case, when the trigger is fired, we reset the penetrating Entity back up
 
 We've set the ground to **Static**, now we'll create the falling objects and make sure they are **Dynamic**.
 
-<img loading="lazy" src="/images/tutorials/collision/box_setup.png" width="300">
+<img loading="lazy" src="/images/tutorials/collision/box_setup.png" width="300" />
 
 This is the *rigidbody* and *collision* setup for the box component, the sphere and capsule are setup in the same way.
 

--- a/content/en/tutorials/light-halos.md
+++ b/content/en/tutorials/light-halos.md
@@ -25,7 +25,7 @@ This texture will form the basis of the glow.
 
 ### Material
 
-<img loading="lazy" src="/images/tutorials/intermediate/light-halos/material.png" height="600">
+<img loading="lazy" src="/images/tutorials/intermediate/light-halos/material.png" height="600" />
 
 The material for the light halo uses the blob texture in the emissive slot. Use the **tint** property to set the color of your halo. We've also enabled blending in the Opacity slot and it also uses the blob texture with **Color Channel** set to **R**.
 

--- a/content/en/tutorials/manipulating-entities.md
+++ b/content/en/tutorials/manipulating-entities.md
@@ -17,8 +17,8 @@ One of the most common operations you will need to perform on Entities is to cha
 
 An important part of understanding how to move and manipulate Entities is understanding local and world co-ordinate systems. The world co-ordinate systems is shared by all Entities, it has a fixed origin `(0,0,0)` and a fixed orientation - where `(0,1,0)` is up. The local co-ordinate system relative to the Entity itself. So the local origin is the Entity position, and the orientation follows the orientation of the Entity.
 
-<img loading="lazy" src="/images/tutorials/world.jpg" style="float:left;" alt="World co-ordinates">
-<img loading="lazy" src="/images/tutorials/local.jpg" style="float:right;" alt="Local co-ordinates">
+<img loading="lazy" src="/images/tutorials/world.jpg" style="float:left;" alt="World co-ordinates" />
+<img loading="lazy" src="/images/tutorials/local.jpg" style="float:right;" alt="Local co-ordinates" />
 <div style="clear:both"></div>
 
 *World and Local co-ordinate systems*

--- a/content/en/tutorials/real-time-multiplayer.md
+++ b/content/en/tutorials/real-time-multiplayer.md
@@ -98,11 +98,11 @@ This will log whatever data is sent to the server when `playerJoined` is emitted
 
 For this demo, we’re aiming to have players move around with others in real time, so we'll need to create an environment. Start by create an entity to use as a ground, and add a collision box and static rigidbody. Here is what the settings on the ground entity should look like:
 
-<img loading="lazy" src="/images/tutorials/multiplayer/ground_entity.png" width="360">
+<img loading="lazy" src="/images/tutorials/multiplayer/ground_entity.png" width="360" />
 
 Next we’ll need a player to control. Create a new capsule and call it `Player`. add a dynamic rigidbody and collision box, and change the rigid body settings to match the picture below.
 
-<img loading="lazy" src="/images/tutorials/multiplayer/player_entity.png" width="360">
+<img loading="lazy" src="/images/tutorials/multiplayer/player_entity.png" width="360" />
 
 Duplicate the player entity and rename it as 'Other'. Uncheck the `Enabled` box on this new entity so that it's disabled to begin with.  This is the entity we'll be using to simulate other players in the game.
 

--- a/content/en/tutorials/ui-elements-buttons.md
+++ b/content/en/tutorials/ui-elements-buttons.md
@@ -33,27 +33,27 @@ There are two ways to add a button to the scene.
 
 This is the easiest way to add a button to the scene as it creates the necessary entities, components and preconfigures the properties.
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/adding-button-via-hierarchy.gif">
+<img loading="lazy" src="/images/tutorials/ui/buttons/adding-button-via-hierarchy.gif" />
 
 ### With an existing Element
 
 If there is an existing Element that we would like to turn into a button, we can add Button component to it in the Inspector panel and configure it ourselves.
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/adding-button-via-inspector.gif" width="300">
+<img loading="lazy" src="/images/tutorials/ui/buttons/adding-button-via-inspector.gif" width="300" />
 
 Remember to enable Use Input on the Element component so the user can interact with it:
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/use-input-element.png" width="300">
+<img loading="lazy" src="/images/tutorials/ui/buttons/use-input-element.png" width="300" />
 
 And set the Image Entity property on the Button component to be same Entity that the Element component is on.
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/set-image-entity-button.png" width="300">
+<img loading="lazy" src="/images/tutorials/ui/buttons/set-image-entity-button.png" width="300" />
 
 ## Button setup
 
 Let's take a closer look at the first button in the example project:
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/button.png" width="300">
+<img loading="lazy" src="/images/tutorials/ui/buttons/button.png" width="300" />
 
 The button has 3 components:
 
@@ -63,19 +63,19 @@ The button has 3 components:
 
 The button Entity also has a Text Element as a child for showing text (this is optional depending on the style of your button).
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/text-element.png" width="300">
+<img loading="lazy" src="/images/tutorials/ui/buttons/text-element.png" width="300" />
 
 The Element's type is Image and it's anchored to the bottom of the screen.
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/bottom-anchor-pivot.png" width="300">
+<img loading="lazy" src="/images/tutorials/ui/buttons/bottom-anchor-pivot.png" width="300" />
 
 After anchoring the button we give it an offset from the bottom by simply moving it up.
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/offset-position.png" width="300">
+<img loading="lazy" src="/images/tutorials/ui/buttons/offset-position.png" width="300" />
 
 We also have Use Input enabled in order to interact with the button.
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/use-input-element.png" width="300">
+<img loading="lazy" src="/images/tutorials/ui/buttons/use-input-element.png" width="300" />
 
 ### Changing how the button looks on interaction
 
@@ -91,21 +91,21 @@ This can be done via two Transition Modes:
 
 Tinting the button color in each state is the easiest method to add some user feedback when they interact with it. In the project, the High Quality button has the following setup:
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/high-quality-button-setup.png" width="300">
+<img loading="lazy" src="/images/tutorials/ui/buttons/high-quality-button-setup.png" width="300" />
 
 With the following effect:
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/high-quality-button-effect.gif">
+<img loading="lazy" src="/images/tutorials/ui/buttons/high-quality-button-effect.gif" />
 
 #### Changing the Sprite
 
 We can also change the sprite image of the button in the different states for cases where you may want the button to change shape or want to give a look of the button being 'pressed' into the screen. The Low Quality button has the following setup:
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/low-quality-button-setup.png" width="300">
+<img loading="lazy" src="/images/tutorials/ui/buttons/low-quality-button-setup.png" width="300" />
 
 With the following effect:
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/low-quality-button-effect.gif">
+<img loading="lazy" src="/images/tutorials/ui/buttons/low-quality-button-effect.gif" />
 
 ### Button events
 
@@ -140,7 +140,7 @@ There are other events that can be listened to such as `mouseenter` and `mousele
 
 These events will only fire if Use Input is enabled on the Element component so make sure that has been ticked in the inspector.
 
-<img loading="lazy" src="/images/tutorials/ui/buttons/use-input-element.png" width="300">
+<img loading="lazy" src="/images/tutorials/ui/buttons/use-input-element.png" width="300" />
 
 [1]: https://playcanvas.com/editor/scene/547900
 [2]: /user-manual/user-interface/elements/

--- a/content/en/tutorials/using-assets.md
+++ b/content/en/tutorials/using-assets.md
@@ -54,7 +54,7 @@ In this case we've declared three script attributes `a`, `b` and `c` which are a
 
 The **A** and **B** assets are marked as **preload** in this project. This means that during the loading screen, these assets are downloaded. They will be ready to use as soon as your application starts. When an asset is loaded, the loaded resource is available as `asset.resource` and we can assign the asset to the [render component asset property][8]. If `asset.loaded` is `false`, then the asset isn't loaded.
 
-<img loading="lazy" src="/images/tutorials/using_assets/using-assets-a-preload.png" width="360">
+<img loading="lazy" src="/images/tutorials/using_assets/using-assets-a-preload.png" width="360" />
 
 So, the `A` and `B` models are preloaded, which means we know they will be ready when we are running the application. This code checks if the space bar is pressed, and if so we change the render asset on the render component to be the resource property of the asset. In this case `asset.resource` will be a `pc.Render` object. For each different asset type (audio, texture, etc), the `asset.resource` property will be the relevant type.
 
@@ -79,7 +79,7 @@ if (app.keyboard.isPressed(pc.KEY_C)) {
 
 The **C** render asset is not marked as *preload*, so in the code above, you can see that we check if the resource is loaded before we use it. if `asset.loaded` is false, then the resource isn't loaded and we can't change the render component. If the **C** render asset is loaded then `this.c.resource` will be the `pc.Render` property and `asset.loaded` will be true, we'll be then able to assign it.
 
-<img loading="lazy" src="/images/tutorials/using_assets/using-assets-c-preload.png" width="360">
+<img loading="lazy" src="/images/tutorials/using_assets/using-assets-c-preload.png" width="360" />
 
 ```javascript
 if (this.app.keyboard.isPressed(pc.KEY_L)) {

--- a/content/en/user-manual/assets/import-pipeline/import-hierarchy.md
+++ b/content/en/user-manual/assets/import-pipeline/import-hierarchy.md
@@ -16,11 +16,11 @@ PlayCanvas supports importing models with their meshes as a hierarchy of entitie
 
 Open the 'Project Settings'
 
-<img loading="lazy" src="/images/user-manual/assets/import-pipeline/import-hierarchy/project-settings.png" width="480">
+<img loading="lazy" src="/images/user-manual/assets/import-pipeline/import-hierarchy/project-settings.png" width="480" />
 
 Scroll down to 'Asset Tasks' and enable 'Import Hierarchy':
 
-<img loading="lazy" src="/images/user-manual/assets/import-pipeline/import-hierarchy/asset-tasks.png" width="360">
+<img loading="lazy" src="/images/user-manual/assets/import-pipeline/import-hierarchy/asset-tasks.png" width="360" />
 
 ## Importing models
 

--- a/content/en/user-manual/assets/import-pipeline/index.md
+++ b/content/en/user-manual/assets/import-pipeline/index.md
@@ -14,7 +14,7 @@ When a source asset is uploaded, PlayCanvas starts an Asset Task to perform this
 
 There are a variety of options available to tune the behavior of the import pipeline to suit your needs.
 
-<img loading="lazy" src="/images/user-manual/assets/import-pipeline/asset-tasks.png" width="480">
+<img loading="lazy" src="/images/user-manual/assets/import-pipeline/asset-tasks.png" width="480" />
 
 ### Search related assets
 
@@ -79,7 +79,7 @@ Only available if using [Convert to GLB](#convert-to-glb) option. Setting this t
 
 If using Draco compression, remember to import the Draco WASM module into the project otherwise the models will not load.
 
-<img loading="lazy" src="/images/user-manual/assets/import-pipeline/draco-import-button.png" width="480">
+<img loading="lazy" src="/images/user-manual/assets/import-pipeline/draco-import-button.png" width="480" />
 
 ### Create FBX Folder
 

--- a/content/en/user-manual/assets/importing.md
+++ b/content/en/user-manual/assets/importing.md
@@ -30,14 +30,14 @@ For projects created prior to this date, they will still create JSON assets by d
 
 If you would like to migrate assets to the GLB format, please go to 'Project Settings'.
 
-<img loading="lazy" src="/images/user-manual/assets/importing/project-settings.png" alt="Project settings" width="300">
+<img loading="lazy" src="/images/user-manual/assets/importing/project-settings.png" alt="Project settings" width="300" />
 
 Open 'Asset Tasks' and tick 'Convert to GLB'.
 
-<img loading="lazy" src="/images/user-manual/assets/importing/asset-tasks.png" alt="Asset tasks settings" width="400">
+<img loading="lazy" src="/images/user-manual/assets/importing/asset-tasks.png" alt="Asset tasks settings" width="400" />
 
 And finally reimport the model and/or animation file (via drag and drop or the 'Upload' menu option) to create the GLB asset.
 
-<img loading="lazy" src="/images/user-manual/assets/importing/drag-and-drop.gif" alt="Drag and drop file">
+<img loading="lazy" src="/images/user-manual/assets/importing/drag-and-drop.gif" alt="Drag and drop file" />
 
 Once created, this can be referenced to Entities in place of the existing JSON asset.

--- a/content/en/user-manual/assets/materials/index.md
+++ b/content/en/user-manual/assets/materials/index.md
@@ -18,13 +18,13 @@ Materials are imported automatically when you upload a 3D model (e.g. FBX or COL
 
 You can create new materials directly from the PlayCanvas Editor interface.
 
-<img loading="lazy" src="/images/user-manual/assets/materials/create-asset-menu.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/assets/materials/create-asset-menu.jpg" width="300" />
 
 This creates a new material Asset and opens up the material inspector on the right-hand side of the screen.
 
 ## Selecting a Material
 
-<img loading="lazy" src="/images/user-manual/assets/materials/model-inspector-simple.jpg" style="width: 300px; float:right; padding: 20px; padding-top: 0px;">
+<img loading="lazy" src="/images/user-manual/assets/materials/model-inspector-simple.jpg" style="width: 300px; float:right; padding: 20px; padding-top: 0px;" />
 
 In order to edit a material, first you must select it. This will bring up the material inspector.
 
@@ -34,39 +34,39 @@ Generally, clicking on a material preview icon will take you to the material ins
 
 ## Assigning Materials
 
-<img loading="lazy" src="/images/user-manual/assets/materials/model.png" style="width: 300px; float: right; padding: 20px; padding-top: 0px;">
+<img loading="lazy" src="/images/user-manual/assets/materials/model.png" style="width: 300px; float: right; padding: 20px; padding-top: 0px;" />
 
 You can modify which materials are assigned to where on a model asset or you can customize the materials of a particular Entity that has a model component.
 
 When you select an Entity with a model component you will see two buttons - Asset Materials and Entity Materials.
 
-<br style="clear:both;">
+<br style="clear:both;" />
 
-<img loading="lazy" src="/images/user-manual/assets/materials/model-inspector-free-slot.jpg" style="width: 300px; float: right; padding: 20px; padding-top: 0px;">
+<img loading="lazy" src="/images/user-manual/assets/materials/model-inspector-free-slot.jpg" style="width: 300px; float: right; padding: 20px; padding-top: 0px;" />
 
 Clicking on Asset Materials will select the model asset. You can also select the model asset from the asset panel. The model inspector will show the meshes of model and which material is assigned to each. You can clear a material using the X button, and click the empty slot to assign a new material.
 
 You can also drag and drop material Assets from the asset panel onto the material slot.
 
-<br style="clear:both;">
+<br style="clear:both;" />
 
 Clicking on Entity Materials will first ask you to select the mesh instance for which you want to customize the material:
 
-<img loading="lazy" src="/images/user-manual/assets/materials/select.png" style="max-width: 100%">
+<img loading="lazy" src="/images/user-manual/assets/materials/select.png" style="max-width: 100%" />
 
 After selecting the mesh instance a new material picker will appear in the model component:
 
-<img loading="lazy" src="/images/user-manual/assets/materials/selected.png" style="max-width: 100%">
+<img loading="lazy" src="/images/user-manual/assets/materials/selected.png" style="max-width: 100%" />
 
 Then you can select a different material for this particular Entity:
 
-<img loading="lazy" src="/images/user-manual/assets/materials/overridden.png" style="max-width: 100%">
+<img loading="lazy" src="/images/user-manual/assets/materials/overridden.png" style="max-width: 100%" />
 
-<br style="clear:both;">
+<br style="clear:both;" />
 
 ## Editing a Material
 
-<img loading="lazy" src="/images/user-manual/assets/materials/material-inspector.jpg" style="width: 300px; float: right; padding: 20px; padding-top: 0px;">
+<img loading="lazy" src="/images/user-manual/assets/materials/material-inspector.jpg" style="width: 300px; float: right; padding: 20px; padding-top: 0px;" />
 
 Once you have a material selected you can edit its properties.
 
@@ -86,7 +86,7 @@ The phong shading model is our legacy shading model. Use this for compatibility 
 
 ## Material Maps
 
-<img loading="lazy" src="/images/user-manual/assets/materials/material-map-slot.jpg" style="width: 300px; float: right; padding: 20px; padding-top: 0px;">
+<img loading="lazy" src="/images/user-manual/assets/materials/material-map-slot.jpg" style="width: 300px; float: right; padding: 20px; padding-top: 0px;" />
 
 Much of editing a material involves creating and assigning textures maps to the various slots detailed on the pages above.
 

--- a/content/en/user-manual/assets/materials/phong-material.md
+++ b/content/en/user-manual/assets/materials/phong-material.md
@@ -8,7 +8,7 @@ The Phong Material is our legacy shading model. We recommend you use the Physica
 
 ### Offset & Tiling
 
-<img loading="lazy" src="/images/user-manual/material-inspector/offset-tiling.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/offset-tiling.jpg" width="300" />
 
 | Property          | Description |
 |-------------------|-------------|
@@ -20,7 +20,7 @@ The Phong Material is our legacy shading model. We recommend you use the Physica
 
 Ambient properties determine how the material appears in ambient light.
 
-<img loading="lazy" src="/images/user-manual/material-inspector/ambient.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/ambient.jpg" width="300" />
 
 | Property   | Description |
 |------------|-------------|
@@ -32,7 +32,7 @@ Ambient properties determine how the material appears in ambient light.
 
 Diffuse properties define the how a material reflects diffuse light emitted by dynamic light sources in the scene.
 
-<img loading="lazy" src="/images/user-manual/material-inspector/diffuse.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/diffuse.jpg" width="300" />
 
 | Property   | Description |
 |------------|-------------|
@@ -44,7 +44,7 @@ Diffuse properties define the how a material reflects diffuse light emitted by d
 
 Specular properties defines the color of the specular highlights. i.e. the shininess
 
-<img loading="lazy" src="/images/user-manual/material-inspector/specular.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/specular.jpg" width="300" />
 
 | Property     | Description |
 |--------------|-------------|
@@ -58,7 +58,7 @@ Specular properties defines the color of the specular highlights. i.e. the shini
 
 Emissive properties control how the material emits light (as opposed to reflecting light).
 
-<img loading="lazy" src="/images/user-manual/material-inspector/emissive.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/emissive.jpg" width="300" />
 
 | Property   | Description |
 |------------|-------------|
@@ -71,7 +71,7 @@ Emissive properties control how the material emits light (as opposed to reflecti
 
 Opacity sets the transparency level.
 
-<img loading="lazy" src="/images/user-manual/material-inspector/opacity.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/opacity.jpg" width="300" />
 
 | Property   | Description |
 |------------|-------------|
@@ -82,7 +82,7 @@ Opacity sets the transparency level.
 
 Use this to specify normal maps (these determine bumpiness - note you have to use normal maps in PlayCanvas, not height maps).
 
-<img loading="lazy" src="/images/user-manual/material-inspector/normals.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/normals.jpg" width="300" />
 
 | Property   | Description |
 |------------|-------------|
@@ -93,7 +93,7 @@ Use this to specify normal maps (these determine bumpiness - note you have to us
 
 A parallax map gives further realism to a normal map by giving the illusion of depth to a surface. Note that parallax options are only enabled if you have set a normal map on the material.
 
-<img loading="lazy" src="/images/user-manual/material-inspector/parallax.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/parallax.jpg" width="300" />
 
 | Property    | Description |
 |-------------|-------------|
@@ -104,7 +104,7 @@ A parallax map gives further realism to a normal map by giving the illusion of d
 
 Environment properties determine how a material reflects the environment.
 
-<img loading="lazy" src="/images/user-manual/material-inspector/environment.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/environment.jpg" width="300" />
 
 | Property            | Description |
 |---------------------|-------------|
@@ -118,7 +118,7 @@ Environment properties determine how a material reflects the environment.
 
 Light maps contain pre-baked diffuse lighting. Using light maps is considered an optimization in that runtime dynamic lighting calculations can be pre-calculated.
 
-<img loading="lazy" src="/images/user-manual/material-inspector/lightmap.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/lightmap.jpg" width="300" />
 
 | Property   | Description |
 |------------|-------------|
@@ -128,7 +128,7 @@ Light maps contain pre-baked diffuse lighting. Using light maps is considered an
 
 Other Render States gives additional controls over how a mesh is rendered with the specified material.
 
-<img loading="lazy" src="/images/user-manual/material-inspector/other.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/other.jpg" width="300" />
 
 | Property        | Description |
 |-----------------|-------------|

--- a/content/en/user-manual/assets/materials/physical-material.md
+++ b/content/en/user-manual/assets/materials/physical-material.md
@@ -8,7 +8,7 @@ The Physical Material represents the most advanced and highest quality shading m
 
 ### Offset & Tiling
 
-<img loading="lazy" src="/images/user-manual/material-inspector/offset-tiling.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/offset-tiling.jpg" width="300" />
 
 | Property          | Description |
 |-------------------|-------------|
@@ -20,7 +20,7 @@ The Physical Material represents the most advanced and highest quality shading m
 
 Ambient properties determine how the material appears in ambient light.
 
-<img loading="lazy" src="/images/user-manual/material-inspector/ambient.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/ambient.jpg" width="300" />
 
 | Property   | Description |
 |------------|-------------|
@@ -32,7 +32,7 @@ Ambient properties determine how the material appears in ambient light.
 
 Diffuse properties define the how a material reflects diffuse light emitted by dynamic light sources in the scene.
 
-<img loading="lazy" src="/images/user-manual/material-inspector/diffuse.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/diffuse.jpg" width="300" />
 
 | Property   | Description |
 |------------|-------------|
@@ -44,7 +44,7 @@ Diffuse properties define the how a material reflects diffuse light emitted by d
 
 Specular properties defines the color of the specular highlights. i.e. the shininess
 
-<img loading="lazy" src="/images/user-manual/material-inspector/specular.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/specular.jpg" width="300" />
 
 | Property      | Description |
 |---------------|-------------|
@@ -60,7 +60,7 @@ Specular properties defines the color of the specular highlights. i.e. the shini
 
 Emissive properties control how the material emits light (as opposed to reflecting light).
 
-<img loading="lazy" src="/images/user-manual/material-inspector/emissive.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/emissive.jpg" width="300" />
 
 | Property   | Description |
 |------------|-------------|
@@ -73,7 +73,7 @@ Emissive properties control how the material emits light (as opposed to reflecti
 
 Opacity sets the transparency level.
 
-<img loading="lazy" src="/images/user-manual/material-inspector/opacity.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/opacity.jpg" width="300" />
 
 | Property   | Description |
 |------------|-------------|
@@ -84,7 +84,7 @@ Opacity sets the transparency level.
 
 Use this to specify normal maps (these determine bumpiness - note you have to use normal maps in PlayCanvas, not height maps).
 
-<img loading="lazy" src="/images/user-manual/material-inspector/normals.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/normals.jpg" width="300" />
 
 | Property   | Description |
 |------------|-------------|
@@ -95,7 +95,7 @@ Use this to specify normal maps (these determine bumpiness - note you have to us
 
 A parallax map gives further realism to a normal map by giving the illusion of depth to a surface. Note that parallax options are only enabled if you have set a normal map on the material.
 
-<img loading="lazy" src="/images/user-manual/material-inspector/parallax.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/parallax.jpg" width="300" />
 
 | Property    | Description |
 |-------------|-------------|
@@ -106,7 +106,7 @@ A parallax map gives further realism to a normal map by giving the illusion of d
 
 Environment properties determine how a material reflects the environment.
 
-<img loading="lazy" src="/images/user-manual/material-inspector/environment.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/environment.jpg" width="300" />
 
 | Property            | Description |
 |---------------------|-------------|
@@ -120,7 +120,7 @@ Environment properties determine how a material reflects the environment.
 
 Light maps contain pre-baked diffuse lighting. Using light maps is considered an optimization in that runtime dynamic lighting calculations can be pre-calculated.
 
-<img loading="lazy" src="/images/user-manual/material-inspector/lightmap.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/lightmap.jpg" width="300" />
 
 | Property   | Description |
 |------------|-------------|
@@ -130,7 +130,7 @@ Light maps contain pre-baked diffuse lighting. Using light maps is considered an
 
 Other Render States gives additional controls over how a mesh is rendered with the specified material.
 
-<img loading="lazy" src="/images/user-manual/material-inspector/other.jpg" width="300">
+<img loading="lazy" src="/images/user-manual/material-inspector/other.jpg" width="300" />
 
 | Property        | Description |
 |-----------------|-------------|

--- a/content/en/user-manual/assets/textures/index.md
+++ b/content/en/user-manual/assets/textures/index.md
@@ -67,11 +67,11 @@ Different devices can support different texture sizes. Using [WebGL report][7] o
 
 For example, this is from a MacBook Pro 16 inch (2020) laptop with Chrome which shows support up to 16384x16384.
 
-<img loading="lazy" src="/images/user-manual/assets/textures/mac-webgl-report.png" alt="Macbook Pro WebGL report" style="width: 600px;">
+<img loading="lazy" src="/images/user-manual/assets/textures/mac-webgl-report.png" alt="Macbook Pro WebGL report" style="width: 600px;" />
 
 Whereas on a Samsung S7 mobile device, only 4096x4096 is supported.
 
-<img loading="lazy" src="/images/user-manual/assets/textures/samsung-s7-webgl-report.jpg" alt="Samsung S7 WebGL report" style="width: 600px;">
+<img loading="lazy" src="/images/user-manual/assets/textures/samsung-s7-webgl-report.jpg" alt="Samsung S7 WebGL report" style="width: 600px;" />
 
 If the engine attempts to utilize a texture that exceeds the max texture size reported by WebGL, it will resize it down to this maximum size at runtime. Note that this is only done for texture loaded from images (PNG, JPG, AVIF, WebP, GIF). Compressed textures cannot be resized at runtime and will simply fail to render if they are too large for the device.
 

--- a/content/en/user-manual/assets/textures/texture-compression.md
+++ b/content/en/user-manual/assets/textures/texture-compression.md
@@ -12,23 +12,23 @@ The Editor has the ability to apply lossy compression schemes to your textures t
 
 Consider this texture asset:
 
-<img loading="lazy" src="/images/user-manual/assets/textures/texture-compression/brick.jpg" alt="Brick Texture" width="256" height="256">
+<img loading="lazy" src="/images/user-manual/assets/textures/texture-compression/brick.jpg" alt="Brick Texture" width="256" height="256" />
 
 It's a 512x512 JPG that is 202KB in size. However, JPG is a compressed format and when passed to the graphics engine, it is expanded to an uncompressed RGB8 format that occupies 1.05MB of VRAM (including mipmap levels).
 
 Enabling texture compression achieves the following results:
 
-<img loading="lazy" src="/images/user-manual/assets/textures/texture-compression/compression-results.png" alt="Basis Compression results" width="400">
+<img loading="lazy" src="/images/user-manual/assets/textures/texture-compression/compression-results.png" alt="Basis Compression results" width="400" />
 
 The compression has achieved a 6 times reduction in VRAM usage. Furthermore, in this case, compression has also reduced download size from 202KB to as little as 46KB using the Default quality setting and ETC Mode.
 
 Below is a side by side comparison of the brick texture on Mac with Chrome:
 
-<a href="/images/user-manual/assets/textures/texture-compression/basis-vs-no-compression-brick.png" target="_blank"><img loading="lazy" src="/images/user-manual/assets/textures/texture-compression/basis-vs-no-compression-brick-thumb.jpg" alt="Brick texture compression comparison"></a>
+<a href="/images/user-manual/assets/textures/texture-compression/basis-vs-no-compression-brick.png" target="_blank"><img loading="lazy" src="/images/user-manual/assets/textures/texture-compression/basis-vs-no-compression-brick-thumb.jpg" alt="Brick texture compression comparison" /></a>
 
 Here is another example of the PlayCanvas cube [with Basis (ETC mode)][2] and [without][3] on Mac with Chrome:
 
-<a href="/images/user-manual/assets/textures/texture-compression/basis-vs-no-compression-cube.png" target="_blank"><img loading="lazy" src="/images/user-manual/assets/textures/texture-compression/basis-vs-no-compression-cube-thumb.jpg" alt="PlayCanvas cube compression comparison"></a>
+<a href="/images/user-manual/assets/textures/texture-compression/basis-vs-no-compression-cube.png" target="_blank"><img loading="lazy" src="/images/user-manual/assets/textures/texture-compression/basis-vs-no-compression-cube-thumb.jpg" alt="PlayCanvas cube compression comparison" /></a>
 
 ## Using Basis Texture Compression
 
@@ -41,7 +41,7 @@ Once the texture has been imported into the Editor, select it and scroll down in
 5. Change the quality setting to balance file size vs quality. Lower quality results in smaller file sizes.
 6. Click on Compress Basis.
 
-<img loading="lazy" src="/images/user-manual/assets/textures/texture-compression/enable-basis-texture-compression.gif" alt="Enabling Basis Texture Compression" width="400">
+<img loading="lazy" src="/images/user-manual/assets/textures/texture-compression/enable-basis-texture-compression.gif" alt="Enabling Basis Texture Compression" width="400" />
 
 The Basis WASM module will add 253KB of extra gzipped data to the preload download size but that should be offset by the texture size savings compared to using the legacy texture compression format files ([see below][4]).
 
@@ -50,11 +50,11 @@ To remove Basis compression from a texture:
 1. Untick BASIS.
 2. Click on Compress Basis.
 
-<img loading="lazy" src="/images/user-manual/assets/textures/texture-compression/disable-basis-texture-compression.gif" alt="Disabling Basis Texture Compression" width="400">
+<img loading="lazy" src="/images/user-manual/assets/textures/texture-compression/disable-basis-texture-compression.gif" alt="Disabling Basis Texture Compression" width="400" />
 
 If you would no longer want to use Basis, remove Basis compression from all textures and delete the Basis folder from the project.
 
-<img loading="lazy" src="/images/user-manual/assets/textures/texture-compression/delete-basis-library.png" alt="Delete Basis Module" width="400">
+<img loading="lazy" src="/images/user-manual/assets/textures/texture-compression/delete-basis-library.png" alt="Delete Basis Module" width="400" />
 
 ## Basis Limitations
 
@@ -79,14 +79,14 @@ To use the Legacy Texture Compression options, select the texture and scroll dow
 2. Tick all the formats you wish to use.
 3. Click on Compress Legacy.
 
-<img loading="lazy" src="/images/user-manual/assets/textures/texture-compression/enable-legacy-texture-compression.gif" alt="Enabling Legacy Texture Compression" width="400">
+<img loading="lazy" src="/images/user-manual/assets/textures/texture-compression/enable-legacy-texture-compression.gif" alt="Enabling Legacy Texture Compression" width="400" />
 
 To remove a or several formats:
 
 1. Untick all the formats you wish to remove.
 2. Click on Compress Legacy.
 
-<img loading="lazy" src="/images/user-manual/assets/textures/texture-compression/disable-legacy-texture-compression.gif" alt="Disabling Legacy Texture Compression" width="400">
+<img loading="lazy" src="/images/user-manual/assets/textures/texture-compression/disable-legacy-texture-compression.gif" alt="Disabling Legacy Texture Compression" width="400" />
 
 ## Migrating from Legacy to Basis Texture Compression
 
@@ -95,7 +95,7 @@ If you have a project that is already using the Legacy Texture Compression forma
 1. Remove all the legacy texture formats.
 2. Enable and use Basis.
 
-<img loading="lazy" src="/images/user-manual/assets/textures/texture-compression/migrate-legacy-to-basis.gif" alt="Migrate from Legacy to Basis" width="400">
+<img loading="lazy" src="/images/user-manual/assets/textures/texture-compression/migrate-legacy-to-basis.gif" alt="Migrate from Legacy to Basis" width="400" />
 
 
 [1]: https://github.com/BinomialLLC/basis_universal

--- a/content/en/user-manual/designer/assets.md
+++ b/content/en/user-manual/designer/assets.md
@@ -72,27 +72,27 @@ You can also drag model, material, and cubemap assets directly into the [Viewpor
 
 To copy an asset or a selection of assets between projects, select the asset(s) and right-click to bring up the context menu to select 'Copy'. You can also use the hotkey Ctrl/Cmd + C instead if the context menu is not available due to being a read-only project.
 
-<img loading="lazy" src="/images/user-manual/editor/assets-panel/right-click-copy.png" alt="Right click copy menu" width="500">
+<img loading="lazy" src="/images/user-manual/editor/assets-panel/right-click-copy.png" alt="Right click copy menu" width="500" />
 
 In the project that you want to copy the asset(s) to, right click in the assets panel and select 'Paste'. Ctrl/Cmd + V hotkey can be used instead.
 
-<img loading="lazy" src="/images/user-manual/editor/assets-panel/right-click-paste.png" alt="Right click paste menu" width="500">
+<img loading="lazy" src="/images/user-manual/editor/assets-panel/right-click-paste.png" alt="Right click paste menu" width="500" />
 
 Copy and pasting an asset will also copy its asset dependencies too. For example, here we have a model which references two materials and they reference a set of textures.
 
-<img loading="lazy" src="/images/user-manual/editor/assets-panel/copy-and-paste-model-with-dependencies.png" alt="Model example" width="100%">
+<img loading="lazy" src="/images/user-manual/editor/assets-panel/copy-and-paste-model-with-dependencies.png" alt="Model example" width="100%" />
 
 If you copy and paste just the model asset into a different project, those asset dependencies are copied too.
 
-<img loading="lazy" src="/images/user-manual/editor/assets-panel/pasted-reference-assets.png" alt="Pasted referenced assets" width="100%">
+<img loading="lazy" src="/images/user-manual/editor/assets-panel/pasted-reference-assets.png" alt="Pasted referenced assets" width="100%" />
 
 By default, it is pasted as a flat hierarchy. If you want keep the folder structure, hold Shift when the context menu is opened and an option will appear called 'Paste (keep folders)'. This will attempt to keep the folder structure using the folder you are pasting into as the root folder.
 
-<img loading="lazy" src="/images/user-manual/editor/assets-panel/right-click-paste-keep-folders.png" alt="Right click paste (keep folders) menu" width="500">
+<img loading="lazy" src="/images/user-manual/editor/assets-panel/right-click-paste-keep-folders.png" alt="Right click paste (keep folders) menu" width="500" />
 
 Will result in the following where the folder structure is preserved:
 
-<img loading="lazy" src="/images/user-manual/editor/assets-panel/pasted-assets-keep-folders.png" alt="Pasted referenced assets with folders" width="100%">
+<img loading="lazy" src="/images/user-manual/editor/assets-panel/pasted-assets-keep-folders.png" alt="Pasted referenced assets with folders" width="100%" />
 
 We generally recommend that if you will be using this feature for reusable libraries and assets, to keep it contained to a root level folder that can be easily copied and pasted to other projects. This will keep the folder structure of projects simpler and cleaner.
 

--- a/content/en/user-manual/designer/hierarchy.md
+++ b/content/en/user-manual/designer/hierarchy.md
@@ -4,7 +4,7 @@ layout: usermanual-page.hbs
 position: 2
 ---
 
-<img loading="lazy" src="/images/user-manual/editor/hierarchy.png" style="float: right; padding: 20px; padding-top: 0px;">
+<img loading="lazy" src="/images/user-manual/editor/hierarchy.png" style="float: right; padding: 20px; padding-top: 0px;" />
 
 The Hierarchy panel shows you a tree view of your entire Scene which is made up from a hierarchy of Entities. A Scene will always contain the Root Entity at the top of the tree. All the other Entities you see here on the right have been added by the developer.
 

--- a/content/en/user-manual/designer/index.md
+++ b/content/en/user-manual/designer/index.md
@@ -13,7 +13,7 @@ The PlayCanvas Editor is a visual editing tool which you use to create and edit 
 
 ## Interface
 
-<img loading="lazy" alt="Editor Interface" width="640" src="/images/user-manual/editor/editor-annotated.jpg">
+<img loading="lazy" alt="Editor Interface" width="640" src="/images/user-manual/editor/editor-annotated.jpg" />
 
 This is the main interface to the PlayCanvas Editor. You can see labeled the main areas
 

--- a/content/en/user-manual/designer/inspector.md
+++ b/content/en/user-manual/designer/inspector.md
@@ -4,7 +4,7 @@ layout: usermanual-page.hbs
 position: 3
 ---
 
-<img loading="lazy" src="/images/user-manual/editor/inspector/inspector.png" style="float: right; padding: 20px; padding-top: 0px;" width="320">
+<img loading="lazy" src="/images/user-manual/editor/inspector/inspector.png" style="float: right; padding: 20px; padding-top: 0px;" width="320" />
 
 The Inspector panel shows attribute values for the currently selected item.
 

--- a/content/en/user-manual/designer/keyboard-shortcuts.md
+++ b/content/en/user-manual/designer/keyboard-shortcuts.md
@@ -8,14 +8,14 @@ position: 11
 
 The Editor's camera is controlled with the mouse and keyboard.
 
-| Operation    | Controls                                                       |
-| ------------ | -------------------------------------------------------------- |
-| Orbit        | Left Mouse Button + Drag                                       |
+| Operation    | Controls                                                         |
+| ------------ | ---------------------------------------------------------------- |
+| Orbit        | Left Mouse Button + Drag                                         |
 | Pan          | Middle Mouse Button + Drag<br />SHIFT + Left Mouse Button + Drag |
-| Look Around  | Right Mouse Button + Drag                                      |
-| Zoom / Dolly | Mouse Wheel                                                    |
-| Move         | W-A-S-D                                                        |
-| Move (fast)  | SHIFT + W-A-S-D                                                |
+| Look Around  | Right Mouse Button + Drag                                        |
+| Zoom / Dolly | Mouse Wheel                                                      |
+| Move         | W-A-S-D                                                          |
+| Move (fast)  | SHIFT + W-A-S-D                                                  |
 
 ## General Mouse Controls
 
@@ -35,26 +35,26 @@ The Editor's camera is controlled with the mouse and keyboard.
 
 Note that on a Mac, CMD should be used instead of CTRL.
 
-| Operation             | Description                                                          | Keyboard Shortcut            |
-| --------------------- | -------------------------------------------------------------------- | ---------------------------- |
-| Launch                | Launch the scene in a new tab                                        | CTRL + ENTER                 |
-| New Entity            | Creates a new entity as a child of the currently selected entity     | CTRL + E                     |
-| Duplicate Entity      | Duplicates the selected entity and all children                      | CTRL + D                     |
-| Rename Entity / Asset | Focuses on name field of the selected entity or asset                | N or F2                      |
-| Copy Entity / Asset   | Copy the current entity/asset selection                              | CTRL + C                     |
-| Paste Entity / Asset  | Paste copied entity/asset under the currently selected entity/folder | CTRL + P                     |
+| Operation             | Description                                                          | Keyboard Shortcut              |
+| --------------------- | -------------------------------------------------------------------- | ------------------------------ |
+| Launch                | Launch the scene in a new tab                                        | CTRL + ENTER                   |
+| New Entity            | Creates a new entity as a child of the currently selected entity     | CTRL + E                       |
+| Duplicate Entity      | Duplicates the selected entity and all children                      | CTRL + D                       |
+| Rename Entity / Asset | Focuses on name field of the selected entity or asset                | N or F2                        |
+| Copy Entity / Asset   | Copy the current entity/asset selection                              | CTRL + C                       |
+| Paste Entity / Asset  | Paste copied entity/asset under the currently selected entity/folder | CTRL + P                       |
 | Delete                | Delete the current selection                                         | DELETE<br />CTRL + BACKSPACE   |
-| Frame Selection       | Focus on the current entity selection in the 3D view                 | F                            |
-| Translate             | Activate the translate gizmo in the 3D view                          | 1                            |
-| Rotate                | Activate the rotate gizmo in the 3D view                             | 2                            |
-| Scale                 | Activate the scale gizmo in the 3D view                              | 3                            |
-| World / Local         | Switch between local and world space gizmos                          | L                            |
-| Toggle All Panels     | Hides or shows all the panels to maximize the 3D view                | SPACE                        |
-| Bake                  | Re-bake lighting using the [Run-time Lightmapper][1]                 | CTRL + B                     |
-| Previous Selection    | Select previously selected items                                     | SHIFT + Z                    |
-| Undo                  | Undo the last action                                                 | CTRL + Z                     |
+| Frame Selection       | Focus on the current entity selection in the 3D view                 | F                              |
+| Translate             | Activate the translate gizmo in the 3D view                          | 1                              |
+| Rotate                | Activate the rotate gizmo in the 3D view                             | 2                              |
+| Scale                 | Activate the scale gizmo in the 3D view                              | 3                              |
+| World / Local         | Switch between local and world space gizmos                          | L                              |
+| Toggle All Panels     | Hides or shows all the panels to maximize the 3D view                | SPACE                          |
+| Bake                  | Re-bake lighting using the [Run-time Lightmapper][1]                 | CTRL + B                       |
+| Previous Selection    | Select previously selected items                                     | SHIFT + Z                      |
+| Undo                  | Undo the last action                                                 | CTRL + Z                       |
 | Redo                  | Redo the last action                                                 | CTRL + Y<br />CTRL + SHIFT + Z |
-| How do I...?          | Toggle search toolbar for mini-tutorials                             | CTRL + SPACE                 |
-| Show Controls         | Display the Editor controls                                          | SHIFT + ?                    |
+| How do I...?          | Toggle search toolbar for mini-tutorials                             | CTRL + SPACE                   |
+| Show Controls         | Display the Editor controls                                          | SHIFT + ?                      |
 
 [1]: /user-manual/graphics/lighting/runtime-lightmaps

--- a/content/en/user-manual/designer/keyboard-shortcuts.md
+++ b/content/en/user-manual/designer/keyboard-shortcuts.md
@@ -11,7 +11,7 @@ The Editor's camera is controlled with the mouse and keyboard.
 | Operation    | Controls                                                       |
 | ------------ | -------------------------------------------------------------- |
 | Orbit        | Left Mouse Button + Drag                                       |
-| Pan          | Middle Mouse Button + Drag<br>SHIFT + Left Mouse Button + Drag |
+| Pan          | Middle Mouse Button + Drag<br />SHIFT + Left Mouse Button + Drag |
 | Look Around  | Right Mouse Button + Drag                                      |
 | Zoom / Dolly | Mouse Wheel                                                    |
 | Move         | W-A-S-D                                                        |
@@ -43,7 +43,7 @@ Note that on a Mac, CMD should be used instead of CTRL.
 | Rename Entity / Asset | Focuses on name field of the selected entity or asset                | N or F2                      |
 | Copy Entity / Asset   | Copy the current entity/asset selection                              | CTRL + C                     |
 | Paste Entity / Asset  | Paste copied entity/asset under the currently selected entity/folder | CTRL + P                     |
-| Delete                | Delete the current selection                                         | DELETE<br>CTRL + BACKSPACE   |
+| Delete                | Delete the current selection                                         | DELETE<br />CTRL + BACKSPACE   |
 | Frame Selection       | Focus on the current entity selection in the 3D view                 | F                            |
 | Translate             | Activate the translate gizmo in the 3D view                          | 1                            |
 | Rotate                | Activate the rotate gizmo in the 3D view                             | 2                            |
@@ -53,7 +53,7 @@ Note that on a Mac, CMD should be used instead of CTRL.
 | Bake                  | Re-bake lighting using the [Run-time Lightmapper][1]                 | CTRL + B                     |
 | Previous Selection    | Select previously selected items                                     | SHIFT + Z                    |
 | Undo                  | Undo the last action                                                 | CTRL + Z                     |
-| Redo                  | Redo the last action                                                 | CTRL + Y<br>CTRL + SHIFT + Z |
+| Redo                  | Redo the last action                                                 | CTRL + Y<br />CTRL + SHIFT + Z |
 | How do I...?          | Toggle search toolbar for mini-tutorials                             | CTRL + SPACE                 |
 | Show Controls         | Display the Editor controls                                          | SHIFT + ?                    |
 

--- a/content/en/user-manual/designer/loading-screen.md
+++ b/content/en/user-manual/designer/loading-screen.md
@@ -6,7 +6,7 @@ position: 8
 
 If you want to create a custom loading screen, you can go to the [Scene Settings][1] and click **Create Default** in the *Loading Screen* section. If you already have a valid loading screen script you can drag and drop it on the loading screen panel or click on **Select Existing**:
 
-<img loading="lazy" alt="Loading Screen" src="/images/user-manual/editor/loading-screen/loading-screen.png">
+<img loading="lazy" alt="Loading Screen" src="/images/user-manual/editor/loading-screen/loading-screen.png" />
 
 Clicking on **Create Default** will create a new script with some default contents. You can edit that script if you want to change the loading screen. Here is an example of a default script:
 

--- a/content/en/user-manual/designer/menus-and-toolbar.md
+++ b/content/en/user-manual/designer/menus-and-toolbar.md
@@ -12,7 +12,7 @@ The menu is available by clicking on the PLAYCANVAS icon and contains a complete
 
 ## Toolbar
 
-<img loading="lazy" src="/images/user-manual/editor/menus-and-toolbar/toolbar.png" style="padding-right: 20px; float: left;" width="44">
+<img loading="lazy" src="/images/user-manual/editor/menus-and-toolbar/toolbar.png" style="padding-right: 20px; float: left;" width="44" />
 
 The Toolbar features common commands for easy access, the most useful one of all is the Launch Button. The Launch Button starts a game instance in a separate browser tab and loads your Scene. You can then start play testing immediately. See the section on the Attribute Editor for how to edit values on a live running instance of your game.
 

--- a/content/en/user-manual/designer/settings.md
+++ b/content/en/user-manual/designer/settings.md
@@ -6,7 +6,7 @@ position: 7
 
 The Settings panel lets you set up various properties. It is accessed using the 'cog' button in the bottom left of the Editor (on the [Toolbar][1]).
 
-<img loading="lazy" src="/images/user-manual/editor/settings/cog.jpg" style="display: inline; vertical-align: middle;">
+<img loading="lazy" src="/images/user-manual/editor/settings/cog.jpg" style="display: inline; vertical-align: middle;" />
 
 ## Editor
 

--- a/content/en/user-manual/designer/viewport.md
+++ b/content/en/user-manual/designer/viewport.md
@@ -4,11 +4,11 @@ layout: usermanual-page.hbs
 position: 4
 ---
 
-<img loading="lazy" alt="Viewport" width="640" height="480" src="/images/user-manual/editor/viewport/viewport.jpg">
+<img loading="lazy" alt="Viewport" width="640" height="480" src="/images/user-manual/editor/viewport/viewport.jpg" />
 
 The viewport shows your scene as currently rendered. You can freely move around the scene by manipulating the Editor's current camera.
 
-<img loading="lazy" alt="Cameras dropdown" src="/images/user-manual/editor/viewport/camera-dropdown.jpg" style="float:right; padding: 20px; padding-top: 0px;">
+<img loading="lazy" alt="Cameras dropdown" src="/images/user-manual/editor/viewport/camera-dropdown.jpg" style="float:right; padding: 20px; padding-top: 0px;" />
 
 ## Cameras
 
@@ -18,9 +18,9 @@ You can also use the camera menu to select any of the camera Entities in your sc
 
 ## Gizmos
 
-<img loading="lazy" src="/images/user-manual/editor/viewport/translate.jpg" style="width:210px; float: left; padding: 10px;">
-<img loading="lazy" src="/images/user-manual/editor/viewport/rotate.jpg" style="width:210px; float: left; padding: 10px;">
-<img loading="lazy" src="/images/user-manual/editor/viewport/scale.jpg" style="width:210px; float: left; padding: 10px;">
+<img loading="lazy" src="/images/user-manual/editor/viewport/translate.jpg" style="width:210px; float: left; padding: 10px;" />
+<img loading="lazy" src="/images/user-manual/editor/viewport/rotate.jpg" style="width:210px; float: left; padding: 10px;" />
+<img loading="lazy" src="/images/user-manual/editor/viewport/scale.jpg" style="width:210px; float: left; padding: 10px;" />
 
 The 3-Colored Axis you can see in the screenshot above is called a [Gizmo][1]. This is used to manipulate the transform matrix of the selected Entity. There are three types of Gizmo: Translate (with arrows on the ends of the axes); Rotate (which is made up of three colored rings) and Scale (with cubes on the ends of the axes).
 

--- a/content/en/user-manual/graphics/lighting/shadows.md
+++ b/content/en/user-manual/graphics/lighting/shadows.md
@@ -12,7 +12,7 @@ The PlayCanvas engine implements a shadowing algorithm called shadow mapping. It
 
 ## Enabling Shadows
 
-<img loading="lazy" src="/images/user-manual/graphics/lighting/shadows/light-shadow-options.png" width="480">
+<img loading="lazy" src="/images/user-manual/graphics/lighting/shadows/light-shadow-options.png" width="480" />
 
 By default, shadow casting is disabled in PlayCanvas. You have to explicitly enable it yourself. Fortunately, enabling shadows is easy. First of all, identify which lights in your scene you want to cast shadows. Select the lights in the Hierarchy to edit their properties in the Inspector panel. Every light has a 'Cast Shadows' option. Simply check this option for the light to generate shadows for shadow casting graphical objects in your scene.
 

--- a/content/en/user-manual/optimization/load-time.md
+++ b/content/en/user-manual/optimization/load-time.md
@@ -32,7 +32,7 @@ The game has 3 phases:
 2. Title Screen and Character Customization
 3. Main Game
 
-<img loading="lazy" src="/images/user-manual/optimization/loading/virtual-voodoo-phases.jpg" style="max-width: 100%;">
+<img loading="lazy" src="/images/user-manual/optimization/loading/virtual-voodoo-phases.jpg" style="max-width: 100%;" />
 
 The Preloader phase loads the assets that are needed for the first PlayCanvas scene which is the Title Screen and Character Customization. This would include assets for the UI, character model and assets.
 
@@ -40,7 +40,7 @@ When the Title Screen is active, the game starts background loading the assets t
 
 However, if the user presses the start button before the assets have finished loading, a progress bar will appear on the button instead. Once it reaches 100%, the game will automatically transition to the Main Game.
 
-<img loading="lazy" src="/images/user-manual/optimization/loading/virtual-voodoo-assets-not-ready.gif" style="max-width: 480px;">
+<img loading="lazy" src="/images/user-manual/optimization/loading/virtual-voodoo-assets-not-ready.gif" style="max-width: 480px;" />
 
 With the assets being loaded in phases and giving something new for the user to interact with and/or look at periodically, the user stays engaged despite a long loading time.
 
@@ -52,7 +52,7 @@ If the game allows, using common placeholders while the more detailed assets are
 
 An example below is using a silhouette of a character as the placeholder until it has fully loaded. The silhouette placeholder is small in file size so it can be part of a preload sequence and also can be reused for other characters in the application.
 
-<img loading="lazy" src="/images/user-manual/optimization/loading/character-load.gif" style="max-width: 360px;">
+<img loading="lazy" src="/images/user-manual/optimization/loading/character-load.gif" style="max-width: 360px;" />
 
 [1]: https://playcanv.as/p/tRUfwVg1/
 [2]: /user-manual/templates/#when-do-i-need-to-load-template-assets?

--- a/content/en/user-manual/optimization/mini-stats.md
+++ b/content/en/user-manual/optimization/mini-stats.md
@@ -8,11 +8,11 @@ Mini stats is a lightweight graphical display of an application's key performanc
 
 Editor users can enable the mini-stats panel via the Launch button menu:
 
-<img loading="lazy" alt="Launch Menu" width="600" src="/images/user-manual/optimization/mini-stats/launch-menu-mini-stats.png">
+<img loading="lazy" alt="Launch Menu" width="600" src="/images/user-manual/optimization/mini-stats/launch-menu-mini-stats.png" />
 
 Clicking on the mini-stats will cycle through three supported sizes:
 
-<img loading="lazy" alt="Mini Stats" width="411" src="/images/user-manual/optimization/mini-stats/mini-stats.gif">
+<img loading="lazy" alt="Mini Stats" width="411" src="/images/user-manual/optimization/mini-stats/mini-stats.gif" />
 
 The information displayed is as follows:
 

--- a/content/en/user-manual/organizations/creating-organizations.md
+++ b/content/en/user-manual/organizations/creating-organizations.md
@@ -16,7 +16,7 @@ The first way is to click on NEW ORGANIZATION in the top-right dropdown menu:
 
 This will bring up the following popup:
 
-<img loading="lazy" src="/images/user-manual/organizations/new-organization.jpg" alt="Organization popup" style="border: 1px solid #ccc">
+<img loading="lazy" src="/images/user-manual/organizations/new-organization.jpg" alt="Organization popup" style="border: 1px solid #ccc" />
 
 Enter the name for the Organization and an Organization ID which is a string with only alphanumeric characters and dashes allowed. The default e-mail address is your own but you can change it to a different one.
 
@@ -35,11 +35,11 @@ All the projects will now be under the Organization account with your user accou
 
 Another way to create an Organization is to convert your user account. You can do this by clicking CONVERT in your [account][3] page.
 
-<img loading="lazy" src="/images/user-manual/organizations/convert.png" alt="Organization popup" style="border: 1px solid #ccc">
+<img loading="lazy" src="/images/user-manual/organizations/convert.png" alt="Organization popup" style="border: 1px solid #ccc" />
 
 This will bring up the following popup:
 
-<img loading="lazy" src="/images/user-manual/organizations/convert-popup.png" alt="Convert popup" style="border: 1px solid #ccc">
+<img loading="lazy" src="/images/user-manual/organizations/convert-popup.png" alt="Convert popup" style="border: 1px solid #ccc" />
 
 Converting your user account into an Organization will mean that you will no longer be able to log in with this user account. For that reason you need to specify an owner for the new Organization.
 

--- a/content/en/user-manual/packs/components/script.md
+++ b/content/en/user-manual/packs/components/script.md
@@ -12,7 +12,7 @@ The Script component can be enabled or disabled using the toggle in the top righ
 
 To create a new script, click on the <span class="font-icon" style="font-size: 18px">&#58468;</span> button in the Assets Panel and select New Script. Then type the name of the script in the popup and hit Enter.
 
-<img loading="lazy" src="/images/user-manual/scenes/components/new-script.jpg">
+<img loading="lazy" src="/images/user-manual/scenes/components/new-script.jpg" />
 
 You can then drag the new script on a script component or you can click the Add Script button in the script component Inspector and then select it from the Assets Panel.
 

--- a/content/en/user-manual/packs/index.md
+++ b/content/en/user-manual/packs/index.md
@@ -17,7 +17,7 @@ They are edited using the PlayCanvas Editor.
 
 The **Scene Hierarchy** is a graph of [Entities][entities] that can have [Components][components] to give these Entities behaviors such as having a mesh to render in the world or to play sound effects. They can also be given custom behavior with [scripts][scripts].
 
-<img loading="lazy" src="/images/user-manual/scenes/scene-hierarchy.png" width="400">
+<img loading="lazy" src="/images/user-manual/scenes/scene-hierarchy.png" width="400" />
 
 ## Scene Settings
 
@@ -34,7 +34,7 @@ The full list of Scene Settings are:
 * [Fog][settings-fog] (7)
 * [Lightmap properties][settings-lightmap] (8)
 
-<img loading="lazy" src="/images/user-manual/scenes/scene-settings.png" width="500">
+<img loading="lazy" src="/images/user-manual/scenes/scene-settings.png" width="500" />
 
 [entities]: /user-manual/packs/entities/
 [components]: /user-manual/packs/components/

--- a/content/en/user-manual/publishing/mobile/cordova.md
+++ b/content/en/user-manual/publishing/mobile/cordova.md
@@ -37,7 +37,7 @@ When you create a new Cordova project, it generates a skeleton web app in a fold
 If you're building on the Engine without the Editor, copy your app files into `www` such that your `index.html` file is in the root.
 
 <div class="alert alert-info">
-    <div>Audio asset files will need to be in Base64 format to load and play correctly. This is due to iOS being restrictive about what files can be loaded in the WebView via local disk.</div><br>
+    <div>Audio asset files will need to be in Base64 format to load and play correctly. This is due to iOS being restrictive about what files can be loaded in the WebView via local disk.</div><br />
     <div>We recommend using a tool like <a href="https://base64.guru/converter/encode/audio" target="_blank">Base64 Guru</a> or automating this via a script.</div>
 </div>
 

--- a/content/en/user-manual/publishing/playable-ads/fb-playable-ads.md
+++ b/content/en/user-manual/publishing/playable-ads/fb-playable-ads.md
@@ -6,7 +6,7 @@ position: 1
 
 PlayCanvas supports the [Facebook Playable Ad][1] formats and requirements via an [official external tool on GitHub][2].
 
-<img loading="lazy" src="/images/user-manual/publishing/playable-ads/fb-playable-ads/bitmoji-creator.gif" style="margin:0px 5px; display:inline;" width="185"> <img loading="lazy" src="/images/user-manual/publishing/playable-ads/fb-playable-ads/cube-jump.gif" style="margin:0px 5px; display:inline;" width="185"> <img loading="lazy" src="/images/user-manual/publishing/playable-ads/fb-playable-ads/flappy-bird.gif" style="margin:0px 5px; display:inline;" width="185">
+<img loading="lazy" src="/images/user-manual/publishing/playable-ads/fb-playable-ads/bitmoji-creator.gif" style="margin:0px 5px; display:inline;" width="185" /> <img loading="lazy" src="/images/user-manual/publishing/playable-ads/fb-playable-ads/cube-jump.gif" style="margin:0px 5px; display:inline;" width="185" /> <img loading="lazy" src="/images/user-manual/publishing/playable-ads/fb-playable-ads/flappy-bird.gif" style="margin:0px 5px; display:inline;" width="185" />
 
 The tool can create both the single 2MB (uncompressed) HTML file and the 5MB (uncompressed) ZIP formats via the configuration options. Full specifications for Facebook Playable Ads can be found on their [help centre][3].
 
@@ -72,13 +72,13 @@ Full details of options and commands can be found in the readme section for '[Co
 
 Follow the steps [here][8] to create a Facebook ad and at the time where the files for the ad are uploaded, there is an opportunity to test within the manager.
 
-<img loading="lazy" src="/images/user-manual/publishing/playable-ads/fb-playable-ads/fb-playable-ad-tester.jpg">
+<img loading="lazy" src="/images/user-manual/publishing/playable-ads/fb-playable-ads/fb-playable-ad-tester.jpg" />
 
 Please ignore the warning about the source may contain an `XMLHttpRequest` as the code path has been removed by this tool.
 
 Facebook also allows testing on device via the ad manager but requires you to publish the ad first. This is a strange limitation by Facebook but is required at the moment.
 
-<img loading="lazy" src="/images/user-manual/publishing/playable-ads/fb-playable-ads/fb-playable-ad-preview-device.jpg">
+<img loading="lazy" src="/images/user-manual/publishing/playable-ads/fb-playable-ads/fb-playable-ad-preview-device.jpg" />
 
 [1]: https://www.facebook.com/business/ads/playable-ad-format
 [2]: https://github.com/playcanvas/playcanvas-rest-api-tools#converting-a-project-into-a-single-html-file

--- a/content/en/user-manual/publishing/playable-ads/ironsource-mraid-playable-ads.md
+++ b/content/en/user-manual/publishing/playable-ads/ironsource-mraid-playable-ads.md
@@ -42,7 +42,7 @@ ironSource have a fantastic test tool [here][ironsource-test-tool] which can be 
 
 Check that Testing mode and MRAID are both enabled on the page.
 
-<img loading="lazy" src="/images/user-manual/publishing/playable-ads/ironsource-playable-ads/ironsource-tool-options.png" width="600">
+<img loading="lazy" src="/images/user-manual/publishing/playable-ads/ironsource-playable-ads/ironsource-tool-options.png" width="600" />
 
 Set the following options in the `config.json` as shown below. This will produce a ZIP file with the asset data and PlayCanvas Engine code as separate files from the `index.html`.
 
@@ -71,7 +71,7 @@ We will need to serve the files from a HTTPS endpoint to test with the ironSourc
 
 Our recommended approach is to [host locally][host-locally] and use [ngrok][ngrok] to create a https tunnel to your computer that the app can access.
 
-<img loading="lazy" src="/images/user-manual/publishing/playable-ads/ironsource-playable-ads/ngrok.png" width="600">
+<img loading="lazy" src="/images/user-manual/publishing/playable-ads/ironsource-playable-ads/ngrok.png" width="600" />
 
 This will give a unique URL for the endpoint that we need to add to the `index.html` where it is referencing external files.
 
@@ -113,13 +113,13 @@ Test locally on your PC by double clicking on the `index.html` to ensure that it
 
 If it plays correctly on your PC, we can test on [ironSource's test tool][ironsource-test-tool] by copying the contents of `index.html` and pasting into MRAID tag area of the test tool.
 
-<img loading="lazy" src="/images/user-manual/publishing/playable-ads/ironsource-playable-ads/ironsource-tool-paste-mraid-tag.png" width="600">
+<img loading="lazy" src="/images/user-manual/publishing/playable-ads/ironsource-playable-ads/ironsource-tool-paste-mraid-tag.png" width="600" />
 
 Click on 'Test Ad' and once it renders, play the ad to reach a CTA button. After pressing the CTA button, the tool should show that all the tests have passed and give you an option to generate a code.
 
 This is used to test on device using their app that is available on both Android and iOS.
 
-<img loading="lazy" src="/images/user-manual/publishing/playable-ads/ironsource-playable-ads/ironsource-tool-generate-code.png" width="400">
+<img loading="lazy" src="/images/user-manual/publishing/playable-ads/ironsource-playable-ads/ironsource-tool-generate-code.png" width="400" />
 
 ### Final export for ironSource
 

--- a/content/en/user-manual/publishing/playable-ads/snapchat-playable-ads.md
+++ b/content/en/user-manual/publishing/playable-ads/snapchat-playable-ads.md
@@ -74,11 +74,11 @@ To test the ad on a device, we can use the Android app [Creative Preview][creati
 
 Our recommended approach is to [host locally][host-locally] and use [ngrok][ngrok] to create a https tunnel to your computer that the app can access.
 
-<img loading="lazy" src="/images/user-manual/publishing/playable-ads/snapchat-playable-ads/ngrok.png" width="600">
+<img loading="lazy" src="/images/user-manual/publishing/playable-ads/snapchat-playable-ads/ngrok.png" width="600" />
 
 Once this is setup, open Creative Preview app and create a new 'Display' ad with the following settings:
 
-<img loading="lazy" src="/images/user-manual/publishing/playable-ads/snapchat-playable-ads/creative-preview.png" width="300">
+<img loading="lazy" src="/images/user-manual/publishing/playable-ads/snapchat-playable-ads/creative-preview.png" width="300" />
 
 ### Export for Snapchat
 

--- a/content/en/user-manual/scripting/script-attributes.md
+++ b/content/en/user-manual/scripting/script-attributes.md
@@ -34,7 +34,7 @@ MyScript.attributes.add('names', {
 
 ## Getting Attributes into Editor
 
-<img loading="lazy" src="/images/user-manual/scripting/script-attributes.jpg" style="width: 300px; float: right; padding: 20px; padding-top: 0px;">
+<img loading="lazy" src="/images/user-manual/scripting/script-attributes.jpg" style="width: 300px; float: right; padding: 20px; padding-top: 0px;" />
 
 Once you've declared your attributes the Editor needs to parse the code in order to expose the script attributes. If attributes have been changed, you need to manually refresh the attributes you can click the parse <img loading="lazy" src="/images/user-manual/scripting/parse-button.jpg" style="display: inline; vertical-align: middle;"> button.
 

--- a/content/en/user-manual/user-interface/safe-area.md
+++ b/content/en/user-manual/user-interface/safe-area.md
@@ -6,7 +6,7 @@ position: 10
 
 With the trend of mobile devices having full device screens, a notch or cut out in the display is used to make room for the ear piece speaker and front facing camera (see below for the iPhone X).
 
-<img loading="lazy" src="/images/user-manual/user-interface/safe-area/iphone-notch.png">
+<img loading="lazy" src="/images/user-manual/user-interface/safe-area/iphone-notch.png" />
 
 (Image Original: Rafael Fernandez, Modified version:PlayCanvas, [CC BY-SA 4.0][cc-by-sa-40], via Wikimedia Commons)
 
@@ -14,11 +14,11 @@ Developers will need to be mindful of any essential information that is needed f
 
 For example, the screenshot below looks fine on desktop in devtools mobile view.
 
-<img loading="lazy" src="/images/user-manual/user-interface/safe-area/desktop-view.png" width="500">
+<img loading="lazy" src="/images/user-manual/user-interface/safe-area/desktop-view.png" width="500" />
 
 However, when opened on a mobile device such as the iPhone X, the 'Left' text is rendered under the notch and the 'Bottom' text is rendered under the navigation bar.
 
-<img loading="lazy" src="/images/user-manual/user-interface/safe-area/mobile-view-render-under-notch.png" width="500">
+<img loading="lazy" src="/images/user-manual/user-interface/safe-area/mobile-view-render-under-notch.png" width="500" />
 
 ## Safe Area
 
@@ -26,25 +26,25 @@ To help developers, browsers on the these devices do support [environment variab
 
 We have a [project with a reusable script][safe-area-project] that takes those CSS values and applies them to an UI Group Element entity via resizing the margins.
 
-<img loading="lazy" src="/images/user-manual/user-interface/safe-area/mobile-view-safe-area.png" width="500">
+<img loading="lazy" src="/images/user-manual/user-interface/safe-area/mobile-view-safe-area.png" width="500" />
 
 The UI setup in the project has an Entity with a full screen Group Element named 'Safe Area'. This has the script 'mobileSafeArea' attached which contains the logic for fitting the Element within the safe area of the device.
 
-<img loading="lazy" src="/images/user-manual/user-interface/safe-area/hierarchy-layout.png" width="420">
+<img loading="lazy" src="/images/user-manual/user-interface/safe-area/hierarchy-layout.png" width="420" />
 
-<img loading="lazy" src="/images/user-manual/user-interface/safe-area/safe-area-entity-setup.png" width="420">
+<img loading="lazy" src="/images/user-manual/user-interface/safe-area/safe-area-entity-setup.png" width="420" />
 
 Any essential UI Elements can be placed as a child of the Safe Area Entity to be anchored relative to it.
 
-<img loading="lazy" src="/images/user-manual/user-interface/safe-area/hierarchy-essential-elements.png" width="420">
+<img loading="lazy" src="/images/user-manual/user-interface/safe-area/hierarchy-essential-elements.png" width="420" />
 
 To help with development, a debug setting can be enabled to simulate a safe area to preview what a UI layout would look like without needing a device.
 
-<img loading="lazy" src="/images/user-manual/user-interface/safe-area/debug-config.png" width="600">
+<img loading="lazy" src="/images/user-manual/user-interface/safe-area/debug-config.png" width="600" />
 
 The debug config can be edited with live updates in the launch tab too.
 
-<img loading="lazy" src="/images/user-manual/user-interface/safe-area/debug-config-runtime.gif" width="500">
+<img loading="lazy" src="/images/user-manual/user-interface/safe-area/debug-config-runtime.gif" width="500" />
 
 [env-mdn]: https://developer.mozilla.org/en-US/docs/Web/CSS/env()
 [safe-area-project]: https://playcanvas.com/project/828118/overview/mobile-ui-safe-areas


### PR DESCRIPTION
HTML5 doesn't require you to close `img` or `br` tags (AKA void elements). But some tools insist on closing these tags by adhering to the rules of XML (e.g. JSX based tooling like Docusaurus). So this PR closes these void elements for better compatibility.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
