### PR TITLE
Added tutorial project links

### DIFF
--- a/docs/tutorials/animation-without-state-graph.md
+++ b/docs/tutorials/animation-without-state-graph.md
@@ -4,8 +4,12 @@ tags: [animation, tutorial, scripts]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/841793/1ED6A8-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example project on how to add and play animations without using a state graph
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/xrWromyG/" title="Animation without State Graph" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/841793/'>Open Project ↗</Link>

--- a/docs/tutorials/create-qr-code-at-runtime.md
+++ b/docs/tutorials/create-qr-code-at-runtime.md
@@ -4,8 +4,12 @@ tags: [ui, tutorial, scripts]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/1025199/3FC3F4-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Create QR codes at runtime with https://github.com/davidshimjs/qrcodejs
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/O5MDA13T/" title="Create QR Code at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/1025199/'>Open Project ↗</Link>

--- a/docs/tutorials/detecting-a-long-press.md
+++ b/docs/tutorials/detecting-a-long-press.md
@@ -4,8 +4,12 @@ tags: [touch, input, mouse, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438459/3173EE-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing how to detect a long press/touch to perform an action.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/kuSZj1KM/" title="Detecting a long press" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/438459/'>Open Project ↗</Link>

--- a/docs/tutorials/load-multiple-assets-at-runtime.md
+++ b/docs/tutorials/load-multiple-assets-at-runtime.md
@@ -4,8 +4,12 @@ tags: [loading, assets, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/439131/AC1AEB-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing how to load multiple assets at runtime.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/P7eFFj4u/" title="Load multiple assets at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/439131/'>Open Project ↗</Link>

--- a/docs/tutorials/loading-circle-ui.md
+++ b/docs/tutorials/loading-circle-ui.md
@@ -4,8 +4,12 @@ tags: [materials, ui, animation, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/705273/8B52B3-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 An example of a radial loading circle
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/WVAhW4ft/" title="Loading Circle UI" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/705273/'>Open Project ↗</Link>

--- a/docs/tutorials/loading-draco-compressed-glbs.md
+++ b/docs/tutorials/loading-draco-compressed-glbs.md
@@ -4,6 +4,8 @@ tags: [rendering, assets, tutorial, scripts]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/730372/61CE32-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 How to load a Draco compressed GLB. 
 
 See https://google.github.io/draco/ for more information on Draco 3D Data Compression.
@@ -13,3 +15,5 @@ See https://github.com/CesiumGS/gltf-pipeline for the tool to compress glTF mode
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/2uU2aYDh/" title="Loading Draco Compressed GLBs" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/730372/'>Open Project ↗</Link>

--- a/docs/tutorials/mobile-ui-safe-areas.md
+++ b/docs/tutorials/mobile-ui-safe-areas.md
@@ -4,8 +4,12 @@ tags: [ui, tutorial, scripts]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/828118/9F85DB-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example project to handle safe areas on the UI - https://developer.playcanvas.com/user-manual/user-interface/safe-area/
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/z5pXervL/" title="Mobile UI Safe Areas" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/828118/'>Open Project ↗</Link>

--- a/docs/tutorials/multiple-camera-layers.md
+++ b/docs/tutorials/multiple-camera-layers.md
@@ -4,8 +4,12 @@ tags: [rendering, camera, ui, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/593374/DF6C72-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Demonstration project that shows how to use multiple cameras and layers to render a mixed user interface of UI elements and world-space objects.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/h7V3tWZK/" title="Multiple Camera Layers" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/593374/'>Open Project ↗</Link>

--- a/docs/tutorials/pan-camera-to-target.md
+++ b/docs/tutorials/pan-camera-to-target.md
@@ -4,6 +4,8 @@ tags: [input, camera, animation, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/693889/B745F1-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 An example shows how to focus a camera on target location
 
 Credit: https://playcanvas.com/lexxik
@@ -11,3 +13,5 @@ Credit: https://playcanvas.com/lexxik
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/5SJsWtg3/" title="Pan Camera to Target" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/693889/'>Open Project ↗</Link>

--- a/docs/tutorials/physics-raycasting-by-tag.md
+++ b/docs/tutorials/physics-raycasting-by-tag.md
@@ -4,8 +4,12 @@ tags: [input, physics, raycast, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/691309/22953E-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing how to pick an entity by tag using raycastAll
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/j1aT7giL/" title="Physics raycasting by tag" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/691309/'>Open Project ↗</Link>

--- a/docs/tutorials/place-entity-without-physics.md
+++ b/docs/tutorials/place-entity-without-physics.md
@@ -4,8 +4,12 @@ tags: [input, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/437894/2D9F7B-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 A sample showing how to place objects in the world without using physics. Click on the ground to place boxes.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/Z2ieIwf8/" title="Place entity without physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/437894/'>Open Project ↗</Link>

--- a/docs/tutorials/procedural-gradient-texture.md
+++ b/docs/tutorials/procedural-gradient-texture.md
@@ -4,8 +4,12 @@ tags: [textures, rendering, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/708598/6E96B8-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example of creating a procedural texture with a gradient effect by LeXXik
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/5qggchI4/" title="Procedural Gradient Texture" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/708598/'>Open Project ↗</Link>

--- a/docs/tutorials/rainbow-trail-with-mesh-api.md
+++ b/docs/tutorials/rainbow-trail-with-mesh-api.md
@@ -4,8 +4,12 @@ tags: [rendering, shaders, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/733569/6226C8-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 A rainbow trail using the pc.Mesh API
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/jGeaTg6B/" title="Rainbow Trail with Mesh API" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/1029772/'>Open Project ↗</Link>

--- a/docs/tutorials/raycast-with-camera-viewports.md
+++ b/docs/tutorials/raycast-with-camera-viewports.md
@@ -4,8 +4,12 @@ tags: [input, camera, physics, raycast, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/964118/E9A5F1-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Raycasting with multiple camera viewports. Click on the shapes in each view
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/dXvrDzH2/" title="Raycast with Camera Viewports" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/964118/'>Open Project ↗</Link>

--- a/docs/tutorials/render-3d-world-to-ui.md
+++ b/docs/tutorials/render-3d-world-to-ui.md
@@ -4,8 +4,12 @@ tags: [rendering, camera, ui, tutorial, scripts]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/855150/6398DC-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Render 3D objects as part of the UI
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/CQzD8zlM/" title="Render 3D World to UI" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/855150/'>Open Project ↗</Link>

--- a/docs/tutorials/right-to-left-language-support.md
+++ b/docs/tutorials/right-to-left-language-support.md
@@ -4,8 +4,12 @@ tags: [ui, tutorial, scripts]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/764309/A62C41-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Scripts to use for RTL language support such Arabic
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/k2TruV1u/" title="Right to left language support" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/764309/'>Open Project ↗</Link>

--- a/docs/tutorials/sound-volume-control-using-curve.md
+++ b/docs/tutorials/sound-volume-control-using-curve.md
@@ -4,8 +4,12 @@ tags: [audio, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/436116/1F5514-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing how to control the volume of a sound slot using curve data. Click on the scene to start the audio.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/hmRciuNn/" title="Sound volume control using curve" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/436116/'>Open Project ↗</Link>

--- a/docs/tutorials/space-rocks.md
+++ b/docs/tutorials/space-rocks.md
@@ -4,8 +4,12 @@ tags: [games, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/1029772/10FC7E-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Get started making your own space shooter game by forking this template Asteroids shooter! Aim with your mouse and fire with your left button. Survive as long as you can!
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/cAFbOEtL/" title="Space Rocks!" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/1029772/'>Open Project ↗</Link>

--- a/docs/tutorials/static-batching.md
+++ b/docs/tutorials/static-batching.md
@@ -4,6 +4,10 @@ tags: [rendering, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/520389/C1E49E-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/Qo7T1kqU/" title="Static Batching" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/520389/'>Open Project ↗</Link>

--- a/docs/tutorials/stencil-buffer---3d-magic-card.md
+++ b/docs/tutorials/stencil-buffer---3d-magic-card.md
@@ -4,6 +4,8 @@ tags: [rendering, culling, materials, tutorial, scripts]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/855103/3B0AC0-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example project that uses the stencil buffer to create a magic window like effect on a card.
 
 Credit: @ alexanderrdx for the original project
@@ -11,3 +13,5 @@ Credit: @ alexanderrdx for the original project
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/RAQhfemb/" title="Stencil Buffer - 3D Magic Card" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/855103/'>Open Project ↗</Link>

--- a/docs/tutorials/tic-tac-toe.md
+++ b/docs/tutorials/tic-tac-toe.md
@@ -4,8 +4,12 @@ tags: [games, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/671439/C24512-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 The classic game Tic Tac Toe
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/i5csiIb9/" title="Tic Tac Toe" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/671439/'>Open Project ↗</Link>

--- a/docs/tutorials/timers.md
+++ b/docs/tutorials/timers.md
@@ -4,8 +4,12 @@ tags: [tutorial, time]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/691984/71DABB-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example of extending the PlayCanvas engine to create one shot timers. Press P to pause time.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/WsI6QA7y/" title="Timers" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/691984/'>Open Project ↗</Link>

--- a/docs/tutorials/tutorial-layout-groups.md
+++ b/docs/tutorials/tutorial-layout-groups.md
@@ -4,8 +4,12 @@ tags: [ui, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/553515/D4C290-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Use the Layout Group component to build a user interface.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/y4JwxWTI/" title="Tutorial: Layout Groups" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/553515/'>Open Project ↗</Link>

--- a/docs/tutorials/tutorial-normal-mapped-text.md
+++ b/docs/tutorials/tutorial-normal-mapped-text.md
@@ -4,8 +4,12 @@ tags: [textures, rendering, materials, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/371210/C1FNWI-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Dynamically generate normal maps and parallax maps for text
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/MbMb81DM/" title="Tutorial: Normal Mapped Text" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/855103/'>Open Project ↗</Link>

--- a/docs/tutorials/vhscrt-post-effect.md
+++ b/docs/tutorials/vhscrt-post-effect.md
@@ -4,8 +4,12 @@ tags: [tutorial, posteffects]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/373076/0WJ6Y8-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Basic fullscreen effect simulating a bad video screen like an old CRT.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/6hhSiHG3/" title="VHS/CRT Post Effect" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/373076/'>Open Project ↗</Link>

--- a/docs/tutorials/vignette-abberation.md
+++ b/docs/tutorials/vignette-abberation.md
@@ -4,6 +4,10 @@ tags: [tutorial, posteffects]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/440854/0F743E-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/UwEmhiJf/" title="Vignette Abberation" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/440854/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-ar-dom-overlay.md
+++ b/docs/tutorials/webxr-ar-dom-overlay.md
@@ -4,8 +4,12 @@ tags: [camera, ar, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/747233/D92E6B-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example of how to use DOM (HTML + CSS) with WebXR AR session.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/S01LYTIU/" title="WebXR AR: DOM Overlay" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/691979/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-ar-raycasting-shapes.md
+++ b/docs/tutorials/webxr-ar-raycasting-shapes.md
@@ -4,6 +4,8 @@ tags: [input, ar, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/884783/E2030C-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example of how to raycast in the PlayCanvas scene when using WebXR AR.
 
 Tap the shapes to change their color!
@@ -11,3 +13,5 @@ Tap the shapes to change their color!
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/qiLEOeL7/" title="WebXR AR Raycasting Shapes" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/884783/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-hands.md
+++ b/docs/tutorials/webxr-hands.md
@@ -4,8 +4,12 @@ tags: [input, vr, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/705931/2507B5-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample application with WebXR Hands Tracking.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/VmHVW3Wb/" title="WebXR Hands" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/705931/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-plane-detection.md
+++ b/docs/tutorials/webxr-plane-detection.md
@@ -4,8 +4,12 @@ tags: [camera, ar, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/782753/602922-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example of how to use WebXR Augmented Reality: Plane Detection API. That allows to *actively* track real world surface estimations.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/f2ESRGge/" title="WebXR: Plane Detection" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/782753/'>Open Project ↗</Link>

--- a/docs/tutorials/world-space-ui-rendering-on-top.md
+++ b/docs/tutorials/world-space-ui-rendering-on-top.md
@@ -4,8 +4,12 @@ tags: [rendering, ui, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/691979/606E3E-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Learn how to render world space UI over the top of the world
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/0Ycgs0n7/" title="World space UI rendering on top" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/691979/'>Open Project ↗</Link>


### PR DESCRIPTION
This PR adds project links back into relevant tutorials. Fixes #575

<img width="761" alt="image" src="https://github.com/playcanvas/developer.playcanvas.com/assets/430764/cf14d072-6178-4209-bea2-0ef133aef3e0">

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
