### PR TITLE
Make all headings consistent

### DIFF
--- a/docs/tutorials/real-time-multiplayer-colyseus.md
+++ b/docs/tutorials/real-time-multiplayer-colyseus.md
@@ -22,20 +22,20 @@ thumb: https://avatars.githubusercontent.com/u/28384334?s=300&v=4
 - [PlayCanvas Project (Client-side)](https://playcanvas.com/project/859259/overview/colyseus-demo)
 - [Colyseus TypeScript Project (Server-side)](https://github.com/colyseus/tutorial-playcanvas-server)
 
-# Before you start
+## Before you start
 
-## Prior Knowledge Expected
+### Prior Knowledge Expected
 
 - Basic PlayCanvas knowledge ([See PlayCanvas Developer Resources](https://developer.playcanvas.com/))
 - Basic JavaScript/TypeScript understanding ([See TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/intro.html))
 - Basic Node.js understanding ([See Introduction to Node.js](https://nodejs.dev/en/learn/))
 
-## Software requirements
+### Software requirements
 
 - [Node.js LTS](https://nodejs.org/en/download/)
 - [Visual Studio Code](https://code.visualstudio.com/download)
 
-# Creating the Server
+## Creating the Server
 
 We will be making a basic server, hosted locally on your computer for keeping player states. Changes will be synchronized with clients accordingly.
 
@@ -64,7 +64,7 @@ If successful, the output should look like this in your command-line:
 ⚔️ Listening on ws://localhost:2567
 ```
 
-# Including the Colyseus JavaScript SDK
+## Including the Colyseus JavaScript SDK
 
 Now we need to add the Colyseus JavaScript SDK on PlayCanvas.
 
@@ -86,7 +86,7 @@ https://unpkg.com/colyseus.js@^0.15.0-preview.2/dist/colyseus.js
 
 This is going to make the `Colyseus` [JavaScript SDK](https://docs.colyseus.io/colyseus/getting-started/javascript-client/) available for our PlayCanvas scripts.
 
-# Establishing a Client-Server Connection
+## Establishing a Client-Server Connection
 
 Now, from a new PlayCanvas Script, let's instantiate our `Colyseus.Client` instance. ([see "Creating new scripts"](/user-manual/scripting/creating-new/))
 
@@ -122,7 +122,7 @@ You will be seeing the following message in your server logs, which means a clie
 19U8WkmoK joined!
 ```
 
-# Room State and Schema
+## Room State and Schema
 
 In Colyseus, we define shared data through its `Schema` structures.
 
@@ -197,20 +197,20 @@ Also, when the client disconnects, let's remove the player from the map of playe
 
 The state mutations we've done in the server-side **can be observed** in the client-side, and that's what we're going to do in the next section.
 
-# Setting up the Scene for Synchronization
+## Setting up the Scene for Synchronization
 
 For this demo, we need to create two objects in our Scene:
 
 - A Plane to represent the floor
 - A Capsule to represent the players, which we will clone for each new player joining the room.
 
-## Creating the Plane
+### Creating the Plane
 
 Let's create a Plane with scale `8`.
 
 ![Plane](/images/tutorials/multiplayer-colyseus/plane.jpg)
 
-## Creating the Player
+### Creating the Player
 
 Let's create the Player capsule with scale `1`.
 
@@ -218,11 +218,11 @@ Make sure to uncheck the `"Enabled"` property. We will not have any Player insta
 
 ![Player](/images/tutorials/multiplayer-colyseus/player.png)
 
-# Listening for State Changes
+## Listening for State Changes
 
 After a connection with the room has been established, the client-side can start listening for state changes, and create a visual representation of the data in the server.
 
-## Adding new players
+### Adding new players
 
 As per [Room State and Schema](#room-state-and-schema) section, whenever the server accepts a new connection - the `onJoin()` method is creating a new Player instance within the state.
 
@@ -271,7 +271,7 @@ this.room.state.players.onAdd((player, sessionId) => {
 // ...
 ```
 
-## The "Current Player"
+### The "Current Player"
 
 You can keep a special reference to the current player object by checking the `sessionId` against the connected `room.sessionId`:
 
@@ -286,7 +286,7 @@ this.room.state.players.onAdd((player, sessionId) => {
 });
 ```
 
-## Removing disconnected players
+### Removing disconnected players
 
 When a player is removed from the state (upon `onLeave()` in the server-side), we need to remove their visual representation as well.
 
@@ -302,9 +302,9 @@ this.room.state.players.onRemove((player, sessionId) => {
 // ...
 ```
 
-# Moving the players
+## Moving the players
 
-## Sending the new position to the server
+### Sending the new position to the server
 
 We are going to allow the "mouse down" event; use [ray cast](/user-manual/physics/ray-casting/) to determine the exact `Vec3` position the player should move towards, and then send it as a message to the server.
 
@@ -343,7 +343,7 @@ this.app.mouse.on(pc.EVENT_MOUSEDOWN, (event) => {
 });
 ```
 
-## Receiving the message from the server
+### Receiving the message from the server
 
 Whenever the `"updatePosition"` message is received in the server, we're going to mutate the player that sent the message through its `sessionId`.
 
@@ -363,7 +363,7 @@ Whenever the `"updatePosition"` message is received in the server, we're going t
 // ...
 ```
 
-## Updating Player's visual representation
+### Updating Player's visual representation
 
 Having the mutation on the server, we can detect it on the client-side via `player.onChange()`, or `player.listen()`.
 
@@ -389,7 +389,7 @@ this.room.state.players.onAdd((player, sessionId) => {
 
 > Read [more about Schema callbacks](https://docs.colyseus.io/colyseus/state/schema/#client-side)
 
-# Extra: Monitoring Rooms and Connections
+## Extra: Monitoring Rooms and Connections
 
 Colyseus comes with an optional monitoring panel that can be helpful during the development of your game.
 
@@ -401,6 +401,6 @@ You can see and interact with all spawned rooms and active client connections th
 
 > See [more information about the monitor panel](https://docs.colyseus.io/colyseus/tools/monitor/).
 
-# More
+## More
 
 We hope you found this tutorial useful, if you'd like to learn more about Colyseus please have a look at the [Colyseus documentation](https://docs.colyseus.io/), and join the [Colyseus Discord community](https://discord.gg/RY8rRS7).

--- a/docs/tutorials/real-time-multiplayer-photon.md
+++ b/docs/tutorials/real-time-multiplayer-photon.md
@@ -16,32 +16,32 @@ Photon (also known as PUN) is used in many games and has a JavaScript SDK availa
 
 Photon is for free for projects with up to 20 online players (CCU).
 
-### You will learn
+## You will learn
 
 - How to add Photon SDK to PlayCanvas
 - Multiplayer implementation with Photon
 
-# Setup
+## Setup
 
-## PlayCanvas Project
+### PlayCanvas Project
 
 We start by forking the [tutorial project here][2].
 
 ![Empty Project][3]
 
-## Photon account
+### Photon account
 
 Account registration is required to use the SDK and view documentation.
 
 Create your Photon account [here][4] - (Photon Engine).
 
-### Create a new app
+#### Create a new app
 
 Click **CREATE NEW APP** from the dashboard
 
 ![Create New Application][5]
 
-### Select Photon Type and Application name.
+#### Select Photon Type and Application name.
 
 Enter the following
 
@@ -50,49 +50,49 @@ Enter the following
 
 ![Create Real Time Project][6]
 
-### Copy of AppID
+#### Copy of AppID
 
 Please make a note of this AppId, as you will need it in the future.
 
 ![App Id][7]
 
-## Download SDK
+### Download SDK
 
 Download the SDK from the dashboard.
 
-### Click SDK from the dashboard
+#### Click SDK from the dashboard
 
 ![SDK][8]
 
-### Select RealTime JavaScript
+#### Select RealTime JavaScript
 
 ![JavaScript SDK][9]
 
-### Click Download SDK
+#### Click Download SDK
 
 ![Download SDK][10]
 
-### Unzip the SDK
+#### Unzip the SDK
 
 ![Unzip SDK][11]
 
 The SDK will be downloaded in ZIP format, unzip it: `photon-javascript-sdk_vX-X-X-X` → `lib` → **`Photon-Javascript_SDK.min.js`**.
 
-## Importing SDK
+### Importing SDK
 
 Import the SDK you have just downloaded into the PlayCanvas editor.
 
-### Upload the SDK on the editor
+#### Upload the SDK on the editor
 
 ![Upload SDK][12]
 
 Drag and drop the SDK to the assets in the editor.
 
-### Change Loading Type "Asset" to "Before Engine"
+#### Change Loading Type "Asset" to "Before Engine"
 
 ![Change Loading Type][13]
 
-# Multiplayer implementation
+## Multiplayer implementation
 
 The multiplayer implementation will do the following:
 
@@ -103,9 +103,9 @@ The multiplayer implementation will do the following:
 
 The [API reference][14] and [glossary][15] are available on Photon's site.
 
-## Using Photon with PlayCanvas
+### Using Photon with PlayCanvas
 
-### Instantiate classes from PlayCanvas to use Photon
+#### Instantiate classes from PlayCanvas to use Photon
 
 Create a script asset named **photon-loadbalancing-playcanvas.js** to the project to initialize Photon.
 
@@ -150,13 +150,13 @@ PhotonLoadBalancingPlayCanvas.prototype.initialize = function () {
 - **Photon.LoadBalancing.LoadBalancingClient**  This class contains many of the features of the Photon SDK for real-time communication.
 
 
-### Set Script for Root entity
+#### Set Script for Root entity
 
 Create a new script asset **photon-loadbalancing-playcanvas.js** and attach it to the Root entity in the Editor.
 
 ![Root Entity - Inspector][16]
 
-### Paste AppId into the script attribute.
+#### Paste AppId into the script attribute.
 
 Enter AppId as a script attribute.
 
@@ -170,9 +170,9 @@ this.loadBalancingClient = new Photon.LoadBalancing.LoadBalancingClient( this.ws
 - **appId** The application identifier value.
 - **appVersion** Used for versioning. Different versions cannot be connected to each other.
 
-## Connect to the Photon master server
+### Connect to the Photon master server
 
-### Connect to the master server using `connectToRegionMaster`
+#### Connect to the master server using `connectToRegionMaster`
 
 ```javascript
 PhotonLoadBalancingPlayCanvas.prototype.initialize = function () {
@@ -197,7 +197,7 @@ If you successfully connect to the lobby by running connectToRegionMaster, Joine
 
 ![Console Log][18]
 
-## Create or Join a room
+### Create or Join a room
 
 **onRoomList** function is called when a connection is made to the lobby.
 
@@ -235,7 +235,7 @@ PhotonLoadBalancingPlayCanvas.prototype.onJoinRoom = function (createdByMe) {
 - **joinRandomOrCreateRoom(options, createRoomName, createOptions)** Join to a random room. If the room does not exist, a new room will be created.
 - **onJoinRoom** When you join a room, this is called.
 
-## Join and Leave
+### Join and Leave
 
 When a player joins a room, it is synchronized with other players.
 Use **onActorJoin** and **onActorLeave**.
@@ -296,7 +296,7 @@ PhotonLoadBalancingPlayCanvas.prototype.onActorLeave = function (actor) {
 If successful, the entity is added when the player joins.
 ![Console log - Actors ][20]
 
-### Player Movement
+#### Player Movement
 
 Create a new **player.js** for character movement.
 
@@ -325,11 +325,11 @@ Player.prototype.update = function (dt) {
 
 - **this.app.keyboard.isPressed:** check if the keyboard is pressed
 
-## Synchronize other players
+### Synchronize other players
 
 Use **raiseEvent** and **onEvent** to synchronize the player's location.
 
-### Position synchronization using **raiseEvent**.
+#### Position synchronization using **raiseEvent**.
 
 ```javascript
 const PhotonLoadBalancingPlayCanvas = pc.createScript("PhotonLoadBalancingPlayCanvas");
@@ -446,7 +446,7 @@ PhotonLoadBalancingPlayCanvas.prototype.onEvent = function (code, content, actor
 - **raiseEvent(eventCode,data, options)** send `eventCode` and `data`.
 - **onEvent(code, content, actorNr)** receive data. Includes `actorNr` and `eventCode`.
 
-### Changed to fire events when player moves
+#### Changed to fire events when player moves
 
 ```javascript
 const Player = pc.createScript("player");

--- a/docs/user-manual/2D/index.md
+++ b/docs/user-manual/2D/index.md
@@ -5,21 +5,21 @@ sidebar_position: 17
 
 The PlayCanvas Engine is designed to make creating 3D games and applications fast and simple. However, we also support a number of great features for creating 2D games. With PlayCanvas' 2D features you get all the benefits of a powerful 3D engine but for 2D games.
 
-# Basic Features
+## Basic Features
 
-## Sprites
+### Sprites
 
 ![Sprite][5]
 
 2D graphics are often known as **Sprites**. In PlayCanvas you can create [Sprite Assets][0] and [Sprite Components][1]. The Sprite Component is attached to Entities in order to display 2D graphics in your scene. Sprite Assets in PlayCanvas store multiple image frames from a Texture Atlas in sequence. So you can use a Sprite Asset to create flip-book style animated graphics in your games.
 
-## Texture Atlases
+### Texture Atlases
 
 ![Texture Atlas][6]
 
 A [Texture Atlas][2] is a enhanced version of the standard [Texture][3] asset. In addition to the regular texture features, a Texture Atlas includes the definitions of a set of "Frames". Each frame is a region of the texture which can be referenced in a Sprite Asset.
 
-## Sprite Editor
+### Sprite Editor
 
 ![Sprite Editor][7]
 

--- a/docs/user-manual/2D/texture-packing.md
+++ b/docs/user-manual/2D/texture-packing.md
@@ -3,7 +3,7 @@ title: Using Texture Packers
 sidebar_position: 3
 ---
 
-# What is texture packing?
+## What is texture packing?
 
 It's common to find sprites or UI images bundled as separate images. Texture packing is combining those separate images into a single [texture atlas][texture-atlas].
 
@@ -12,11 +12,11 @@ This has several advantages including:
 - Faster loading times as it's a single network request instead of many.
 - As it's a single texture, the sprites can be batched into a single draw call.
 
-# Tools
+## Tools
 
 Here are some texture packing tools that are compatible with PlayCanvas.
 
-## TexturePacker Online (free)
+### TexturePacker Online (free)
 
 ([Website][texture-packer-online])
 
@@ -30,7 +30,7 @@ A free browser tool that is able to do the basics of texture packing.
 4. Download .png for the texture atlas.
 5. Download .json for the frame data.
 
-## Texture Packer tool
+### Texture Packer tool
 
 ([Website][texture-packer-tool])
 
@@ -44,7 +44,7 @@ Basic steps:
 2. Set Output files -> Framework as PlayCanvas.
 3. Click on Publish sprite sheet to create the texture atlas and JSON frame data.
 
-# Creating frames in Sprite Editor
+## Creating frames in Sprite Editor
 
 Once you have uploaded the texture atlas file into the Editor and created a [texture atlas asset][texture-atlas], open the Sprite Editor.
 

--- a/docs/user-manual/animation/index.md
+++ b/docs/user-manual/animation/index.md
@@ -5,7 +5,7 @@ sidebar_position: 15
 
 PlayCanvas provides a powerful state-based animation system which can be used to animate character models and other arbitrary scene object models. Users can work with any of their .FBX animation assets. These can be organized using animation state machines to easily control the animated behavior of scene models at runtime.
 
-# System Overview
+## System Overview
 
 The animation system touches on three main areas of the PlayCanvas platform. This section will walk through how these areas can be used together to create complex animation behavior for your models. The following sections of the animation user manual then will explore each area in more detail.
 

--- a/docs/user-manual/graphics/physical-rendering/index.md
+++ b/docs/user-manual/graphics/physical-rendering/index.md
@@ -4,11 +4,12 @@ sidebar_position: 3
 ---
 
 ![Star-Lord][1]
+
 *Star-Lord Model by [Joachim Coppens][2]*
 
 Physically based rendering (PBR) is a combination of artist workflow, measured physical properties and material shaders that work together to bring order and consistency to graphics rendering. Using the underlying physical principles of how light and surfaces interact we can create predictable visuals which work in all lighting conditions without special cases.
 
-# Fundamental Principles
+## Fundamental Principles
 
 Below, we'll try and summarize the basic principles behind how physically based shaders calculate the lighting. In the next sections we'll cover in more detail the specifics of how physically based rendering can be used with in PlayCanvas.
 

--- a/docs/user-manual/graphics/physical-rendering/physical-materials.md
+++ b/docs/user-manual/graphics/physical-rendering/physical-materials.md
@@ -27,9 +27,9 @@ There is a good explanation of the differences on the [Marmoset Toolbag blog][5]
 
 On to materials...
 
-# Material Properties and Maps
+## Material Properties and Maps
 
-## Diffuse
+### Diffuse
 
 The Diffuse Color is the base color of the material. This is an RGB color value. For clean pure (metal, plastic) substances this can be a constant value but it can also be supplied as a diffuse map texture. Note, you should usually avoid including lighting detail (shadows or highlights) in your diffuse map as this can be applied in other maps.
 
@@ -49,7 +49,7 @@ You can often find the charts of recorded values for diffuse/albedo values on th
 | Silver   | (0.972, 0.960, 0.915) or [248, 245, 233] |
 | Copper   | (0.955, 0.637, 0.538) or [244, 162, 137] |
 
-## Metalness
+### Metalness
 
 The metalness value is part of the **metalness** workflow. Metalness is a single value between 0-1 which determines if a material is metal (1) or non-metal (0).
 
@@ -65,7 +65,7 @@ You can also supply a metalness map which lets you define specific areas of your
     <iframe loading="lazy" src="https://playcanv.as/p/Q28EwTwQ/?metal" title="Physical Materials - Metalness"></iframe>
 </div>
 
-## Glossiness
+### Glossiness
 
 Glossiness is used in both  **metalness** and **specular** workflows and it defines how smooth your material surface is. The glossiness will affect how blurry or sharp the reflections on the material are, or how broad or narrow the specular highlights are. Glossiness is provided as a single value between 0-100 or a glossiness map.
 
@@ -77,7 +77,7 @@ Some PBR systems use **Roughness** instead of Glossiness. The roughness is the i
 
 Sometimes glossiness and roughness are referred to as the **microsurface** value.
 
-## All together
+### All together
 
 These three properties **diffuse**, **metalness** and **glossiness** are the core of the physical material system. You can try different combinations in the live demo below.
 

--- a/docs/user-manual/profile/projects.md
+++ b/docs/user-manual/profile/projects.md
@@ -39,23 +39,23 @@ The other user will need to accept your request to transfer the Project. The tra
 
 If the user accepts the request then the transfer will be completed and all team members apart from the new owner will be removed from the Project.
 
-# Backing Up and Restoring Projects
+## Backing Up and Restoring Projects
 
 We recommend that users create periodic backups of projects to protect against accidental deletion or malicious team members. There are several ways to do this listed below.
 
-## Forking a Project
+### Forking a Project
 
 The simplest way to create a backup of a project is to fork it. This creates a new project that is a copy of what is on the 'main' branch in the project. No version control history is preserved in the newly created fork.
 
 You can find this option on the [project dashboard][7].
 
-## Backing Up a Project to an Archive File
+### Backing Up a Project to an Archive File
 
 An archive file will contain all the data of the current project state in a branch. However, it does not contain any version control history.
 
 There are two methods to create an offline backup archive of a project:
 
-### From the Projects List
+#### From the Projects List
 
 ![export-archive][2]
 
@@ -63,7 +63,7 @@ You can export a .zip archive of your project to keep an offline backup. You can
 
 To export a project, click on the arrow next to a project and select 'Export Project'. This can only export the 'main' branch.
 
-### Using the REST API
+#### Using the REST API
 
 Exporting an archive file can also be done with the [REST API][8] and can be automated with continuous integration systems for automatic, periodic backups.
 
@@ -71,7 +71,7 @@ It also allows you to choose which branch to export via the parameters.
 
 We've written a [Node-based open source tool][9] to make this process easier for users.
 
-## Restoring a Project from an Archive File
+### Restoring a Project from an Archive File
 
 ![import-archive][3]
 

--- a/docs/user-manual/publishing/web/self-hosting-for-beginners.md
+++ b/docs/user-manual/publishing/web/self-hosting-for-beginners.md
@@ -5,11 +5,11 @@ sidebar_position: 3
 
 This document is aimed at people who are complete beginners to web programming and describes at high level how the different parts of a web application combine to serve PlayCanvas applications, or other web pages to a user's browser.
 
-# The Web Stack
+## The Web Stack
 
 In general you can separate a web application into 3 parts: Server-side, Client-side and Static content. In almost all cases you will have all three of these parts for your web application, though sometimes one or several parts will be either very simple or handled by another service.
 
-## Server-side Code
+### Server-side Code
 
 When a user opens a link in their web browser the browser sends a request to a server somewhere on the internet asking for an HTML page. At its simplest this is a page of text that sits on a hard disk on the web server and is set back over the internet to the browser.
 
@@ -51,7 +51,7 @@ There are many, many different languages and frameworks to choose from when writ
 
 When writing PlayCanvas applications, no code you write in PlayCanvas runs server-side and we don't provide any server-side code for your projects.
 
-## Client-side Code
+### Client-side Code
 
 In the web stack, the server is not the only place where we can do programming and respond to user input. Client-side refers to code running inside your browser. This code is always in Javascript, which is the language that browsers run. With client-side javascript you can perform many different operations. In the simplest case, you can modify the HTML page that was downloaded from the server
 
@@ -62,7 +62,7 @@ title.innerHTML = "This is the new title";
 
 Or in the most complex case, you can write a full 3D WebGL game using PlayCanvas. Because everything you write using PlayCanvas is client-side javascript.
 
-## Static Content
+### Static Content
 
 Some parts of your web application are not dynamic and do not need to change. For example, images, audio files, text files and in the case of PlayCanvas applications 3D models and textures. You can think of this a bit like loading files of a local disk, except that of course it comes over the internet so it's a bit slower. Serving static content is done by a web server, very much like server-side code and in some cases it will be the same machine. As there is no interactivity, there is no processing done to fulfill the request. The web server just sends back the requested file.
 

--- a/docs/user-manual/scripting/anatomy.md
+++ b/docs/user-manual/scripting/anatomy.md
@@ -33,8 +33,6 @@ Rotate.prototype.swap = function(old) {
 
 We'll break down each section of the script
 
-# Script Methods
-
 ## Declaration of Script Type
 
 ```javascript
@@ -53,7 +51,9 @@ This line declares a script attribute. A script attribute is a property of the s
 
 Attributes are automatically inherited from a new script instance during code hot-swap.
 
-## Initialize
+## Script Methods
+
+### Initialize
 
 ```javascript
 // initialize code called once per entity
@@ -69,7 +69,7 @@ When an entity is cloned using the `entity.clone` method, the `initialize` metho
 
 If a script component has multiple scripts attached to it, the `initialize` method is called in the order of the scripts on the component.
 
-## Update
+### Update
 
 ```javascript
 // update code called every frame
@@ -86,7 +86,7 @@ The update method is called for every frame; it is invoked within each entity th
 
 If a script component has multiple scripts attached to it, `update` is called in the order of the scripts on the component.
 
-## Swap
+### Swap
 
 ```javascript
 // swap method called for script hot-reloading
@@ -102,15 +102,15 @@ The `swap` method is passed the old script instance as an argument and you can u
 
 If you do not wish to support hot-swapping of code, you can delete the swap method and the engine will not attempt to refresh the script.
 
-## Additional Methods: postInitialize and postUpdate
+### Additional Methods: postInitialize and postUpdate
 
 There are two more methods that are called by the engine on scripts if they are present. `postInitialize` is called on all scripts that implement it after all scripts have been initialized. Use this method to perform functions that can assume all scripts are initialized. `postUpdate` is an update method that is called after all scripts have been updated. Use this to perform functions that can assume that all scripts have been updated. For example, a camera that is tracking another entity should update its position in `postUpdate` so that the other entity has completed its motion for the frame.
 
-# Events
+## Events
 
 Script instances fire a number of events that can be used to respond to specific circumstances.
 
-## state and enable/disable
+### state and enable/disable
 
 The `state` event is fired when the script instance changes running state from enabled to disabled or vice versa. The script instance state can be changed by enabling/disabling the script itself, the component the script is a member of, or the entity that the script component is attached to. The `enable` event fires only when the state changes from disabled to enabled, and the `disable` event fires only when the state changes from enabled to disabled.
 
@@ -141,7 +141,7 @@ Rotate.prototype.initialize = function () {
 };
 ```
 
-## destroy
+### destroy
 
 The `destroy` event is fired when the script instance is destroyed. This could be because the script was removed from the component by calling the `destroy()` method, or script component been removed from Entity, or because the Entity it was attached to was destroyed.
 
@@ -154,7 +154,7 @@ Rotate.prototype.initialize = function () {
 };
 ```
 
-## attr and attr:[name]
+### attr and attr:[name]
 
 The `attr` and `attr:[name]` events are fired when a declared script attribute value is changed. This could be in the course of running the application or it could be when changes are made to the value via the Editor. The `attr` is fired for every attribute changed. The `attr:[name]` is fired only for a specific attribute e.g. if you have an attribute called 'speed' the event `attr:speed` would be fired when the speed is changed.
 

--- a/docs/user-manual/user-interface/elements.md
+++ b/docs/user-manual/user-interface/elements.md
@@ -49,7 +49,7 @@ In this image the Anchor is set to `[0,0,1,1]` so we are anchoring the edges of 
 
 The margin property is only available when the anchor value is split in one axis. The margin sets the number of Screen component pixels from the anchor that the edge of the element will be. Shortcuts to the margin values are available in scripts on the Element component as the properties `left`, `right`, `top` and `bottom`.
 
-# Loose Elements
+## Loose Elements
 
 Whilst the primary use-case of Elements is to be part of a User Interface Screen Component. It is valid to have an Element component which is not part of a screen. For example, a single in-world piece of text.
 


### PR DESCRIPTION
All titles in Docusaurus should start as `##` (not `#`).

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
