### PR TITLE
Fixed react rendering error. Renamed `class` attribute in markdown wi…

### DIFF
--- a/docs/tutorials/Using-forces-on-rigid-bodies.md
+++ b/docs/tutorials/Using-forces-on-rigid-bodies.md
@@ -4,7 +4,7 @@ tags: [physics, collision]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405828/95F429-image-75.jpg
 ---
 
-<div class='iframe-container'>
+<div className='iframe-container'>
     <iframe loading="lazy" src="https://playcanv.as/p/8LTSuf4F/" title="Forces and Impulses" />
 </div>
 

--- a/docs/tutorials/additive-loading-scenes.md
+++ b/docs/tutorials/additive-loading-scenes.md
@@ -6,7 +6,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/6850
 
 Full documentation for Loading Scenes is now in the [User Manual][documentation-page].
 
-<div class='iframe-container'>
+<div className='iframe-container'>
     <iframe loading="lazy" src="https://playcanv.as/e/p/cjBInud1/" title="Additive Loading Scenes"></iframe>
 </div>
 

--- a/docs/tutorials/anim-blending.md
+++ b/docs/tutorials/anim-blending.md
@@ -4,7 +4,7 @@ tags: [animation,basics]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405874/A8B1FE-image-75.jpg
 ---
 
-<div class='iframe-container'>
+<div className='iframe-container'>
     <iframe loading="lazy" src="https://playcanv.as/p/HI8kniOx/" title="Anim State Graph Blending"></iframe>
 </div>
 

--- a/docs/tutorials/animated-textures.md
+++ b/docs/tutorials/animated-textures.md
@@ -4,7 +4,7 @@ tags: [animation, textures]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405882/831708-image-75.jpg
 ---
 
-<div class='iframe-container'>
+<div className='iframe-container'>
     <iframe loading="lazy" src="https://playcanv.as/p/BM93v05L/" title="Animated Textures"></iframe>
 </div>
 

--- a/docs/tutorials/animation-blending.md
+++ b/docs/tutorials/animation-blending.md
@@ -10,7 +10,7 @@ This tutorial uses the deprecated Model and Animation components. Please refer t
 
 :::
 
-<div class='iframe-container'>
+<div className='iframe-container'>
     <iframe loading="lazy" src="https://playcanv.as/p/HI8kniOx/" title="Animation Blending"></iframe>
 </div>
 


### PR DESCRIPTION
Fixes react rendering error with markdown files with `class` attribute. Renamed to `className`

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
