### PR TITLE
Removed conditional base url

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -16,7 +16,7 @@ const config = {
   url: 'https://developer.playcanvas.com',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: process.env.NODE_ENV === 'production' ? '/developer.playcanvas.com/' : '/',
+  baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
Removes the uncessary conditional `process.env.NODE_ENV === 'production' ? '/developer.playcanvas.com/' : ` which broke local production builds.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
