### PR TITLE
Fixed alert admonitions that weren't rendering

### DIFF
--- a/docs/user-manual/api/asset-create.md
+++ b/docs/user-manual/api/asset-create.md
@@ -13,9 +13,9 @@ POST https://playcanvas.com/api/assets
 
 Create a new asset.
 
-<div class="alert alert-info">
-    This endpoint currently only supports creating `script`, `html`, `css`, `text`, `shader` and `json` type assets.
-</div>
+:::warning
+This endpoint currently only supports creating `script`, `html`, `css`, `text`, `shader` and `json` type assets.
+:::
 
 **Unlike other REST API endpoints. The Create Asset endpoint expects data to be sent in `multipart/form-data`**
 

--- a/docs/user-manual/api/asset-delete.md
+++ b/docs/user-manual/api/asset-delete.md
@@ -11,7 +11,11 @@ GET https://playcanvas.com/api/assets/:assetId?branchId=:branchId
 
 ## Description
 
-Permanently delete an asset from a branch of your project. **Warning** deleting an asset is permanent and unrecoverable unless you have taken a checkpoint of it.
+Permanently delete an asset from a branch of your project. 
+
+:::warning 
+deleting an asset is permanent and unrecoverable unless you have taken a checkpoint of it.
+:::
 
 ## Example
 

--- a/docs/user-manual/api/asset-update.md
+++ b/docs/user-manual/api/asset-update.md
@@ -13,9 +13,9 @@ PUT https://playcanvas.com/api/assets/:assetId
 
 Update an existing asset's file.
 
-<div class="alert alert-info">
-    This endpoint currently only supports updating `script`, `html`, `css`, `text`, `shader` and `json` type assets.
-</div>
+:::note
+This endpoint currently only supports updating `script`, `html`, `css`, `text`, `shader` and `json` type assets.
+:::
 
 **Unlike other REST API endpoints. The Update Asset endpoint expects data to be sent in `multipart/form-data`**
 

--- a/docs/user-manual/api/index.md
+++ b/docs/user-manual/api/index.md
@@ -3,9 +3,9 @@ title: REST API
 sidebar_position: 22
 ---
 
-<div class="alert alert-info">
-    The REST API is currently in beta. This means we may change certain endpoints and API responses.
-</div>
+:::warning
+The REST API is currently in beta. This means we may change certain endpoints and API responses.
+:::
 
 ## Authorization
 

--- a/docs/user-manual/assets/animation.md
+++ b/docs/user-manual/assets/animation.md
@@ -18,9 +18,9 @@ There is also a viewer in the [Anim State Graph Editor][anim-state-graph-editor]
 
 ## Animation Import Settings
 
-<div class="alert alert-info">
-Note: This is an experimental feature. Please let us know your feedback in the <a href="https://forum.playcanvas.com/" target="_blank">forums</a>.
-</div>
+:::note
+This is an experimental feature. Please let us know your feedback in the <a href="https://forum.playcanvas.com/" target="_blank">forums</a>.
+:::
 
 When importing animations, there are settings that can be tweaked to adjust the animation quality against the file size.
 

--- a/docs/user-manual/assets/cubemaps.md
+++ b/docs/user-manual/assets/cubemaps.md
@@ -81,7 +81,9 @@ The default Phong and Physical material types both have reflection properties. I
 
 You can click the Empty slot to select a cubemap or drag and drop a cubemap asset from the asset panel into the cubemap slot.
 
-Note: a Physical material will use the scene's skybox as a default environment map if it is assigned and  prefiltered.
+:::note
+A Physical material will use the scene's skybox as a default environment map if it is assigned and  prefiltered.
+:::
 
 ## Converting Equirectangular or Octahedral HDRIs to Cubemaps
 

--- a/docs/user-manual/assets/import-pipeline/import-hierarchy.md
+++ b/docs/user-manual/assets/import-pipeline/import-hierarchy.md
@@ -9,9 +9,9 @@ PlayCanvas supports importing models with their meshes as a hierarchy of entitie
 
 ## How to enable
 
-<div class="alert alert-info">
-    This is now enabled by default for new projects.
-</div>
+:::note
+This is now enabled by default for new projects.
+:::
 
 Open the 'Project Settings'
 

--- a/docs/user-manual/assets/importing.md
+++ b/docs/user-manual/assets/importing.md
@@ -15,7 +15,9 @@ To upload an asset to PlayCanvas, follow these steps:
 
 Now, when you attempt to choose an asset via the asset picker attribute control (for the Model component or the Animation component for example), your asset will be available for assignment.
 
