### PR TITLE
Replaces api links to typedoc links

### DIFF
--- a/docs/shader-editor/window-layout/inspector-pane/material-inspector.md
+++ b/docs/shader-editor/window-layout/inspector-pane/material-inspector.md
@@ -33,4 +33,4 @@ The parameters section lists the parameter nodes placed on the graph. The names 
 
 [1]: /images/shader-editor/inspector-pane-material.png
 [2]: /shader-editor/window-layout/assets-pane
-[3]: /api/pc.Material.html#blendType
+[3]: https://api.playcanvas.com/classes/Engine.Material.html#blendType

--- a/docs/tutorials/Using-forces-on-rigid-bodies.md
+++ b/docs/tutorials/Using-forces-on-rigid-bodies.md
@@ -183,12 +183,12 @@ DynamicBody.prototype.reset = function () {
 };
 ```
 
-[1]: /api/pc.RigidBodyComponent.html#applyForce
-[2]: /api/pc.RigidBodyComponent.html#applyImpulse
-[3]: /api/pc.RigidBodyComponent.html#applyTorque
-[4]: /api/pc.RigidBodyComponent.html#applyTorqueImpulse
-[5]: /api/pc.Vec3.html
-[6]: /api/pc.CollisionComponent.html
+[1]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html#applyForce
+[2]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html#applyImpulse
+[3]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html#applyTorque
+[4]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html#applyTorqueImpulse
+[5]: https://api.playcanvas.com/classes/Engine.Vec3.html
+[6]: https://api.playcanvas.com/classes/Engine.CollisionComponent.html
 [7]: /api/pc.html
 [8]: /tutorials/first-person-movement/
 [9]: /tutorials/collision-and-triggers/

--- a/docs/tutorials/audio-effects.md
+++ b/docs/tutorials/audio-effects.md
@@ -68,4 +68,4 @@ You can find out more about the Sound Component API [here][8].
 [5]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API
 [6]: https://developer.mozilla.org/en-US/docs/Web/API/ConvolverNode
 [7]: https://developer.mozilla.org/en-US/docs/Web/API/ConvolverNode/buffer
-[8]: /api/pc.Sound.html
+[8]: https://api.playcanvas.com/classes/Engine.Sound.html

--- a/docs/tutorials/collision-and-triggers.md
+++ b/docs/tutorials/collision-and-triggers.md
@@ -140,5 +140,7 @@ And that's all there is to handling Collisions and Triggers in PlayCanvas.
 [5]: /user-manual/scenes/components/rigidbody/
 [6]: /images/tutorials/collision/ground_setup.png
 [7]: /images/tutorials/collision/trigger_setup.jpg
-[8]: /api/pc.Entity.html
+[8]: https://api.playcanvas.com/classes/Engine.Entity.html
+
+/classes/Engine.Entity.html
 [9]: /images/tutorials/collision/box_setup.png

--- a/docs/tutorials/controlling-lights.md
+++ b/docs/tutorials/controlling-lights.md
@@ -125,5 +125,5 @@ LightHandler.prototype.pivot = function () {
 };
 ```
 
-[1]: /api/pc.LightComponent.html
+[1]: https://api.playcanvas.com/classes/Engine.LightComponent.html
 [2]: https://playcanvas.com/project/405812/overview/tutorial-controlling-lights

--- a/docs/tutorials/custom-posteffect.md
+++ b/docs/tutorials/custom-posteffect.md
@@ -150,9 +150,9 @@ For more tutorials on custom shaders look [here][6].
 See the [Custom Post Effects project here][7].
 
 [1]: https://github.com/playcanvas/engine/tree/master/scripts/posteffects
-[2]: /api/pc.Shader.html
-[4]: /api/pc.PostEffect.html
+[2]: https://api.playcanvas.com/classes/Engine.Shader.html
+[4]: https://api.playcanvas.com/classes/Engine.PostEffect.html
 [3]: /user-manual/scenes/components/camera
 [6]: /tutorials/custom-shaders/
-[5]: /api/pc.CameraComponent.html#postEffects
+[5]: https://api.playcanvas.com/classes/Engine.CameraComponent.html#postEffects
 [7]: https://playcanvas.com/project/406045

