### PR TITLE
Add Redirects

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -37,7 +37,13 @@ const config = {
 
   plugins: [
     [ '@docusaurus/plugin-client-redirects', {
-      createRedirects: (path) => `/en/${path}`
+      createRedirects: (path) => {
+
+        path = path.replace('/user-manual/editor/', '/user-manual/designer/');
+        path = path.replace('/user-manual/scenes/', '/user-manual/packs/');
+
+        return `/en${path}`;
+      }
     }],
     'docusaurus-plugin-sass',
   ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -35,7 +35,12 @@ const config = {
     locales: ['en', 'ja']
   },
 
-  plugins: ['docusaurus-plugin-sass'],
+  plugins: [
+    [ '@docusaurus/plugin-client-redirects', {
+      createRedirects: (path) => `/en/${path}`
+    }],
+    'docusaurus-plugin-sass',
+  ],
 
   presets: [
     [

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@docusaurus/core": "^3.1.0",
+        "@docusaurus/plugin-client-redirects": "^3.1.0",
         "@docusaurus/preset-classic": "^3.1.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
@@ -2334,6 +2335,29 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.1.0.tgz",
+      "integrity": "sha512-CuFbdciMGvtGYiIPSOpj5idsHOQUcqZWTLCmZV3ePhviekm4dRZm1+QK/BxigmSTL5ICJMGbtOQnz7bgFSWHqg==",
+      "dependencies": {
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-common": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^3.1.0",
+    "@docusaurus/plugin-client-redirects": "^3.1.0",
     "@docusaurus/preset-classic": "^3.1.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",


### PR DESCRIPTION
This PR adds the docusaurus redirects plugin and redirects any path starting in `/en` to the root. This should help solve existing inbound links which use `/en/**/*`. 

Note this only works in production, not in dev, also it does not cover all situations as there are new routes used in the docusaurus upgrade.


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