-Note: There is a file size limit of 340MB.
+:::note
+There is a file size limit of 340MB.
+:::
 
 ## Updating Existing Assets
 

--- a/docs/user-manual/assets/models/building.md
+++ b/docs/user-manual/assets/models/building.md
@@ -74,9 +74,9 @@ The 2.71 release of Blender features a revamped FBX export module that enables m
 
 Alternatively, use the [Autodesk FBX Converter][5] to convert an export from Blender into one with embedded media. Just open the file in the FBX Converter and re-save with the *Embedded Media* checkbox set.
 
-<div class="alert alert-warning">
-Note: there seems to be an issue with Blender 2.71's FBX export generating emissivity despite no emissive properties being set in Blender - this is not an issue with the PlayCanvas engine. To avoid this from within Blender, you can change the material's Diffuse color setting to 0 (under the 'Material' tab in the 'Properties Editor'). Or simply reduce emissivity from within the PlayCanvas Editor.
-</div>
+:::warning
+There seems to be an issue with Blender 2.71's FBX export generating emissivity despite no emissive properties being set in Blender - this is not an issue with the PlayCanvas engine. To avoid this from within Blender, you can change the material's Diffuse color setting to 0 (under the 'Material' tab in the 'Properties Editor'). Or simply reduce emissivity from within the PlayCanvas Editor.
+:::
 
 ### **Animations**
 

--- a/docs/user-manual/dashboard/settings.md
+++ b/docs/user-manual/dashboard/settings.md
@@ -21,9 +21,9 @@ If you want your project to be featured on playcanvas.com, you must add a projec
 
 Private projects are only visible to users who have been explicitly assigned read, write or admin access.
 
-<div class="alert alert-info">
+:::note
 Only users with premium accounts can access private projects
-</div>
+:::
 
 ## Team
 

--- a/docs/user-manual/designer/assets.md
+++ b/docs/user-manual/designer/assets.md
@@ -95,9 +95,9 @@ Will result in the following where the folder structure is preserved:
 
 We generally recommend that if you will be using this feature for reusable libraries and assets, to keep it contained to a root level folder that can be easily copied and pasted to other projects. This will keep the folder structure of projects simpler and cleaner.
 
-<div class="alert alert-info">
-Note that copy and pasting assets does not overwrite existing assets with the same name and will create a new asset.
-</div>
+:::warning
+Copy and pasting assets does not overwrite existing assets with the same name and will create a new asset.
+:::
 
 ## Checking References
 
@@ -105,9 +105,9 @@ Sometimes it's useful to know where assets are being used (or referenced) within
 
 ![Unreferenced Asset][5]
 
-<div class="alert alert-info">
-Note that the Editor cannot detect references to assets that are made in code. So think carefully before you delete an asset based on this indicator!
-</div>
+:::note
+The Editor cannot detect references to assets that are made in code. So think carefully before you delete an asset based on this indicator!
+:::
 
 If an asset does have references, you can check them via the References content menu item:
 

--- a/docs/user-manual/designer/editor-api.md
+++ b/docs/user-manual/designer/editor-api.md
@@ -3,9 +3,9 @@ title: Editor API
 sidebar_position: 10
 ---
 
-<div class="alert alert-info">
+:::warning
 The Editor API is a beta feature. Please use caution when using on live projects.
-</div>
+:::
 
 The Editor has a user accessible API that is currently in beta which can be used to help automate and extend the base functionality.
 

--- a/docs/user-manual/graphics/advanced-rendering/batching.md
+++ b/docs/user-manual/graphics/advanced-rendering/batching.md
@@ -12,9 +12,9 @@ Common batching use cases are:
 * Combine together static geometry -- e.g. environments -- into a single mesh instance or multiple large instances to reduce draw calls, but still support camera culling.
 * Combine together dynamic geometry -- e.g. a set of moving objects -- into a single mesh instance with dynamic properties that are applied on the GPU.
 
-<div class="alert-info">
-    The use of batching is currently not compatible with <a href="/user-manual/graphics/lighting/runtime-lightmaps/">runtime lightmaps</a> due to each lightmapped object requiring its own unique lightmap texture.
-</div>
+:::warning
+The use of batching is currently not compatible with <a href="/user-manual/graphics/lighting/runtime-lightmaps/">runtime lightmaps</a> due to each lightmapped object requiring its own unique lightmap texture.
+:::
 
 ## Creating Batch Groups
 