--- a/docs/tutorials/custom-shaders.md
+++ b/docs/tutorials/custom-shaders.md
@@ -285,7 +285,7 @@ CustomShader.prototype.update = function(dt) {
 
 Here is the complete script. Remember you'll need to create vertex shader and fragment shader assets in order for it to work.
 
-[1]: /api/pc.Shader.html
+[1]: https://api.playcanvas.com/classes/Engine.Shader.html
 [2]: /user-manual/scripting/script-attributes/
 [3]: /user-manual/graphics/physical-rendering/physical-materials/
 [project]: https://playcanvas.com/project/406044/overview/tutorial-custom-shaders

--- a/docs/tutorials/entity-picking.md
+++ b/docs/tutorials/entity-picking.md
@@ -146,5 +146,5 @@ PickerFramebuffer.prototype.onSelect = function (event) {
 ```
 
 [1]: https://playcanvas.com/project/405856
-[2]: /api/pc.RigidBodyComponentSystem.html#raycastFirst
-[3]: /api/pc.Picker.html
+[2]: https://api.playcanvas.com/classes/Engine.RigidBodyComponentSystem.html#raycastFirst
+[3]: https://api.playcanvas.com/classes/Engine.Picker.html

--- a/docs/tutorials/first-person-movement.md
+++ b/docs/tutorials/first-person-movement.md
@@ -145,4 +145,4 @@ FirstPersonMovement.prototype._createCamera = function () {
 
 [1]: https://playcanvas.com/project/405842
 [2]: /images/tutorials/beginner/first_person_movement/rigidbody_attributes.jpg
-[3]: /api/pc.RigidBodyComponent.html#applyForce
+[3]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html#applyForce

--- a/docs/tutorials/light-halos.md
+++ b/docs/tutorials/light-halos.md
@@ -129,4 +129,4 @@ That's it. A simple but pretty effect to add to your scene. Take a look at the [
 [2]: /images/tutorials/intermediate/light-halos/material.png
 [3]: /images/tutorials/intermediate/light-halos/entity-setup.jpg
 [4]: https://playcanvas.com/project/406040
-[5]: /api/pc.MeshInstance.html
+[5]: https://api.playcanvas.com/classes/Engine.MeshInstance.html

--- a/docs/tutorials/music-visualizer.md
+++ b/docs/tutorials/music-visualizer.md
@@ -137,4 +137,4 @@ This is just a taster of how you can visualize your music. Why not try scaling 3
 [1]: https://playcanvas.com/project/405891
 [2]: https://developer.mozilla.org/en/docs/Web/API/AudioContext
 [3]: https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode
-[4]: /api/pc.Application.html#renderLines
+[4]: https://api.playcanvas.com/classes/Engine.Application.html#renderLines

--- a/docs/tutorials/procedural-levels.md
+++ b/docs/tutorials/procedural-levels.md
@@ -57,5 +57,5 @@ Generate.prototype.initialize = function() {
 };
 ```
 
-[1]: /api/pc.Entity.html#clone
+[1]: https://api.playcanvas.com/classes/Engine.Entity.html#clone
 [2]: https://playcanvas.com/project/405864

--- a/docs/tutorials/terrain-generation.md
+++ b/docs/tutorials/terrain-generation.md
@@ -164,5 +164,5 @@ Terrain.prototype.createTerrainFromHeightMap = function (img, subdivisions) {
 };
 ```
 
-[1]: /api/pc.Mesh.html
+[1]: https://api.playcanvas.com/classes/Engine.Mesh.html
 [2]: https://playcanvas.com/project/406046

--- a/docs/tutorials/touch-joypad.md
+++ b/docs/tutorials/touch-joypad.md
@@ -142,8 +142,8 @@ console.log('Was pressed: ' + buttons.wasPressed('button0'));
 [adding-left-half-joystick]: /images/tutorials/touchscreen-joypad-controls/adding-left-half-joystick.gif
 [adding-button]: /images/tutorials/touchscreen-joypad-controls/adding-button.gif
 [joystick-layout]: /images/tutorials/touchscreen-joypad-controls/joystick-layout.png
-[pc-app-mouse-api]: /api/pc.Mouse.html
-[pc-app-touch-api]: /api/pc.Touch.html
+[pc-app-mouse-api]: https://api.playcanvas.com/classes/Engine.Mouse.html
+[pc-app-touch-api]: https://api.playcanvas.com/classes/Engine.Touch.html
 [elements-manual]: /user-manual/user-interface/elements/
 [joystick-script-attributes]: /images/tutorials/touchscreen-joypad-controls/joystick-script-attributes.gif
 [joystick-fixed]: /images/tutorials/touchscreen-joypad-controls/joystick-fixed.gif

--- a/docs/tutorials/ui-elements-buttons.md
+++ b/docs/tutorials/ui-elements-buttons.md
@@ -150,4 +150,4 @@ These events will only fire if Use Input is enabled on the Element component so 
 [5]: /images/tutorials/ui/buttons/screen.png
 [6]: /images/tutorials/ui/buttons/button.png
 [elements-tutorial]: /user-manual/user-interface/elements/
-[click-event-api]: /api/pc.ButtonComponent.html#event:click
+[click-event-api]: https://api.playcanvas.com/classes/Engine.ButtonComponent.html#event:click

--- a/docs/tutorials/ui-elements-progress.md
+++ b/docs/tutorials/ui-elements-progress.md
@@ -111,4 +111,4 @@ Changing the `width` makes the fill image larger and changing the `rect` makes s
 [5]: /images/tutorials/ui/progressbar/screen.png
 [6]: /images/tutorials/ui/progressbar/progress-bar-bg.png
 [7]: /images/tutorials/ui/progressbar/progress-bar-fill.png
-[8]: /api/pc.ElementComponent.html#rect
+[8]: https://api.playcanvas.com/classes/Engine.ElementComponent.html#rect

--- a/docs/tutorials/using-assets.md
+++ b/docs/tutorials/using-assets.md
@@ -202,9 +202,9 @@ this.app.assets.load(asset);
 
 The `asset.ready()` method will call it's callback as soon as the asset is loaded, if the asset is already loaded, it will call it straight away. `app.assets.load()` does nothing if the asset is already loaded.
 
-[1]: /api/pc.AssetRegistry.html
+[1]: https://api.playcanvas.com/classes/Engine.AssetRegistry.html
 [3]: https://playcanvas.com/project/406036
 [5]: /downloads/tutorials/A.dae
 [6]: /downloads/tutorials/B.dae
 [7]: /downloads/tutorials/C.dae
-[8]: /api/pc.RenderComponent.html#asset
+[8]: https://api.playcanvas.com/classes/Engine.RenderComponent.html#asset

--- a/docs/tutorials/webxr-ray-input.md
+++ b/docs/tutorials/webxr-ray-input.md
@@ -107,10 +107,10 @@ This UI interaction is agnostic to input source: either it originates from VR ha
 [1]: https://playcanvas.com/project/460449/overview/webvr-ray-input
 [2]: /user-manual/xr/using-webxr/
 [3]: /user-manual/user-interface/
-[4]: /api/pc.XrInput.html
-[5]: /api/pc.XrInputSource.html
-[6]: /api/pc.ButtonComponent.html
-[7]: /api/pc.ElementComponent.html
-[8]: /api/pc.XrInputSource.html#getOrigin
-[9]: /api/pc.XrInputSource.html#getDirection
-[10]: /api/pc.ButtonComponent.html#event:click
+[4]: https://api.playcanvas.com/classes/Engine.XrInput.html
+[5]: https://api.playcanvas.com/classes/Engine.XrInputSource.html
+[6]: https://api.playcanvas.com/classes/Engine.ButtonComponent.html
+[7]: https://api.playcanvas.com/classes/Engine.ElementComponent.html
+[8]: https://api.playcanvas.com/classes/Engine.XrInputSource.html#getOrigin
+[9]: https://api.playcanvas.com/classes/Engine.XrInputSource.html#getDirection
+[10]: https://api.playcanvas.com/classes/Engine.ButtonComponent.html#event:click

--- a/docs/user-manual/assets/import-pipeline/import-hierarchy.md
+++ b/docs/user-manual/assets/import-pipeline/import-hierarchy.md
@@ -63,6 +63,6 @@ How the Editor decides what is a new or removed mesh instance is done by the fol
 [material_asset]: /user-manual/assets/materials/physical-material/
 [texture_asset]: /user-manual/assets/textures/
 [template_asset]: /user-manual/templates/
-[render_component]: /api/pc.RenderComponent.html
-[collision_component]: /api/pc.CollisionComponent.html
+[render_component]: https://api.playcanvas.com/classes/Engine.RenderComponent.html
+[collision_component]: https://api.playcanvas.com/classes/Engine.CollisionComponent.html
 [first_model_animation_import]: /tutorials/importing-first-model-and-animation/

--- a/docs/user-manual/editor/assets.md
+++ b/docs/user-manual/editor/assets.md
@@ -125,4 +125,4 @@ Selecting a reference will load it into the Inspector panel.
 [4]: /user-manual/editor/settings
 [5]: /images/user-manual/editor/assets-panel/unreferenced-asset.png
 [6]: /images/user-manual/editor/assets-panel/asset-references.png
-[7]: /api/pc.AssetRegistry.html#findByTag
+[7]: https://api.playcanvas.com/classes/Engine.AssetRegistry.html#findByTag

--- a/docs/user-manual/graphics/advanced-rendering/batching.md
+++ b/docs/user-manual/graphics/advanced-rendering/batching.md
@@ -93,6 +93,6 @@ In this animation we have created 4 batch groups for the buildings, the cacti, t
 [5]: /images/user-manual/optimization/batching/western-animation.gif
 [6]: /user-manual/editor/settings/#batch-groups
 [7]: /user-manual/scenes/components/model
-[8]: /api/pc.BatchManager.html
+[8]: https://api.playcanvas.com/classes/Engine.BatchManager.html
 [9]: /user-manual/scenes/components/sprite
 [10]: /user-manual/scenes/components/element

--- a/docs/user-manual/graphics/cameras/depth-layer.md
+++ b/docs/user-manual/graphics/cameras/depth-layer.md
@@ -26,8 +26,8 @@ These engine examples demonstrate the rendering of both the depth and the color 
 - GrabPass demonstrates the use of the color buffer: [`GrabPass`][2]
 - GroundFog demonstrates the use of the depth buffer: [`GroundFog`][3]
 
-[0]: /api/pc.CameraComponent.html#requestSceneColorMap
-[1]: /api/pc.CameraComponent.html#requestSceneDepthMap
+[0]: https://api.playcanvas.com/classes/Engine.CameraComponent.html#requestSceneColorMap
+[1]: https://api.playcanvas.com/classes/Engine.CameraComponent.html#requestSceneDepthMap
 [2]: https://playcanvas.github.io/#/graphics/grab-pass
 [3]: https://playcanvas.github.io/#/graphics/ground-fog
 [4]: /user-manual/graphics/layers/#choosing-the-layer-order

--- a/docs/user-manual/graphics/lighting/clustered-lighting.md
+++ b/docs/user-manual/graphics/lighting/clustered-lighting.md
@@ -132,5 +132,5 @@ this.app.scene.lighting.debugLayer = undefined;
 [manual-split]: /images/user-manual/graphics/lighting/lights/manual_split.png
 [clustered-lighting-ui]: /images/user-manual/graphics/lighting/lights/clustered_lighting_ui.png
 [shadows]: /user-manual/graphics/lighting/shadows/#soft-shadows-vs-hard-shadows
-[pc-layer-api]: /api/pc.Layer.html
-[pc-lighting-debug-layer-api]: /api/pc.LightingParams.html#debugLayer
+[pc-layer-api]: https://api.playcanvas.com/classes/Engine.Layer.html
+[pc-lighting-debug-layer-api]: https://api.playcanvas.com/classes/Engine.LightingParams.html#debugLayer

--- a/docs/user-manual/graphics/particles.md
+++ b/docs/user-manual/graphics/particles.md
@@ -44,5 +44,5 @@ Soft particles are particles that are faded out near their intersections with sc
 [2]: /images/user-manual/graphics/particles/particle_system_create.png
 [3]: /images/user-manual/graphics/particles/particle_system_default.gif
 [4]: /user-manual/scenes/components/particlesystem
-[5]: /api/pc.ParticleSystemComponent.html#depthSoftening
+[5]: https://api.playcanvas.com/classes/Engine.ParticleSystemComponent.html#depthSoftening
 [6]: /user-manual/graphics/cameras/depth-layer

--- a/docs/user-manual/optimization/guidelines.md
+++ b/docs/user-manual/optimization/guidelines.md
@@ -39,7 +39,7 @@ Here are some tips and hints on how to achieve good performance in your PlayCanv
 
 [1]: /user-manual/graphics/advanced-rendering/batching
 [2]: /user-manual/optimization/runtime-devicepixelratio
-[3]: /api/pc.Application.html#autoRender
-[4]: /api/pc.Application.html#renderNextFrame
-[5]: /api/pc.RenderComponent.html#customAabb
-[6]: /api/pc.ModelComponent.html#customAabb
+[3]: https://api.playcanvas.com/classes/Engine.Application.html#autoRender
+[4]: https://api.playcanvas.com/classes/Engine.Application.html#renderNextFrame
+[5]: https://api.playcanvas.com/classes/Engine.RenderComponent.html#customAabb
+[6]: https://api.playcanvas.com/classes/Engine.ModelComponent.html#customAabb

--- a/docs/user-manual/optimization/runtime-devicepixelratio.md
+++ b/docs/user-manual/optimization/runtime-devicepixelratio.md
@@ -75,6 +75,6 @@ We also recommend to have an option in the application for the user to be able t
 [1]: /images/user-manual/optimization/device-pixel-ratio/device-pixel-ratio-closeup.jpg
 [2]: /images/user-manual/optimization/device-pixel-ratio/device-pixel-ratio.jpg
 [3]: /images/user-manual/optimization/device-pixel-ratio/device-pixel-ratio-setting.png
-[4]: /api/pc.GraphicsDevice.html#maxPixelRatio
+[4]: https://api.playcanvas.com/classes/Engine.GraphicsDevice.html#maxPixelRatio
 [5]: https://www.videocardbenchmark.net/GPU_mega_page.html
 [6]: https://www.notebookcheck.net/Smartphone-Graphics-Cards-Benchmark-List.149363.0.html

--- a/docs/user-manual/physics/forces-and-impulses.md
+++ b/docs/user-manual/physics/forces-and-impulses.md
@@ -29,4 +29,4 @@ MyScript.prototype.update = function(dt) {
 };
 ```
 
-[1]: /api/pc.RigidBodyComponent.html
+[1]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html

--- a/docs/user-manual/scenes/components/animation.md
+++ b/docs/user-manual/scenes/components/animation.md
@@ -29,4 +29,4 @@ You can control an Animation component's properties using a [script component][2
 
 [1]: /images/user-manual/scenes/components/component-animation.png
 [2]: /user-manual/scenes/components/script
-[3]: /api/pc.AnimationComponent.html
+[3]: https://api.playcanvas.com/classes/Engine.AnimationComponent.html

--- a/docs/user-manual/scenes/components/audiolistener.md
+++ b/docs/user-manual/scenes/components/audiolistener.md
@@ -14,4 +14,4 @@ You can control an Audio Listener component's properties using a [script compone
 
 [1]: /images/user-manual/scenes/components/component-audiolistener.png
 [2]: /user-manual/scenes/components/script
-[3]: /api/pc.AudioListenerComponent.html
+[3]: https://api.playcanvas.com/classes/Engine.AudioListenerComponent.html

--- a/docs/user-manual/scenes/components/button.md
+++ b/docs/user-manual/scenes/components/button.md
@@ -49,4 +49,4 @@ You can control the properties of a Button component using a [script component][
 [3]: /images/user-manual/scenes/components/component-button-sprite-change.png
 [4]: /images/user-manual/scenes/components/component-button-tint.png
 [5]: /user-manual/scenes/components/script
-[6]: /api/pc.ButtonComponent.html
+[6]: https://api.playcanvas.com/classes/Engine.ButtonComponent.html

--- a/docs/user-manual/scenes/components/camera.md
+++ b/docs/user-manual/scenes/components/camera.md
@@ -29,4 +29,4 @@ You can control a Camera component's properties using a [script component][2]. T
 
 [1]: /images/user-manual/scenes/components/component-camera.png
 [2]: /user-manual/scenes/components/script
-[3]: /api/pc.CameraComponent.html
+[3]: https://api.playcanvas.com/classes/Engine.CameraComponent.html

--- a/docs/user-manual/scenes/components/collision.md
+++ b/docs/user-manual/scenes/components/collision.md
@@ -46,4 +46,4 @@ You can control a Collision component's properties using a [script component][8]
 [6]: /images/user-manual/scenes/components/component-collision-mesh.png
 [7]: /images/user-manual/scenes/components/component-collision-sphere.png
 [8]: /user-manual/scenes/components/script
-[9]: /api/pc.CollisionComponent.html
+[9]: https://api.playcanvas.com/classes/Engine.CollisionComponent.html

--- a/docs/user-manual/scenes/components/layout-child.md
+++ b/docs/user-manual/scenes/components/layout-child.md
@@ -27,4 +27,4 @@ You can control an LayoutChild component's properties using a [script component]
 [0]: /user-manual/user-interface/layout-groups
 [1]: /images/user-manual/scenes/components/component-layoutchild.png
 [2]: /user-manual/scenes/components/script
-[3]: /api/pc.LayoutChildComponent.html
+[3]: https://api.playcanvas.com/classes/Engine.LayoutChildComponent.html

--- a/docs/user-manual/scenes/components/layout-group.md
+++ b/docs/user-manual/scenes/components/layout-group.md
@@ -29,4 +29,4 @@ You can control an LayoutGroup component's properties using a [script component]
 [0]: /user-manual/user-interface/layout-groups
 [1]: /images/user-manual/scenes/components/component-layoutgroup.png
 [2]: /user-manual/scenes/components/script
-[3]: /api/pc.LayoutGroupComponent.html
+[3]: https://api.playcanvas.com/classes/Engine.LayoutGroupComponent.html

--- a/docs/user-manual/scenes/components/light.md
+++ b/docs/user-manual/scenes/components/light.md
@@ -48,4 +48,4 @@ You can control a Light component's properties using a [script component][4]. Th
 [2]: /images/user-manual/scenes/components/component-light-point.png
 [3]: /images/user-manual/scenes/components/component-light-spot.png
 [4]: /user-manual/scenes/components/script
-[5]: /api/pc.LightComponent.html
+[5]: https://api.playcanvas.com/classes/Engine.LightComponent.html

--- a/docs/user-manual/scenes/components/model.md
+++ b/docs/user-manual/scenes/components/model.md
@@ -37,6 +37,6 @@ You can learn how to customize the materials of your model [here][4].
 
 [1]: /images/user-manual/scenes/components/component-model.png
 [2]: /user-manual/scenes/components/script
-[3]: /api/pc.ModelComponent.html
+[3]: https://api.playcanvas.com/classes/Engine.ModelComponent.html
 [4]: /user-manual/assets/materials/#assigning-materials
 [5]: /user-manual/graphics/advanced-rendering/batching

--- a/docs/user-manual/scenes/components/particlesystem.md
+++ b/docs/user-manual/scenes/components/particlesystem.md
@@ -49,4 +49,4 @@ You can control a Particle System component's properties using a [script compone
 
 [1]: /images/user-manual/scenes/components/component-particle-system.png
 [2]: /user-manual/scenes/components/script
-[3]: /api/pc.ParticleSystemComponent.html
+[3]: https://api.playcanvas.com/classes/Engine.ParticleSystemComponent.html

--- a/docs/user-manual/scenes/components/render.md
+++ b/docs/user-manual/scenes/components/render.md
@@ -29,4 +29,4 @@ You can control a render component's properties using a [script component][2]. T
 
 [1]: /images/user-manual/scenes/components/component-render.png
 [2]: /user-manual/scenes/components/script
-[3]: /api/pc.RenderComponent.html
+[3]: https://api.playcanvas.com/classes/Engine.RenderComponent.html

--- a/docs/user-manual/scenes/components/rigidbody.md
+++ b/docs/user-manual/scenes/components/rigidbody.md
@@ -42,4 +42,4 @@ You can control a Rigid Body component's properties using a [script component][5
 [3]: /images/user-manual/scenes/components/component-rigid-body-kinematic.png
 [4]: /user-manual/scenes/components/collision/
 [5]: /user-manual/scenes/components/script
-[6]: /api/pc.RigidBodyComponent.html
+[6]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html

--- a/docs/user-manual/scenes/components/script.md
+++ b/docs/user-manual/scenes/components/script.md
@@ -21,4 +21,4 @@ To edit the script in the PlayCanvas Code Editor you can either click on the hyp
 The Script component's scripting interface is [here][2].
 
 [1]: /images/user-manual/scenes/components/component-script.png
-[2]: /api/pc.ScriptComponent.html
+[2]: https://api.playcanvas.com/classes/Engine.ScriptComponent.html

--- a/docs/user-manual/scenes/components/sound.md
+++ b/docs/user-manual/scenes/components/sound.md
@@ -45,4 +45,4 @@ You can control the properties of a Sound component using a [script component][2
 
 [1]: /images/user-manual/scenes/components/component-sound.png
 [2]: /user-manual/scenes/components/script
-[3]: /api/pc.SoundComponent.html
+[3]: https://api.playcanvas.com/classes/Engine.SoundComponent.html

--- a/docs/user-manual/scenes/components/sprite.md
+++ b/docs/user-manual/scenes/components/sprite.md
@@ -66,5 +66,5 @@ You can control the properties of a Sprite component using a [script component][
 [2]: /images/user-manual/scenes/components/component-sprite-simple.png
 [3]: /images/user-manual/scenes/components/component-sprite-animated.png
 [4]: /user-manual/scenes/components/script
-[5]: /api/pc.SpriteComponent.html
+[5]: https://api.playcanvas.com/classes/Engine.SpriteComponent.html
 [6]: /user-manual/graphics/advanced-rendering/batching

--- a/docs/user-manual/scenes/loading-scenes.md
+++ b/docs/user-manual/scenes/loading-scenes.md
@@ -76,7 +76,7 @@ Scenes are represented by [Scene Registry Items][sceneregistryitem-api] that are
 
 :::note
 
-The [application root node](/api/pc.Application.html#root) is not the scene hierarchy root entity that is named 'Root' by default that you see in the scene with the Editor. The scene hierarchy root entity will be a child of the application root node.
+The [application root node](https://api.playcanvas.com/classes/Engine.Application.html#root) is not the scene hierarchy root entity that is named 'Root' by default that you see in the scene with the Editor. The scene hierarchy root entity will be a child of the application root node.
 
 :::
 
@@ -200,17 +200,17 @@ The [example project][asset-load-for-scene-project] below loads the assets when 
 [additively-loading-scenes-project]: https://playcanvas.com/project/685077/overview/additive-loading-scenes
 [templates]: /user-manual/templates/
 [assets]: /user-manual/assets/
-[loadscenehierarchy-api]: /api/pc.SceneRegistry.html#loadSceneHierarchy
-[loadscenesettings-api]: /api/pc.SceneRegistry.html#loadSceneSettings
-[sceneregistryitem-api]: /api/pc.SceneRegistryItem.html
-[sceneregistry-api]: /api/pc.SceneRegistry.html
-[application-sceneregistry-api]: /api/pc.Application.html#scenes
+[loadscenehierarchy-api]: https://api.playcanvas.com/classes/Engine.SceneRegistry.html#loadSceneHierarchy
+[loadscenesettings-api]: https://api.playcanvas.com/classes/Engine.SceneRegistry.html#loadSceneSettings
+[sceneregistryitem-api]: https://api.playcanvas.com/classes/Engine.SceneRegistryItem.html
+[sceneregistry-api]: https://api.playcanvas.com/classes/Engine.SceneRegistry.html
+[application-sceneregistry-api]: https://api.playcanvas.com/classes/Engine.Application.html#scenes
 [loadhierarchycallback-api]: /api/pc.html#LoadHierarchyCallback
 [loadsettingscallback-api]: /api/pc.html#LoadSettingsCallback
-[application-root-api]: /api/pc.Application.html#root
-[loadscenedata-api]: /api/pc.SceneRegistry.html#loadSceneData
-[unloadscenedata-api]: /api/pc.SceneRegistry.html#unloadSceneData
+[application-root-api]: https://api.playcanvas.com/classes/Engine.Application.html#root
+[loadscenedata-api]: https://api.playcanvas.com/classes/Engine.SceneRegistry.html#loadSceneData
+[unloadscenedata-api]: https://api.playcanvas.com/classes/Engine.SceneRegistry.html#unloadSceneData
 [copy-and-paste-assets]: /user-manual/editor/assets/#copy-and-paste-between-projects
 [asset-tags-loading]: /user-manual/assets/preloading-and-streaming/#asset-tags
 [asset-load-for-scene-project]: https://playcanvas.com/project/926754/overview/asset-loading-for-scenes-example
-[changescene-api]: /api/pc.SceneRegistry.html#changeScene
+[changescene-api]: https://api.playcanvas.com/classes/Engine.SceneRegistry.html#changeScene

--- a/docs/user-manual/scripting/communication.md
+++ b/docs/user-manual/scripting/communication.md
@@ -94,4 +94,4 @@ Display.prototype.initialize = function () {
 
 As you can see, this reduces the amount of set up and makes for cleaner code.
 
-[1]: /api/pc.EventHandler.html
+[1]: https://api.playcanvas.com/classes/Engine.EventHandler.html

--- a/docs/user-manual/scripting/creating-new.md
+++ b/docs/user-manual/scripting/creating-new.md
@@ -44,4 +44,4 @@ entity.script.destroy("rotate");
 [0]: /images/user-manual/scripting/new-script.png
 [1]: /images/user-manual/scripting/code-editor-new-script.png
 [2]: /images/user-manual/scripting/select-script.png
-[3]: /api/pc.AssetRegistry.html#load
+[3]: https://api.playcanvas.com/classes/Engine.AssetRegistry.html#load

--- a/docs/user-manual/scripting/script-attributes.md
+++ b/docs/user-manual/scripting/script-attributes.md
@@ -181,4 +181,4 @@ We currently do not support defining JSON attributes as children of other JSON a
 
 [1]: /images/user-manual/scripting/script-attributes.png
 [2]: /images/user-manual/scripting/script-parse-button.png
-[3]: /api/pc.ScriptAttributes.html
+[3]: https://api.playcanvas.com/classes/Engine.ScriptAttributes.html

--- a/docs/user-manual/user-interface/localization.md
+++ b/docs/user-manual/user-interface/localization.md
@@ -128,9 +128,9 @@ To retrieve the text from a key in script, use the APIs:
 For the complete engine API reference for localization see [this page][2].
 
 [1]: https://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html
-[2]: /api/pc.I18n.html
-[3]: /api/pc.I18n.html#getText
-[4]: /api/pc.I18n.html#getPluralText
+[2]: https://api.playcanvas.com/classes/Engine.I18n.html
+[3]: https://api.playcanvas.com/classes/Engine.I18n.html#getText
+[4]: https://api.playcanvas.com/classes/Engine.I18n.html#getPluralText
 [5]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString
 [6]: http://www.thai-language.com/ref/breaking-words
 [7]: https://en.wikipedia.org/wiki/Zero-width_space

--- a/docs/user-manual/xr/input-sources.md
+++ b/docs/user-manual/xr/input-sources.md
@@ -143,14 +143,14 @@ if (inputSource.profiles.indexOf('oculus-touch-v2') !== -1) {
 PlayCanvas provides a number of [tutorials and samples][11] on the usage of WebXR functionality. Users are able to fork them and examine how code and components are structured to allow for XR to be used.
 
 
-[1]: /api/pc.XrInputSource.html
-[2]: /api/pc.XrInput.html
-[3]: /api/pc.XrManager.html
+[1]: https://api.playcanvas.com/classes/Engine.XrInputSource.html
+[2]: https://api.playcanvas.com/classes/Engine.XrInput.html
+[3]: https://api.playcanvas.com/classes/Engine.XrManager.html
 [4]: https://www.w3.org/TR/webxr-gamepads-module-1/
 [5]: https://w3c.github.io/gamepad/
 [6]: https://github.com/immersive-web/webxr-input-profiles/tree/master/packages/registry
 [7]: https://immersive-web.github.io/webxr-hand-input/
-[8]: /api/pc.XrHand.html
-[9]: /api/pc.XrFinger.html
-[10]: /api/pc.XrJoint.html
+[8]: https://api.playcanvas.com/classes/Engine.XrHand.html
+[9]: https://api.playcanvas.com/classes/Engine.XrFinger.html
+[10]: https://api.playcanvas.com/classes/Engine.XrJoint.html
 [11]: /tutorials/?tags=vr

--- a/docs/user-manual/xr/using-webxr.md
+++ b/docs/user-manual/xr/using-webxr.md
@@ -118,5 +118,5 @@ app.xr.start(cameraComponent, pc.XRTYPE_VR, pc.XRSPACE_LOCAL, {
 ```
 
 [1]: /images/user-manual/xr/using-webxr/camera-offset.jpg
-[2]: /api/pc.XrManager.html
+[2]: https://api.playcanvas.com/classes/Engine.XrManager.html
 [3]: https://immersive-web.github.io/layers/


### PR DESCRIPTION
This PR replaces all relative links to the existing api site in the form of `/api/pc.Entity.html` to their typedoc equivalents of `https://api.playcanvas.com/classes/Engine.Entity.html`. It does not update any links to the `pc.html` as this does not currently exist in the typedoc site.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
