### PR TITLE
Added redirects from /en/api/pc.* to api.playcanvas.com/classes/Engine.*

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -35,6 +35,9 @@ const config = {
 
   plugins: [
     [ '@docusaurus/plugin-client-redirects', {
+      redirects: [
+        { from: ['/api', '/en/api'], to: 'https://api.playcanvas.com' },
+      ],
       createRedirects: (path) => {
 
         path = path.replace('/user-manual/editor/', '/user-manual/designer/');

--- a/src/theme/NotFound/Content/index.js
+++ b/src/theme/NotFound/Content/index.js
@@ -1,0 +1,56 @@
+import React, { useEffect } from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Heading from '@theme/Heading';
+import { useLocation } from '@docusaurus/router';
+
+const RedirectRoutes = ({ from, to }) => {
+  const { pathname } = useLocation();
+
+  useEffect(_ => {
+    const match = pathname.match(from);
+    if (match) {
+      const redirectTo = to.replace("$1", match[1]);
+      window.location.href = redirectTo;
+    }
+
+  }, [pathname, from, to])
+}
+
+export default function NotFoundContent({className}) {
+  return (
+    <>
+      <RedirectRoutes 
+        from={/\/en\/api\/pc\.(.*)/}
+        to={"https://api.playcanvas.com/classes/Engine.$1"} />
+      <main className={clsx('container margin-vert--xl', className)}>
+        <div className="row">
+          <div className="col col--6 col--offset-3">
+            <Heading as="h1" className="hero__title">
+              <Translate
+                id="theme.NotFound.title"
+                description="The title of the 404 page">
+                Page Not Found
+              </Translate>
+            </Heading>
+            <p>
+              <Translate
+                id="theme.NotFound.p1"
+                description="The first paragraph of the 404 page">
+                We could not find what you were looking for.
+              </Translate>
+            </p>
+            <p>
+              <Translate
+                id="theme.NotFound.p2"
+                description="The 2nd paragraph of the 404 page">
+                Please contact the owner of the site that linked you to the
+                original URL and let them know their link is broken.
+              </Translate>
+            </p>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/theme/NotFound/index.js
+++ b/src/theme/NotFound/index.js
@@ -1,0 +1,19 @@
+import {translate} from '@docusaurus/Translate';
+import {PageMetadata} from '@docusaurus/theme-common';
+import Layout from '@theme/Layout';
+import NotFoundContent from '@theme/NotFound/Content';
+
+export default function Index() {
+  const title = translate({
+    id: 'theme.NotFound.title',
+    message: 'Page Not Found',
+  });
+  return (
+    <>
+      <PageMetadata title={title} />
+      <Layout>
+        <NotFoundContent />
+      </Layout>
+    </>
+  );
+}


### PR DESCRIPTION
This PR modifies the NotFound 404 page and performs a JS redirect for any route under `/en/api/pc.*` and routes it to the corresponding `api.playcanvas.com/classes/Entity.*`. Additionally this adds a declarative base redirect from `/en/api` -> api.playcanvas.com

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