--- a/docs/user-manual/graphics/layers/index.md
+++ b/docs/user-manual/graphics/layers/index.md
@@ -87,7 +87,9 @@ Components that render meshes all have a `layers` property which is used to dete
 
 ![Layer Components][5]
 
-*Note:* The model is assigned to the Test Layer. In order for it to be rendered, the camera must include Test Layer in its layer list. In order for it to be lit, the light must include Test Layer in its layer list too.
+:::note
+The model is assigned to the Test Layer. In order for it to be rendered, the camera must include Test Layer in its layer list. In order for it to be lit, the light must include Test Layer in its layer list too.
+:::
 
 ### Recommended setup
 

--- a/docs/user-manual/graphics/lighting/clustered-lighting.md
+++ b/docs/user-manual/graphics/lighting/clustered-lighting.md
@@ -3,9 +3,9 @@ title: Clustered Lighting
 sidebar_position: 6
 ---
 
-<div class="alert alert-info">
-    Clustered lighting is enabled by default from PlayCanvas Engine v1.56 onwards. The older lighting system will still be available in the Engine for the short term. However, we will deprecate it in a future minor release.
-</div>
+:::warning
+Clustered lighting is enabled by default from PlayCanvas Engine v1.56 onwards. The older lighting system will still be available in the Engine for the short term. However, we will deprecate it in a future minor release.
+:::
 
 Lights are a great way to add realism to your application. However, real time lights can also create significant runtime performance cost, especially when you have large numbers of lights that cast shadows.
 

--- a/docs/user-manual/graphics/lighting/runtime-lightmaps.md
+++ b/docs/user-manual/graphics/lighting/runtime-lightmaps.md
@@ -24,9 +24,9 @@ There are multiple advantages to runtime lightmap generation:
 
 However, a disadvantage of runtime lightmap generation is that currently we do not support baking global illumination or some other advanced features of specialized baking tools.
 
-<div class="alert-info">
-    The use of <a href="/user-manual/optimization/batching">batching</a> is not compatible with runtime lightmaps, as each lightmapped object requires its own unique lightmap texture.
-</div>
+:::note
+The use of <a href="/user-manual/optimization/batching">batching</a> is not compatible with runtime lightmaps, as each lightmapped object requires its own unique lightmap texture.
+:::
 
 ## Setting Up Lights for Baking
 

--- a/docs/user-manual/graphics/physical-rendering/physical-materials.md
+++ b/docs/user-manual/graphics/physical-rendering/physical-materials.md
@@ -51,9 +51,9 @@ You can often find the charts of recorded values for diffuse/albedo values on th
 
 The metalness value is part of the **metalness** workflow. Metalness is a single value between 0-1 which determines if a material is metal (1) or non-metal (0).
 
-<div class="alert-info">
+:::note
 The metalness value should almost always be 0 or 1. It is rare that you will need a value somewhere between these two.
-</div>
+:::
 
 You can also supply a metalness map which lets you define specific areas of your material as metal or non-metal.
 

--- a/docs/user-manual/organizations/creating-organizations.md
+++ b/docs/user-manual/organizations/creating-organizations.md
@@ -42,9 +42,9 @@ This will bring up the following popup:
 
 Converting your user account into an Organization will mean that you will no longer be able to log in with this user account. For that reason you need to specify an owner for the new Organization.
 
-<div class="alert alert-info">
+:::note
 Make sure you can log in with the new owner's account.
-</div>
+:::
 
 If you have subscribed for a paid plan, that plan will be cancelled unless you choose to subscribe to an Organization plan which is offered in the popup. The number of seats to purchase will be calculated for you automatically based on the number of users in your existing private projects.
 

--- a/docs/user-manual/packs/loading-scenes.md
+++ b/docs/user-manual/packs/loading-scenes.md
@@ -70,9 +70,9 @@ Scenes are separate from [assets][assets] and have different properties and APIs
 
 Scenes are represented by [Scene Registry Items][sceneregistryitem-api] that are stored in the [Scene Registry][sceneregistry-api] which can be accessed through [Application][application-sceneregistry-api] object. Through the Scene Registry, you can find the Scene Registry Item by the name of the scene in the Editor and use it to load the scene hierarchy or settings.
 
