### PR TITLE
Add CNAME

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+developer.playcanvas.com


### PR DESCRIPTION
Adds a CNAME entry in the static dir which should prevent the developer.playcanva.com setting being overridden during the build and deployment

Fixes #

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
