### PR TITLE
Fix broken anchors

### DIFF
--- a/docs/tutorials/mouse-input.md
+++ b/docs/tutorials/mouse-input.md
@@ -133,6 +133,6 @@ Try the tutorial in full screen [here][5] or at the top of the page. Move the mo
 
 [1]: https://playcanvas.com/project/405819/overview/tutorial-basic-mouse-input
 [2]: /user-manual/glossary#framework
-[3]: /user-manual/glossary#app
+[3]: /user-manual/glossary#application
 [4]: /user-manual/glossary#dom
 [5]: https://playcanv.as/p/MHIdZgaj/

--- a/docs/user-manual/animation/anim-layer-masking.md
+++ b/docs/user-manual/animation/anim-layer-masking.md
@@ -3,7 +3,7 @@ title: Anim Layer Masks
 sidebar_position: 4
 ---
 
-When creating complex animation behavior for your game objects, it is often necessary to isolate the playback of certain animations to specific bones in each object's model. This is particularly useful when animating characters that need to carry out multiple actions at the same time. This can be achieved in PlayCanvas by creating an a mask for a given [animation layer](/user-manual/animation/anim-state-graph-assets/#layers/) in your anim component.
+When creating complex animation behavior for your game objects, it is often necessary to isolate the playback of certain animations to specific bones in each object's model. This is particularly useful when animating characters that need to carry out multiple actions at the same time. This can be achieved in PlayCanvas by creating an a mask for a given [animation layer](/user-manual/animation/anim-state-graph-assets/#layers) in your anim component.
 
 ### Creating a mask
 

--- a/docs/user-manual/api/project-archive.md
+++ b/docs/user-manual/api/project-archive.md
@@ -66,4 +66,4 @@ This route uses a [strict][1] rate limit.
 
 [1]: /user-manual/api#rate-limiting
 [2]: /user-manual/api/job-get
-[3]: /user-manual/profile/projects/#import-project
+[3]: /user-manual/profile/projects/#restoring-a-project-from-an-archive-file

--- a/docs/user-manual/packs/loading-scenes.md
+++ b/docs/user-manual/packs/loading-scenes.md
@@ -211,6 +211,6 @@ The [example project][asset-load-for-scene-project] below loads the assets when 
 [loadscenedata-api]: /api/pc.SceneRegistry.html#loadSceneData
 [unloadscenedata-api]: /api/pc.SceneRegistry.html#unloadSceneData
 [copy-and-paste-assets]: /user-manual/designer/assets/#copy-and-paste-between-projects
-[asset-tags-loading]: /user-manual/assets/preloading-and-streaming/#asset-tag
+[asset-tags-loading]: /user-manual/assets/preloading-and-streaming/#asset-tags
 [asset-load-for-scene-project]: https://playcanvas.com/project/926754/overview/asset-loading-for-scenes-example
 [changescene-api]: /api/pc.SceneRegistry.html#changeScene


### PR DESCRIPTION
Fixes a number of broken anchor-based links. These are now reported as of Docusaurus 3.1.0.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