-<div class="alert alert-info">
+:::note
 The <a href="/api/pc.Application.html#root">application root node</a> is not the scene hierarchy root entity that is named 'Root' by default that you see in the scene with the Editor. The scene hierarchy root entity will be a child of the application root node.
-</div>
+:::
 
 There are two APIs to load the scene hierarchy and settings:
 

--- a/docs/user-manual/publishing/mobile/cordova.md
+++ b/docs/user-manual/publishing/mobile/cordova.md
@@ -35,10 +35,10 @@ When you create a new Cordova project, it generates a skeleton web app in a fold
 
 If you're building on the Engine without the Editor, copy your app files into `www` such that your `index.html` file is in the root.
 
-<div class="alert alert-info">
-    <div>Audio asset files will need to be in Base64 format to load and play correctly. This is due to iOS being restrictive about what files can be loaded in the WebView via local disk.</div><br />
-    <div>We recommend using a tool like <a href="https://base64.guru/converter/encode/audio" target="_blank">Base64 Guru</a> or automating this via a script.</div>
-</div>
+:::tip
+<div>Audio asset files will need to be in Base64 format to load and play correctly. This is due to iOS being restrictive about what files can be loaded in the WebView via local disk.</div><br />
+<div>We recommend using a tool like <a href="https://base64.guru/converter/encode/audio" target="_blank">Base64 Guru</a> or automating this via a script.</div>
+:::
 
 If you have built your app in the PlayCanvas Editor, we have an official external tool that will build and prepare the project to be most compatible with Cordova. This includes automating tasks such as converting the audio files to Base64 so that they can be loaded on iOS.
 

--- a/docs/user-manual/publishing/web/facebook.md
+++ b/docs/user-manual/publishing/web/facebook.md
@@ -23,9 +23,9 @@ sidebar_position: 6
 
 ![Website URL][5]
 
-<div class="alert alert-info">
+:::note
 Adding this URL as your website URL is required because of the way PlayCanvas hosts games and the security requirements that Facebook implements to allow access to its API. We're working on a fix for this in PlayCanvas so that you only need to set the Secure Canvas URL.
-</div>
+:::
 
 **6.** Finally, set up all the images and icons that are required for your game
 

--- a/docs/user-manual/publishing/web/playcanvas-hosting.md
+++ b/docs/user-manual/publishing/web/playcanvas-hosting.md
@@ -60,9 +60,9 @@ You can also set the Primary Build for your project, by clicking on the banner i
 
 It's useful to have a single link that will always refer to the latest version of your game. That way you don't have to worry about broken links when you delete old builds. This is why each project has a Primary Build link. This will always be in the form `https://playcanv.as/p/PROJECT_ID/`
 
-<div class="alert alert-info">
+:::tip
 If you are sharing a link to your game you should use the Primary Build link. That means you know it won't change when you re-publish.
-</div>
+:::
 
 The first time you publish a build, it will automatically become the Primary Build. For any subsequent build, you can choose when to assign it to be the Primary Build. This means that you can publish builds and test them before finally publishing them to your audience.
 

--- a/docs/user-manual/scripting/custom_engine.md
+++ b/docs/user-manual/scripting/custom_engine.md
@@ -63,9 +63,9 @@ To launch with the minified build, use:
     https://launch.playcanvas.com/<scene_id>?use_local_engine=https://code.playcanvas.com/playcanvas-0.225.0.min.js
 ```
 
-<div class="alert alert-info">
-    The Editor only officially supports the current Engine release and the previous minor version. While it is sometimes possible to use an older version of the Engine, it is not a long-term supported workflow. We strongly recommend keeping live projects updated with the current Engine release.
-</div>
+:::warning
+The Editor only officially supports the current Engine release and the previous minor version. While it is sometimes possible to use an older version of the Engine, it is not a long-term supported workflow. We strongly recommend keeping live projects updated with the current Engine release.
+:::
 
 ### Launch with a Locally Built Engine
 

--- a/docs/user-manual/scripting/debugging.md
+++ b/docs/user-manual/scripting/debugging.md
@@ -21,9 +21,9 @@ The navigator lists all of the scripts currently running in the active tab, incl
 
 Each browser has detailed instructions on how to debug javascript. You should read through these documents: [Chrome][3], [Firefox][4], [Safari][5], [Edge / Internet Explorer][6].
 
-<div class="alert alert-info">
-Note that when a running app is paused at a breakpoint in the debugger, other browser windows/tabs used to launch that app (containing the PlayCanvas Code Editor or Editor etc.) might also be paused.
-</div>
+:::tip
+When a running app is paused at a breakpoint in the debugger, other browser windows/tabs used to launch that app (containing the PlayCanvas Code Editor or Editor etc.) might also be paused.
+:::
 
 ### Debugging on Mobile Devices
 

--- a/docs/user-manual/scripting/script-attributes.md
+++ b/docs/user-manual/scripting/script-attributes.md
@@ -173,7 +173,9 @@ MyScript.prototype.update = function (dt) {
 };
 ```
 
