### PR TITLE
Use vanilla markdown for REST API

### DIFF
--- a/docs/user-manual/api/app-download.md
+++ b/docs/user-manual/api/app-download.md
@@ -21,20 +21,20 @@ curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json
 
 ## Parameters
 
-<div class="params">
-<div class="parameter"><span class="param">project_id: number</span><p>The id of the project.</p></div>
-<div class="parameter"><span class="param">name: string</span><p>The name of the app. Must be less than 1000 characters</p></div>
-<div class="parameter"><span class="param">scenes: [number]</span><p>A list of scene ids to be included in the app. When you specify scenes then the first scene in the list will be used as the initial scene of the application.</p></div>
-<div class="parameter"><span class="param">branch_id [optional]: string</span><p>The id of the branch. If no id is specified the main branch will be used.</p></div>
-<div class="parameter"><span class="param">description [optional]: string</span><p>The description of the app. Must be less than 10,000 characters.</p></div>
-<div class="parameter"><span class="param">version [optional]: string</span><p>The version of the app. Can be a string up to 20 characters.</p></div>
-<div class="parameter"><span class="param">release_notes [optional]: string</span><p>Release notes for the app. Can be a string up to 10,000 characters.</p></div>
-<div class="parameter"><span class="param">scripts_concatenate [optional]: boolean</span><p>Set it to true if you want scripts to be concatenated.</p></div>
-<div class="parameter"><span class="param">scripts_minify [optional]: boolean</span><p>Set it to true if you want scripts to be minified. Defaults to true.</p></div>
-<div class="parameter"><span class="param">scripts_sourcemaps [optional] boolean</span><p>Set it to true if you want script sourcemaps to be generated. Defaults to false.</p></div>
-<div class="parameter"><span class="param">optimize_scene_format [optional] boolean</span><p>Set it to true if you want scenes to be in an optimized format (see <a href="/user-manual/optimization/optimizing-scene-format">Optimize Scene Format</a> for more information)</p></div>
-<div class="parameter"><span class="param">engine_version [optional]: string</span><p>Set it to a Engine version string (<a href="https://github.com/playcanvas/engine/releases" target="_blank">full list of releases</a>) if a specific version is needed for the app.</p></div>
-</div>
+| Name                    | Type       | Required | Description                                                                                                                                                           |
+| ----------------------- | ---------- | :------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `project_id`            | `number`   | ✔️      | The id of the project.                                                                                                                                                |
+| `name`                  | `string`   | ✔️      | The name of the app. Must be less than 1000 characters.                                                                                                               |
+| `scenes`                | `number[]` | ✔️      | A list of scene ids to be included in the app. When you specify scenes then the first scene in the list will be used as the initial scene of the application.         |
+| `branch_id`             | `string`   |          | The id of the branch. If no id is specified the main branch will be used.                                                                                             |
+| `description`           | `string`   |          | The description of the app. Must be less than 10,000 characters.                                                                                                      |
+| `version`               | `string`   |          | The version of the app. Can be a string up to 20 characters.                                                                                                          |
+| `release_notes`         | `string`   |          | Release notes for the app. Can be a string up to 10,000 characters.                                                                                                   |
+| `scripts_concatenate`   | `boolean`  |          | Set it to true if you want scripts to be concatenated.                                                                                                                |
+| `scripts_minify`        | `boolean`  |          | Set it to true if you want scripts to be minified. Defaults to true.                                                                                                  |
+| `scripts_sourcemaps`    | `boolean`  |          | Set it to true if you want script sourcemaps to be generated. Defaults to false.                                                                                      |
+| `optimize_scene_format` | `boolean`  |          | Set it to true if you want scenes to be in an optimized format (see [Optimize Scene Format](/user-manual/optimization/optimizing-scene-format) for more information). |
+| `engine_version`        | `string`   |          | Set it to a Engine version string ([full list of releases](https://github.com/playcanvas/engine/releases)) if a specific version is needed for the app.               |
 
 ## Response Schema
 
@@ -67,14 +67,14 @@ Status: 201 Created
 
 ## Errors
 
-<div class="params">
-<div class="parameter"><span class="param">401</span><p>Unauthorized</p></div>
-<div class="parameter"><span class="param">403</span><p>Forbidden</p></div>
-<div class="parameter"><span class="param">404</span><p>Project not found</p></div>
-<div class="parameter"><span class="param">404</span><p>Owner not found</p></div>
-<div class="parameter"><span class="param">404</span><p>Scene not found</p></div>
-<div class="parameter"><span class="param">429</span><p>Too many requests</p></div>
-</div>
+| Code | Description       |
+| ---- | ----------------- |
+| 401  | Unauthorized      |
+| 403  | Forbidden         |
+| 404  | Project not found |
+| 404  | Owner not found   |
+| 404  | Scene not found   |
+| 429  | Too many requests |
 
 ## Rate Limiting
 

--- a/docs/user-manual/api/app-get-primary.md
+++ b/docs/user-manual/api/app-get-primary.md
@@ -21,9 +21,9 @@ curl -H "Authorization: Bearer {accessToken}" https://playcanvas.com/api/project
 
 ## Parameters
 
-<div class="params">
-<div class="parameter"><span class="param">projectId: number</span><p>The id of the project.</p></div>
-</div>
+| Name        | Type     | Description            |
+| ----------- | -------- | ---------------------- |
+| `projectId` | `number` | The id of the project. |
 
 ## Response Schema
 
@@ -56,14 +56,14 @@ Status: 200
 
 ## Errors
 
-<div class="params">
-<div class="parameter"><span class="param">401</span><p>Unauthorized</p></div>
-<div class="parameter"><span class="param">403</span><p>Forbidden</p></div>
-<div class="parameter"><span class="param">404</span><p>Project not found</p></div>
-<div class="parameter"><span class="param">404</span><p>Project does not have a primary app</p></div>
-<div class="parameter"><span class="param">404</span><p>App not found</p></div>
-<div class="parameter"><span class="param">429</span><p>Too many requests</p></div>
-</div>
+| Code | Description                         |
+| ---- | ----------------------------------- |
+| 401  | Unauthorized                        |
+| 403  | Forbidden                           |
+| 404  | Project not found                   |
+| 404  | Project does not have a primary app |
+| 404  | App not found                       |
+| 429  | Too many requests                   |
 
 ## Rate Limiting
 

--- a/docs/user-manual/api/app-get-project.md
+++ b/docs/user-manual/api/app-get-project.md
@@ -21,9 +21,9 @@ curl -H "Authorization: Bearer {accessToken}" https://playcanvas.com/api/project
 
 ## Parameters
 
-<div class="params">
-<div class="parameter"><span class="param">projectId: number</span><p>The id of the project.</p></div>
-</div>
+| Name        | Type     | Description            |
+| ----------- | -------- | ---------------------- |
+| `projectId` | `number` | The id of the project. |
 
 ## Response Schema
 
@@ -61,12 +61,12 @@ Status: 200
 
 ## Errors
 
-<div class="params">
-<div class="parameter"><span class="param">401</span><p>Unauthorized</p></div>
-<div class="parameter"><span class="param">403</span><p>Forbidden</p></div>
-<div class="parameter"><span class="param">404</span><p>Project not found</p></div>
-<div class="parameter"><span class="param">429</span><p>Too many requests</p></div>
-</div>
+| Code | Description       |
+| ---- | ----------------- |
+| 401  | Unauthorized      |
+| 403  | Forbidden         |
+| 404  | Project not found |
+| 429  | Too many requests |
 
 ## Rate Limiting
 

--- a/docs/user-manual/api/app-get.md
+++ b/docs/user-manual/api/app-get.md
@@ -21,9 +21,9 @@ curl -H "Authorization: Bearer {accessToken}" https://playcanvas.com/api/apps/{i
 
 ## Parameters
 
-<div class="params">
-<div class="parameter"><span class="param">id: number</span><p>The id of the app.</p></div>
-</div>
+| Name | Type     | Description        |
+| ---- | -------- | ------------------ |
+| `id` | `number` | The id of the app. |
 
 ## Response Schema
 
@@ -56,13 +56,13 @@ Status: 200
 
 ## Errors
 
-<div class="params">
-<div class="parameter"><span class="param">401</span><p>Unauthorized</p></div>
-<div class="parameter"><span class="param">403</span><p>Forbidden</p></div>
-<div class="parameter"><span class="param">404</span><p>App not found</p></div>
-<div class="parameter"><span class="param">404</span><p>Project not found</p></div>
-<div class="parameter"><span class="param">429</span><p>Too many requests</p></div>
-</div>
+| Code | Description       |
+| ---- | ----------------- |
+| 401  | Unauthorized      |
+| 403  | Forbidden         |
+| 404  | App not found     |
+| 404  | Project not found |
+| 429  | Too many requests |
 
 ## Rate Limiting
 

--- a/docs/user-manual/api/asset-create.md
+++ b/docs/user-manual/api/asset-create.md
@@ -59,15 +59,15 @@ Content-Type: application/javascript
 ```
 ## Parameters
 
-<div class="params">
-<div class="parameter"><span class="param">name: string</span><p>Name of the asset</p></div>
-<div class="parameter"><span class="param">projectId: number</span><p>Project id to add the asset to</p></div>
-<div class="parameter"><span class="param">branchId: string</span><p>The id of the branch</p></div>
-<div class="parameter"><span class="param">parent [optional]: number</span><p>Parent asset's id</p></div>
-<div class="parameter"><span class="param">preload [optional]: boolean</span><p>Preload the asset (true | false)</p></div>
-<div class="parameter"><span class="param">file [optional]: file</span><p>Data to store as the asset file.</p></div>
-<div class="parameter"><span class="param">pow2 [optional]: boolean</span><p>Only used for textures and defaults to false. Resize the texture to power of two dimensions (true | false)</p></div>
-</div>
+| Name        | Type      | Required | Description                                                                                                 |
+| ----------- | --------- | :------: | ----------------------------------------------------------------------------------------------------------- |
+| `name`      | `string`  | ✔️      | The name of the asset.                                                                                      |
+| `projectId` | `number`  | ✔️      | The id of the project.                                                                                      |
+| `branchId`  | `string`  | ✔️      | The id of the branch.                                                                                       |
+| `parent`    | `number`  |          | Parent asset's id.                                                                                          |
+| `preload`   | `boolean` |          | Preload the asset (true | false).                                                                           |
+| `file`      | `file`    |          | Data to store as the asset file.                                                                            |
+| `pow2`      | `boolean` |          | Only used for textures and defaults to false. Resize the texture to power of two dimensions (true | false). |
 
 ## Response Schema
 
@@ -106,12 +106,12 @@ Status: 201
 
 ## Errors
 
-<div class="params">
-<div class="parameter"><span class="param">401</span><p>Unauthorized</p></div>
-<div class="parameter"><span class="param">403</span><p>Forbidden</p></div>
-<div class="parameter"><span class="param">404</span><p>Project not found</p></div>
-<div class="parameter"><span class="param">429</span><p>Too many requests</p></div>
-</div>
+| Code | Description       |
+| ---- | ----------------- |
+| 401  | Unauthorized      |
+| 403  | Forbidden         |
+| 404  | Project not found |
+| 429  | Too many requests |
 
 ## Rate Limiting
 

--- a/docs/user-manual/api/asset-delete.md
+++ b/docs/user-manual/api/asset-delete.md
@@ -11,7 +11,13 @@ GET https://playcanvas.com/api/assets/:assetId?branchId=:branchId
 
 ## Description
 
-Permanently delete an asset from a branch of your project. **Warning** deleting an asset is permanent and unrecoverable unless you have taken a checkpoint of it.
+Permanently delete an asset from a branch of your project.
+
+:::warning
+
+Deleting an asset is permanent and unrecoverable unless you have taken a checkpoint of it.
+
+:::
 
 ## Example
 
@@ -28,10 +34,10 @@ Authorization: Bearer {accessToken}
 
 ## Parameters
 
-<div class="params">
-<div class="parameter"><span class="param">assetId: number</span><p>The id of the asset to delete</p></div>
-<div class="parameter"><span class="param">branchId: string</span><p>The id of the branch to delete the asset from</p></div>
-</div>
+| Name       | Type     | Required | Description                                    |
+| ---------- | -------- | :------: | ---------------------------------------------- |
+| `assetId`  | `number` | ✔️      | The id of the asset to delete.                 |
+| `branchId` | `string` | ✔️      | The id of the branch to delete the asset from. |
 
 ## Response Schema
 
@@ -41,12 +47,12 @@ Status: 200
 
 ## Errors
 
-<div class="params">
-<div class="parameter"><span class="param">401</span><p>Unauthorized</p></div>
-<div class="parameter"><span class="param">403</span><p>Forbidden</p></div>
-<div class="parameter"><span class="param">404</span><p>Project or Asset not found</p></div>
-<div class="parameter"><span class="param">429</span><p>Too many requests</p></div>
-</div>
+| Code | Description                |
+| ---- | -------------------------- |
+| 401  | Unauthorized               |
+| 403  | Forbidden                  |
+| 404  | Project or Asset not found |
+| 429  | Too many requests          |
 
 ## Rate Limiting
 

--- a/docs/user-manual/api/asset-file.md
+++ b/docs/user-manual/api/asset-file.md
@@ -28,9 +28,11 @@ Authorization: Bearer {accessToken}
 
 ## Parameters
 
-<div class="params">
-<div class="parameter"><span class="param">branchId: string</span><p>The id of the branch.</p></div>
-</div>
+| Name       | Type     | Required | Description                |
+| ---------- | -------- | :------: | -------------------------- |
+| `assetId`  | `number` | ✔️      | The id of the asset.       |
+| `branchId` | `string` | ✔️      | The id of the branch.      |
+| `filename` | `string` | ✔️      | The filename of the asset. |
 
 ## Response Schema
 
@@ -44,12 +46,12 @@ Status: 200
 
 ## Errors
 
-<div class="params">
-<div class="parameter"><span class="param">401</span><p>Unauthorized</p></div>
-<div class="parameter"><span class="param">403</span><p>Forbidden</p></div>
-<div class="parameter"><span class="param">404</span><p>Project or Asset not found</p></div>
-<div class="parameter"><span class="param">429</span><p>Too many requests</p></div>
-</div>
+| Code | Description                |
+| ---- | -------------------------- |
+| 401  | Unauthorized               |
+| 403  | Forbidden                  |
+| 404  | Project or Asset not found |
+| 429  | Too many requests          |
 
 ## Rate Limiting
 

--- a/docs/user-manual/api/asset-get.md
+++ b/docs/user-manual/api/asset-get.md
@@ -28,9 +28,10 @@ Authorization: Bearer {accessToken}
 
 ## Parameters
 
-<div class="params">
-<div class="parameter"><span class="param">branchId: string</span><p>The id of the branch.</p></div>
-</div>
+| Name       | Type     | Required | Description           |
+| ---------- | -------- | :------: | --------------------- |
+| `assetId`  | `number` | ✔️      | The id of the asset.  |
+| `branchId` | `string` | ✔️      | The id of the branch. |
 
 ## Response Schema
 
@@ -66,12 +67,12 @@ Status: 200
 
 ## Errors
 
-<div class="params">
-<div class="parameter"><span class="param">401</span><p>Unauthorized</p></div>
-<div class="parameter"><span class="param">403</span><p>Forbidden</p></div>
-<div class="parameter"><span class="param">404</span><p>Project or Asset not found</p></div>
-<div class="parameter"><span class="param">429</span><p>Too many requests</p></div>
-</div>
+| Code | Description                |
+| ---- | -------------------------- |
+| 401  | Unauthorized               |
+| 403  | Forbidden                  |
+| 404  | Project or Asset not found |
+| 429  | Too many requests          |
 
 ## Rate Limiting
 

--- a/docs/user-manual/api/asset-list.md
+++ b/docs/user-manual/api/asset-list.md
@@ -28,12 +28,12 @@ Authorization: Bearer {accessToken}
 
 ## Parameters
 
-<div class="params">
-<div class="parameter"><span class="param">projectId: number</span><p>The id of the project to list assets from.</p></div>
-<div class="parameter"><span class="param">branchId: string</span><p>The id of the branch.</p></div>
-<div class="parameter"><span class="param">skip [optional]: number</span><p>Number of assets to skip before listing. Used for pagination. Defaults to 0.</p></div>
-<div class="parameter"><span class="param">limit [optional]: number</span><p>Maximum number of assets to list. Defaults to 16. Maximum 100000.</p></div>
-</div>
+| Name        | Type       | Required | Description                                                                  |
+| ----------- | ---------- | :------: | ---------------------------------------------------------------------------- |
+| `projectId` | `number`   | ✔️      | The id of the project.                                                       |
+| `branchId`  | `string`   | ✔️      | The id of the branch.                                                        |
+| `skip`      | `number`   |          | Number of assets to skip before listing. Used for pagination. Defaults to 0. |
+| `limit`     | `number`   |          | Maximum number of assets to list. Defaults to 16. Maximum 100000.            |
 
 ## Response Schema
 
@@ -76,12 +76,12 @@ Status: 200
 
 ## Errors
 
-<div class="params">
-<div class="parameter"><span class="param">401</span><p>Unauthorized</p></div>
-<div class="parameter"><span class="param">403</span><p>Forbidden</p></div>
-<div class="parameter"><span class="param">404</span><p>Project not found</p></div>
-<div class="parameter"><span class="param">429</span><p>Too many requests</p></div>
-</div>
+| Code | Description       |
+| ---- | ----------------- |
+| 401  | Unauthorized      |
+| 403  | Forbidden         |
+| 404  | Project not found |
+| 429  | Too many requests |
 
 ## Rate Limiting
 

--- a/docs/user-manual/api/asset-update.md
+++ b/docs/user-manual/api/asset-update.md
@@ -29,11 +29,11 @@ curl -H "Authorization: Bearer {accessToken}" -X PUT -F 'pow2={pow2}' -F 'file=@
 
 ## Parameters
 
-<div class="params">
-<div class="parameter"><span class="param">branchId: string</span><p>The id of the branch</p></div>
-<div class="parameter"><span class="param">file: file</span><p>Data to update asset file with</p></div>
-<div class="parameter"><span class="param">pow2 [optional]: boolean</span><p>Only used for textures and defaults to false. Resize the texture to power of two dimensions (true | false)</p></div>
-</div>
+| Name       | Type      | Required | Description                                                                                                 |
+| ---------- | --------- | :------: | ----------------------------------------------------------------------------------------------------------- |
+| `assetId`  | `number`  | ✔️      | The id of the asset.                                                                                        |
+| `file`     | `file`    | ✔️      | Data to update asset file with.                                                                             |
+| `pow2`     | `boolean` |          | Only used for textures and defaults to false. Resize the texture to power of two dimensions (true | false). |
 
 ## Response Schema
 
@@ -72,12 +72,12 @@ Status: 200
 
 ## Errors
 
-<div class="params">
-<div class="parameter"><span class="param">401</span><p>Unauthorized</p></div>
-<div class="parameter"><span class="param">403</span><p>Forbidden</p></div>
-<div class="parameter"><span class="param">404</span><p>Project or Asset not found</p></div>
-<div class="parameter"><span class="param">429</span><p>Too many requests</p></div>
-</div>
+| Code | Description                |
+| ---- | -------------------------- |
+| 401  | Unauthorized               |
+| 403  | Forbidden                  |
+| 404  | Project or Asset not found |
+| 429  | Too many requests          |
 
 ## Rate Limiting
 

--- a/docs/user-manual/api/branch-list.md
+++ b/docs/user-manual/api/branch-list.md
@@ -28,9 +28,9 @@ Authorization: Bearer {accessToken}
 
 ## Parameters
 
-<div class="params">
-<div class="parameter"><span class="param">projectId: number</span><p>The id of the project to list branches from</p></div>
-</div>
+| Name        | Type     | Description            |
+| ----------- | -------- | ---------------------- |
+| `projectId` | `number` | The id of the project. |
 
 ## Response Schema
 
@@ -63,12 +63,12 @@ This endpoint uses a slightly different pagination method. If a response contain
 
 ## Errors
 
-<div class="params">
-<div class="parameter"><span class="param">401</span><p>Unauthorized</p></div>
-<div class="parameter"><span class="param">403</span><p>Forbidden</p></div>
-<div class="parameter"><span class="param">404</span><p>Project not found</p></div>
-<div class="parameter"><span class="param">429</span><p>Too many requests</p></div>
-</div>
+| Code | Description       |
+| ---- | ----------------- |
+| 401  | Unauthorized      |
+| 403  | Forbidden         |
+| 404  | Project not found |
+| 429  | Too many requests |
 
 ## Rate Limiting
 

--- a/docs/user-manual/api/index.md
+++ b/docs/user-manual/api/index.md
@@ -97,12 +97,12 @@ If you are trying to GET multiple resources like for example listing the Apps of
 
 As you can notice the response in this case also contains pagination data. To control the pagination of the response you can pass the following URL parameters:
 
-<div class="params">
-<div class="parameter"><span class="param">limit</span><p>The maximum number of items to include in the response.</p></div>
-<div class="parameter"><span class="param">skip</span><p>The number of items to skip from the original result set.</p></div>
-<div class="parameter"><span class="param">sort</span><p>The name of the field to use to sort the result set. See the documentation of each request to see which values are allowed here.</p></div>
-<div class="parameter"><span class="param">order</span><p>If you want results in ascending order pass 1 otherwise pass -1 for descending order.</p></div>
-</div>
+| Name    | Description                                                                                                                      |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `limit` | The maximum number of items to include in the response.                                                                          |
+| `skip`  | The number of items to skip from the original result set.                                                                        |
+| `sort`  | The name of the field to use to sort the result set. See the documentation of each request to see which values are allowed here. |
+| `order` | If you want results in ascending order pass 1 otherwise pass -1 for descending order.                                            |
 
 So for example to get 32 items after the first 16 items you would send this request:
 
@@ -124,23 +124,22 @@ Also the status code of the response will be the appropriate HTTP error code.
 
 ## Rate Limiting
 
-Calls to the REST API have a rate limit. Check your actual limits by querying [this endpoint](https://playcanvas.com/api/ratelimits).
-There are different rate limits depending on the request:
+Calls to the REST API have a rate limit. Check your actual limits by querying [this endpoint](https://playcanvas.com/api/ratelimits). There are different rate limits depending on the request:
 
-| Rate Limit Type | Description               | Limit for free accounts          | Limit for personal/org accounts   |
-|-----------------|---------------------------|-------------------------------|--------------------------------|
-| Normal          | The normal rate limit     | 120 requests/minute    | 240 requests/minute     |
-| Strict          | The strict rate limit     | 5 requests/minute      | 10 requests/minute      |
-| Assets          | The assets rate limit     | 60 requests/minute     | 120 requests/minute     |
+| Rate Limit Type | Description               | Limit for free accounts | Limit for personal/org accounts |
+| --------------- | ------------------------- | ----------------------- | ------------------------------- |
+| Normal          | The normal rate limit     | 120 requests/minute     | 240 requests/minute             |
+| Strict          | The strict rate limit     | 5 requests/minute       | 10 requests/minute              |
+| Assets          | The assets rate limit     | 60 requests/minute      | 120 requests/minute             |
 
 
 The response will contain the following headers to help you regulate how often you call the API:
 
-<div class="params">
-<div class="parameter"><span class="param">X-RateLimit-Limit</span><p>The number of requests allowed in a minute.</p></div>
-<div class="parameter"><span class="param">X-RateLimit-Remaining</span><p>The remaining number of requests that you are allowed to make this minute.</p></div>
-<div class="parameter"><span class="param">X-RateLimit-Reset</span><p>The time at which the current rate limit window resets in <a href="https://en.wikipedia.org/wiki/Unix_time" target="_blank">UTC epoch seconds</a>.</p></div>
-</div>
+| Name                    | Description                                                                                                             |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `X-RateLimit-Limit`     | The number of requests allowed in a minute.                                                                             |
+| `X-RateLimit-Remaining` | The remaining number of requests that you are allowed to make this minute.                                              |
+| `X-RateLimit-Reset`     | The time at which the current rate limit window resets in [UTC epoch seconds](https://en.wikipedia.org/wiki/Unix_time). |
 
 If you exceed the rate limit you will get a `429 Too Many Requests` status code. You will have to wait for the current window to reset in order to continue making requests.
 

--- a/docs/user-manual/api/job-get.md
+++ b/docs/user-manual/api/job-get.md
@@ -21,9 +21,9 @@ curl -H "Authorization: Bearer {accessToken}" "https://playcanvas.com/api/jobs/{
 
 ## Parameters
 
-<div class="params">
-<div class="parameter"><span class="param">id: number</span><p>The id of the job.</p></div>
-</div>
+| Name | Type     | Description        |
+| ---- | -------- | ------------------ |
+| `id` | `number` | The id of the job. |
 
 ## Response Schema
 
@@ -44,12 +44,12 @@ Status: 200
 
 ## Errors
 
-<div class="params">
-<div class="parameter"><span class="param">401</span><p>Unauthorized</p></div>
-<div class="parameter"><span class="param">403</span><p>Forbidden</p></div>
-<div class="parameter"><span class="param">404</span><p>Job not found</p></div>
-<div class="parameter"><span class="param">429</span><p>Too many requests</p></div>
-</div>
+| Code | Description       |
+| ---- | ----------------- |
+| 401  | Unauthorized      |
+| 403  | Forbidden         |
+| 404  | Job not found     |
+| 429  | Too many requests |
 
 ## Rate Limiting
 

--- a/docs/user-manual/api/project-archive.md
+++ b/docs/user-manual/api/project-archive.md
@@ -23,10 +23,10 @@ curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json
 
 ## Parameters
 
-<div class="params">
-<div class="parameter"><span class="param">projectId: number</span><p>The id of the project.</p></div>
-<div class="parameter"><span class="param">branch_id [optional]: string</span><p>The id of the branch. If no id is specified the main branch will be used.</p></div>
-</div>
+| Name        | Type     | Required | Description                                                                |
+| ----------- | -------- | :------: | -------------------------------------------------------------------------- |
+| `projectId` | `number` | ✔️      | The id of the project.                                                     |
+| `branch_id` | `string` |          | The id of the branch. If no id is specified, the main branch will be used. |
 
 ## Response Schema
 
@@ -52,13 +52,13 @@ Status: 201 Created
 
 ## Errors
 
-<div class="params">
-<div class="parameter"><span class="param">401</span><p>Unauthorized</p></div>
-<div class="parameter"><span class="param">403</span><p>Forbidden</p></div>
-<div class="parameter"><span class="param">404</span><p>Project not found</p></div>
-<div class="parameter"><span class="param">404</span><p>Owner not found</p></div>
-<div class="parameter"><span class="param">429</span><p>Too many requests</p></div>
-</div>
+| Code | Description       |
+| ---- | ----------------- |
+| 401  | Unauthorized      |
+| 403  | Forbidden         |
+| 404  | Project not found |
+| 404  | Owner not found   |
+| 429  | Too many requests |
 
 ## Rate Limiting
 

--- a/docs/user-manual/api/scene-list.md
+++ b/docs/user-manual/api/scene-list.md
@@ -28,10 +28,10 @@ Authorization: Bearer {accessToken}
 
 ## Parameters
 
-<div class="params">
-<div class="parameter"><span class="param">projectId: number</span><p>The id of the project to list scenes from</p></div>
-<div class="parameter"><span class="param">branchId: string [optional]</span><p>The id of the branch. If no `branchId` is specified, the main branch will be used.</p></div>
-</div>
+| Name        | Type     | Required | Description                                                                |
+| ----------- | -------- | :------: | -------------------------------------------------------------------------- |
+| `projectId` | `number` | ✔️      | The id of the project.                                                     |
+| `branchId`  | `string` |          | The id of the branch. If no id is specified, the main branch will be used. |
 
 ## Response Schema
 
@@ -53,12 +53,12 @@ Status: 200
 
 ## Errors
 
-<div class="params">
-<div class="parameter"><span class="param">401</span><p>Unauthorized</p></div>
-<div class="parameter"><span class="param">403</span><p>Forbidden</p></div>
-<div class="parameter"><span class="param">404</span><p>Project not found</p></div>
-<div class="parameter"><span class="param">429</span><p>Too many requests</p></div>
-</div>
+| Code | Description       |
+| ---- | ----------------- |
+| 401  | Unauthorized      |
+| 403  | Forbidden         |
+| 404  | Project not found |
+| 429  | Too many requests |
 
 ## Rate Limiting
 


### PR DESCRIPTION
This PR migrates the REST API docs from using HTML to use vanilla Markdown tables. This is because the new Docusaurus site doesn't have the styling of the old site and as it happens, Markdown tables look more than OK. It also separates out a new column for parameter type and required/optional nature of parameters.

Old:

![image](https://github.com/playcanvas/developer.playcanvas.com/assets/697563/603c07f1-413c-45b5-a7ea-b78e5e48f6bf)

New: 

![image](https://github.com/playcanvas/developer.playcanvas.com/assets/697563/b095c1c5-368b-4481-8e80-175047890b65)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
