### PR TITLE
Added home page links

### DIFF
--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -5,11 +5,13 @@ import styles from './styles.module.css';
 import UserManualImage from '@site/static/img/playcanvas-user-manual.png';
 import TutorialsImage from '@site/static/img/playcanvas-tutorials.png';
 import ApiReferenceImage from '@site/static/img/playcanvas-api-reference.png';
+import Link from '@docusaurus/Link';
 
 const FeatureList = [
   {
     title: 'User Manual',
     Image: UserManualImage,
+    Url: './user-manual',
     description: (
       <>
         Learn about every aspect of PlayCanvas, from the basics to advanced.
@@ -19,6 +21,7 @@ const FeatureList = [
   {
     title: 'Tutorials',
     Image: TutorialsImage,
+    Url: './tutorials',
     description: (
       <>
         Real world applications of PlayCanvas that make learning both fun and
@@ -38,16 +41,18 @@ const FeatureList = [
   },
 ];
 
-function Feature({Image, title, description}) {
+function Feature({Image, title, description, Url}) {
   return (
     <div className={clsx('col col--4')}>
-      <div className="text--center">
-        <img src={Image} alt={title} className={styles.featureImg} />
-      </div>
-      <div className="text--center padding-horiz--md">
-        <Heading as="h3">{title}</Heading>
-        <p>{description}</p>
-      </div>
+      <Link to={Url}>
+        <div className="text--center">
+          <img src={Image} alt={title} className={styles.featureImg} />
+        </div>
+        <div className="text--center padding-horiz--md">
+          <Heading as="h3">{title}</Heading>
+          <p>{description}</p>
+        </div>
+      </Link>
     </div>
   );
 }

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -5,7 +5,17 @@
   width: 100%;
 }
 
+.features a {
+  color: var(--ifm-navbar-link-color);
+}
+
+.features a:hover {
+  color: var(--ifm-navbar-link-hover-color);
+  text-decoration: none;
+}
+
 .featureImg {
   height: 200px;
   width: 200px;
+  border-radius: .5rem;
 }


### PR DESCRIPTION
Home page features feel like they should be clickable links to the relevant sections. This PR adds that with minimal hover styling.

<img width="1611" alt="image" src="https://github.com/playcanvas/developer.playcanvas.com/assets/430764/5bc46960-01f7-4b67-8d1a-800000f45e80">

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