-*NOTE: We currently do not support defining JSON attributes as children of other JSON attributes. You can only go 1 level deep when defining a JSON attribute.*
+:::note
+We currently do not support defining JSON attributes as children of other JSON attributes. You can only go 1 level deep when defining a JSON attribute.
+:::
 
 [1]: /images/user-manual/scripting/script-attributes.jpg
 [2]: /images/user-manual/scripting/parse-button.jpg

--- a/docs/user-manual/templates/index.md
+++ b/docs/user-manual/templates/index.md
@@ -58,7 +58,9 @@ Alternatively you can open the [Override Diff View][4] and apply overrides from 
 
 Any overrides you apply to the Template Asset will propagate to other instances of the Template Asset in any scene that these might be.
 
-*Note: You cannot currently undo the action of applying overrides to a Template Asset.*
+:::
+You cannot currently undo the action of applying overrides to a Template Asset.
+:::
 
 ### Reverting Overrides
 

--- a/docs/user-manual/user-interface/image-elements.md
+++ b/docs/user-manual/user-interface/image-elements.md
@@ -21,7 +21,9 @@ As with the color property, the opacity property can be used to set the transpar
 
 If you can't achieve the results you are looking for using the texture, color and opacity properties. You can assign your own material to an image element using the material property. For correct rendering you should *disable Depth Write* on any material added to an image Element.
 
-Note: Lighting will not function as expected for Screen Space elements. You will probably want to disable lighting and shadows for any material that is used in screen space.
+:::note
+Lighting will not function as expected for Screen Space elements. You will probably want to disable lighting and shadows for any material that is used in screen space.
+:::
 
 ## Masks and Masking
 

--- a/docs/user-manual/user-interface/text-elements.md
+++ b/docs/user-manual/user-interface/text-elements.md
@@ -23,7 +23,9 @@ By default a Text Element is set to automatically adjust its width and height to
 
 ![Auto Size][2]
 
-Note: The height of the character is determined by the largest character present in the font. It is the same for every character so as to avoid the string position changing depending on the contents of the string.
+:::note
+The height of the character is determined by the largest character present in the font. It is the same for every character so as to avoid the string position changing depending on the contents of the string.
+:::
 
 ## Alignment
 

--- a/docs/user-manual/version-control/branches.md
+++ b/docs/user-manual/version-control/branches.md
@@ -71,7 +71,9 @@ To close a branch, open the version control panel, select the branch you wish to
 
 You will be asked to confirm the closing of the branch and you have an option to create a checkpoint before closing. This is enabled by default. If you wish to discard these changes you can untick the option here.
 
-**Note: Unticking this checkbox will lose any work you have made in the branch since you last made a checkpoint**
+:::note
+Unticking this checkbox will lose any work you have made in the branch since you last made a checkpoint
+:::
 
 Closed branches can also be reopened at a later date.
 

--- a/docs/user-manual/your-first-app.md
+++ b/docs/user-manual/your-first-app.md
@@ -127,11 +127,11 @@ The Launch page opens in a new tab. When it opens, try pressing the 4 arrow keys
 
 ![Launch Page][15]
 
-<div class="alert alert-info">
+:::tip
 There is a 'Live Link' between the Editor and the Launch page. Any change you make in the Editor will be reflected in the Launch page in real time! It can be convenient to place the Launch page side by side with the Editor while you are working.
 
 ![Editor Live Link][16]
-</div>
+:::
 
 The final step is to publish your app so you can share it with others. To do this, click on the <span class="pc-icon">&#57911;</span> button in the left hand side toolbar.
 


### PR DESCRIPTION
the admonitions in markdown weren't rendering using the css classes, so changed to use markdown syntax as per https://docusaurus.io/docs/next/markdown-features/admonitions

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
