### PR TITLE
Tutorial project links

### DIFF
--- a/docs/tutorials/360-lookaround-camera.md
+++ b/docs/tutorials/360-lookaround-camera.md
@@ -13,4 +13,4 @@ Sample showing how to move the camera with mouse and touch to look around
     <iframe loading="lazy" src="https://playcanv.as/p/TMrb4ucs/" title="360 lookaround camera" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/438216/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/438216/'>Open Project ↗</Link>

--- a/docs/tutorials/360-lookaround-camera.md
+++ b/docs/tutorials/360-lookaround-camera.md
@@ -5,8 +5,12 @@ tags: [input, camera, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438216/3B51C6-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing how to move the camera with mouse and touch to look around
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/TMrb4ucs/" title="360 lookaround camera" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/438216/'>Open Project ↗</Link>

--- a/docs/tutorials/animate-entities-with-curves.md
+++ b/docs/tutorials/animate-entities-with-curves.md
@@ -12,4 +12,4 @@ Sample showing use of curves to do basic animation with curves.
     <iframe loading="lazy" src="https://playcanv.as/p/cp3OGFrJ/" title="Animate entities with curves" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/438191/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/438191/'>Open Project ↗</Link>

--- a/docs/tutorials/animate-entities-with-curves.md
+++ b/docs/tutorials/animate-entities-with-curves.md
@@ -4,8 +4,12 @@ tags: [animation, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438191/53A10A-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing use of curves to do basic animation with curves.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/cp3OGFrJ/" title="Animate entities with curves" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/438191/'>Open Project ↗</Link>

--- a/docs/tutorials/animation-without-state-graph.md
+++ b/docs/tutorials/animation-without-state-graph.md
@@ -12,4 +12,4 @@ Example project on how to add and play animations without using a state graph
     <iframe loading="lazy" src="https://playcanv.as/p/xrWromyG/" title="Animation without State Graph" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/841793/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/841793/'>Open Project ↗</Link>

--- a/docs/tutorials/animation-without-state-graph.md
+++ b/docs/tutorials/animation-without-state-graph.md
@@ -4,8 +4,12 @@ tags: [animation, tutorial, scripts]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/841793/1ED6A8-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example project on how to add and play animations without using a state graph
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/xrWromyG/" title="Animation without State Graph" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/841793/'>Open Project ↗</Link>

--- a/docs/tutorials/basic-touch-input.md
+++ b/docs/tutorials/basic-touch-input.md
@@ -4,8 +4,12 @@ tags: [touch, input, basics, mobile, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438010/E61079-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Tutorial demonstrating basic touch input in PlayCanvas. Touch the box and move it around the screen!
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/iEIZxwBC/" title="Basic touch input" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/438010/'>Open Project ↗</Link>

--- a/docs/tutorials/basic-touch-input.md
+++ b/docs/tutorials/basic-touch-input.md
@@ -12,4 +12,4 @@ Tutorial demonstrating basic touch input in PlayCanvas. Touch the box and move i
     <iframe loading="lazy" src="https://playcanv.as/p/iEIZxwBC/" title="Basic touch input" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/438010/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/438010/'>Open Project ↗</Link>

--- a/docs/tutorials/billboards.md
+++ b/docs/tutorials/billboards.md
@@ -4,8 +4,12 @@ tags: [rendering, camera, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/353938/4RTOLK-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Simple example of planes that always face the camera. i.e. billboards. Click on the box and fly around the scene with WASD
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/ZCD1bSXQ/" title="Billboards" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/353938/'>Open Project ↗</Link>

--- a/docs/tutorials/billboards.md
+++ b/docs/tutorials/billboards.md
@@ -12,4 +12,4 @@ Simple example of planes that always face the camera. i.e. billboards. Click on 
     <iframe loading="lazy" src="https://playcanv.as/p/ZCD1bSXQ/" title="Billboards" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/353938/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/353938/'>Open Project ↗</Link>

--- a/docs/tutorials/camera-following-a-path.md
+++ b/docs/tutorials/camera-following-a-path.md
@@ -12,4 +12,4 @@ Sample of a camera following points on a spline path.
     <iframe loading="lazy" src="https://playcanv.as/p/LuNJjRCr/" title="Camera following a path" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/438429/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/438429/'>Open Project ↗</Link>

--- a/docs/tutorials/camera-following-a-path.md
+++ b/docs/tutorials/camera-following-a-path.md
@@ -4,8 +4,12 @@ tags: [camera, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438429/66E9AF-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample of a camera following points on a spline path.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/LuNJjRCr/" title="Camera following a path" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/438429/'>Open Project ↗</Link>

--- a/docs/tutorials/camera-model-masking.md
+++ b/docs/tutorials/camera-model-masking.md
@@ -4,8 +4,12 @@ tags: [rendering, camera, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/436772/B47904-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing to use render masking on the lights and models to enable lighting to only affect certain models and cameras to render certain models.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/D4ZYtQrG/" title="Camera model masking" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/436772/'>Open Project ↗</Link>

--- a/docs/tutorials/camera-model-masking.md
+++ b/docs/tutorials/camera-model-masking.md
@@ -12,4 +12,4 @@ Sample showing to use render masking on the lights and models to enable lighting
     <iframe loading="lazy" src="https://playcanv.as/p/D4ZYtQrG/" title="Camera model masking" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/436772/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/436772/'>Open Project ↗</Link>

--- a/docs/tutorials/capturing-a-screenshot.md
+++ b/docs/tutorials/capturing-a-screenshot.md
@@ -4,8 +4,12 @@ tags: [rendering, camera, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438437/35C2AB-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 A sample showing how capture a screenshot from a camera and download as a PNG
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/Qlf6YvOV/" title="Capturing a screenshot" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0"/>
 </div>
+
+<Link to='https://playcanvas.com/editor/project/438437/'>Open Project ↗</Link>

--- a/docs/tutorials/capturing-a-screenshot.md
+++ b/docs/tutorials/capturing-a-screenshot.md
@@ -12,4 +12,4 @@ A sample showing how capture a screenshot from a camera and download as a PNG
     <iframe loading="lazy" src="https://playcanv.as/p/Qlf6YvOV/" title="Capturing a screenshot" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0"/>
 </div>
 
-<Link to='https://playcanvas.com/editor/project/438437/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/438437/'>Open Project ↗</Link>

--- a/docs/tutorials/changing-textures-at-runtime.md
+++ b/docs/tutorials/changing-textures-at-runtime.md
@@ -12,4 +12,4 @@ A sample showing how to change a materials texture through a script
     <iframe loading="lazy" src="https://playcanv.as/p/Ivdxse42/" title="Changing textures at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/437446/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/437446/'>Open Project ↗</Link>

--- a/docs/tutorials/changing-textures-at-runtime.md
+++ b/docs/tutorials/changing-textures-at-runtime.md
@@ -4,8 +4,12 @@ tags: [textures, assets, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/437446/54BF56-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 A sample showing how to change a materials texture through a script
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/Ivdxse42/" title="Changing textures at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/437446/'>Open Project ↗</Link>

--- a/docs/tutorials/create-qr-code-at-runtime.md
+++ b/docs/tutorials/create-qr-code-at-runtime.md
@@ -4,8 +4,12 @@ tags: [ui, tutorial, scripts]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/1025199/3FC3F4-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Create QR codes at runtime with https://github.com/davidshimjs/qrcodejs
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/O5MDA13T/" title="Create QR Code at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/1025199/'>Open Project ↗</Link>

--- a/docs/tutorials/create-qr-code-at-runtime.md
+++ b/docs/tutorials/create-qr-code-at-runtime.md
@@ -12,4 +12,4 @@ Create QR codes at runtime with https://github.com/davidshimjs/qrcodejs
     <iframe loading="lazy" src="https://playcanv.as/p/O5MDA13T/" title="Create QR Code at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/1025199/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/1025199/'>Open Project ↗</Link>

--- a/docs/tutorials/creating-rigid-bodies-in-code.md
+++ b/docs/tutorials/creating-rigid-bodies-in-code.md
@@ -10,4 +10,4 @@ import Link from '@docusaurus/Link';
     <iframe loading="lazy" src="https://playcanv.as/p/w8Hhxovk/" title="Creating Rigid Bodies in Code" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/442322/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/442322/'>Open Project ↗</Link>

--- a/docs/tutorials/creating-rigid-bodies-in-code.md
+++ b/docs/tutorials/creating-rigid-bodies-in-code.md
@@ -4,6 +4,10 @@ tags: [animation, physics, tutorial, procedural]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/442322/BABA92-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/w8Hhxovk/" title="Creating Rigid Bodies in Code" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/442322/'>Open Project ↗</Link>

--- a/docs/tutorials/detecting-a-double-click.md
+++ b/docs/tutorials/detecting-a-double-click.md
@@ -12,4 +12,4 @@ Double click on the screen to move the camera
     <iframe loading="lazy" src="https://playcanv.as/p/BSSXwNAj/" title="Detecting a double click" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/436526/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/436526/'>Open Project ↗</Link>

--- a/docs/tutorials/detecting-a-double-click.md
+++ b/docs/tutorials/detecting-a-double-click.md
@@ -4,8 +4,12 @@ tags: [input, mouse, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/436526/A98DD2-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Double click on the screen to move the camera
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/BSSXwNAj/" title="Detecting a double click" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/436526/'>Open Project ↗</Link>

--- a/docs/tutorials/detecting-a-double-tap.md
+++ b/docs/tutorials/detecting-a-double-tap.md
@@ -12,4 +12,4 @@ Sample showing how to detect a double tap on a touch screen.
     <iframe loading="lazy" src="https://playcanv.as/p/adm70VcR/" title="Detecting a double tap" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/436531/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/436531/'>Open Project ↗</Link>

--- a/docs/tutorials/detecting-a-double-tap.md
+++ b/docs/tutorials/detecting-a-double-tap.md
@@ -4,8 +4,12 @@ tags: [touch, input, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/436531/38B52B-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing how to detect a double tap on a touch screen.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/adm70VcR/" title="Detecting a double tap" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/436531/'>Open Project ↗</Link>

--- a/docs/tutorials/detecting-a-long-press.md
+++ b/docs/tutorials/detecting-a-long-press.md
@@ -4,8 +4,12 @@ tags: [touch, input, mouse, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438459/3173EE-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing how to detect a long press/touch to perform an action.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/kuSZj1KM/" title="Detecting a long press" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/438459/'>Open Project ↗</Link>

--- a/docs/tutorials/detecting-a-long-press.md
+++ b/docs/tutorials/detecting-a-long-press.md
@@ -12,4 +12,4 @@ Sample showing how to detect a long press/touch to perform an action.
     <iframe loading="lazy" src="https://playcanv.as/p/kuSZj1KM/" title="Detecting a long press" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/438459/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/438459/'>Open Project ↗</Link>

--- a/docs/tutorials/dynamic-ui-scroll-view.md
+++ b/docs/tutorials/dynamic-ui-scroll-view.md
@@ -12,4 +12,4 @@ An example of adding and removing elements from the scroll view in the UI
     <iframe loading="lazy" src="https://playcanv.as/p/XIarUWAW/" title="Dynamic UI Scroll View" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/734864/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/734864/'>Open Project ↗</Link>

--- a/docs/tutorials/dynamic-ui-scroll-view.md
+++ b/docs/tutorials/dynamic-ui-scroll-view.md
@@ -4,8 +4,12 @@ tags: [ui, tutorial, scripts]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/734864/1DC6CB-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 An example of adding and removing elements from the scroll view in the UI
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/XIarUWAW/" title="Dynamic UI Scroll View" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/734864/'>Open Project ↗</Link>

--- a/docs/tutorials/entity-picking-using-physics.md
+++ b/docs/tutorials/entity-picking-using-physics.md
@@ -12,4 +12,4 @@ A sample showing how to use the physics raycast to pick entities
     <iframe loading="lazy" src="https://playcanv.as/p/J02HZ0PC/" title="Entity picking using physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/410547/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/410547/'>Open Project ↗</Link>

--- a/docs/tutorials/entity-picking-using-physics.md
+++ b/docs/tutorials/entity-picking-using-physics.md
@@ -4,8 +4,12 @@ tags: [input, physics, tutorial, raycast]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/410547/4B3EC7-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 A sample showing how to use the physics raycast to pick entities
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/J02HZ0PC/" title="Entity picking using physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/410547/'>Open Project ↗</Link>

--- a/docs/tutorials/entity-picking-without-physics.md
+++ b/docs/tutorials/entity-picking-without-physics.md
@@ -12,4 +12,4 @@ Sample showing how to pick at objects without using the physics system (extra 1M
     <iframe loading="lazy" src="https://playcanv.as/p/Sd7PcPNL/" title="Entity picking without physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/436809/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/436809/'>Open Project ↗</Link>

--- a/docs/tutorials/entity-picking-without-physics.md
+++ b/docs/tutorials/entity-picking-without-physics.md
@@ -4,8 +4,12 @@ tags: [input, tutorial, raycast]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/436809/C6979E-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing how to pick at objects without using the physics system (extra 1MB to published project) or the frame buffer.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/Sd7PcPNL/" title="Entity picking without physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/436809/'>Open Project ↗</Link>

--- a/docs/tutorials/explosion-particle-effect.md
+++ b/docs/tutorials/explosion-particle-effect.md
@@ -4,8 +4,12 @@ tags: [particles, camera, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/439297/80EDE5-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample project showing a multi layered particle effect with screen shake.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/0hjGM2Lh/" title="Explosion Particle Effect" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/439297/'>Open Project ↗</Link>

--- a/docs/tutorials/explosion-particle-effect.md
+++ b/docs/tutorials/explosion-particle-effect.md
@@ -12,4 +12,4 @@ Sample project showing a multi layered particle effect with screen shake.
     <iframe loading="lazy" src="https://playcanv.as/p/0hjGM2Lh/" title="Explosion Particle Effect" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/439297/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/439297/'>Open Project ↗</Link>

--- a/docs/tutorials/fading-objects-in-and-out.md
+++ b/docs/tutorials/fading-objects-in-and-out.md
@@ -4,8 +4,12 @@ tags: [materials, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/436566/440B17-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing how to fade a model in and out using on a per model basis.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/kvToWplO/" title="Fading objects in and out" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/436566/'>Open Project ↗</Link>

--- a/docs/tutorials/fading-objects-in-and-out.md
+++ b/docs/tutorials/fading-objects-in-and-out.md
@@ -12,4 +12,4 @@ Sample showing how to fade a model in and out using on a per model basis.
     <iframe loading="lazy" src="https://playcanv.as/p/kvToWplO/" title="Fading objects in and out" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/436566/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/436566/'>Open Project ↗</Link>

--- a/docs/tutorials/first-person-shooter-starter-kit.md
+++ b/docs/tutorials/first-person-shooter-starter-kit.md
@@ -4,8 +4,12 @@ tags: [input, camera, tutorial, scripts]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/626211/DDDD48-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example project that extends the First Person Camera tutorial to move and jump around a 3D level
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/deRCEGms/" title="First Person Shooter Starter Kit" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/626211/'>Open Project ↗</Link>

--- a/docs/tutorials/first-person-shooter-starter-kit.md
+++ b/docs/tutorials/first-person-shooter-starter-kit.md
@@ -12,4 +12,4 @@ Example project that extends the First Person Camera tutorial to move and jump a
     <iframe loading="lazy" src="https://playcanv.as/p/deRCEGms/" title="First Person Shooter Starter Kit" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/626211/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/626211/'>Open Project ↗</Link>

--- a/docs/tutorials/flaming-fireball.md
+++ b/docs/tutorials/flaming-fireball.md
@@ -12,4 +12,4 @@ Sample with a fireball that moves with the mouse
     <iframe loading="lazy" src="https://playcanv.as/p/eavVneJi/" title="Flaming fireball" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/439385/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/439385/'>Open Project ↗</Link>

--- a/docs/tutorials/flaming-fireball.md
+++ b/docs/tutorials/flaming-fireball.md
@@ -4,8 +4,12 @@ tags: [particles, input, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/439385/DECA7B-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample with a fireball that moves with the mouse
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/eavVneJi/" title="Flaming fireball" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/439385/'>Open Project ↗</Link>

--- a/docs/tutorials/flappy-bird.md
+++ b/docs/tutorials/flappy-bird.md
@@ -12,4 +12,4 @@ Flappy's Back! Guide Flappy Bird through as many pipes as you can. Made with @pl
     <iframe loading="lazy" src="https://playcanv.as/p/2OlkUaxF/" title="Flappy Bird" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/375389/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/375389/'>Open Project ↗</Link>

--- a/docs/tutorials/flappy-bird.md
+++ b/docs/tutorials/flappy-bird.md
@@ -4,8 +4,12 @@ tags: [games, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/8/375389/23PRTL-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Flappy's Back! Guide Flappy Bird through as many pipes as you can. Made with @playcanvas
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/2OlkUaxF/" title="Flappy Bird" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/375389/'>Open Project ↗</Link>

--- a/docs/tutorials/frames-per-sec-fps-counter.md
+++ b/docs/tutorials/frames-per-sec-fps-counter.md
@@ -4,8 +4,12 @@ tags: [rendering, tutorial, scripts]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/433323/373838-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample with self contained FPS counter that can be used in other projects.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/VRCXOsxi/" title="Frames Per Sec (FPS) counter" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/433323/'>Open Project ↗</Link>

--- a/docs/tutorials/frames-per-sec-fps-counter.md
+++ b/docs/tutorials/frames-per-sec-fps-counter.md
@@ -12,4 +12,4 @@ Sample with self contained FPS counter that can be used in other projects.
     <iframe loading="lazy" src="https://playcanv.as/p/VRCXOsxi/" title="Frames Per Sec (FPS) counter" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/433323/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/433323/'>Open Project ↗</Link>

--- a/docs/tutorials/htmlcss---live-updates.md
+++ b/docs/tutorials/htmlcss---live-updates.md
@@ -4,8 +4,12 @@ tags: [html, ui, assets, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/354600/0FD3B1-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example of how to use live HTML and CSS editing.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/KqqOGvVi/" title="HTML/CSS - Live Updates" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/354600/'>Open Project ↗</Link>

--- a/docs/tutorials/htmlcss---live-updates.md
+++ b/docs/tutorials/htmlcss---live-updates.md
@@ -12,4 +12,4 @@ Example of how to use live HTML and CSS editing.
     <iframe loading="lazy" src="https://playcanv.as/p/KqqOGvVi/" title="HTML/CSS - Live Updates" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/354600/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/354600/'>Open Project ↗</Link>

--- a/docs/tutorials/htmlcss-ui.md
+++ b/docs/tutorials/htmlcss-ui.md
@@ -12,4 +12,4 @@ Example of how to use HTML and CSS to create UI
     <iframe loading="lazy" src="https://playcanv.as/p/B4W3iveA/" title="HTML/CSS UI" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/443090/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/443090/'>Open Project ↗</Link>

--- a/docs/tutorials/htmlcss-ui.md
+++ b/docs/tutorials/htmlcss-ui.md
@@ -4,8 +4,12 @@ tags: [html, ui, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/443090/3B31E1-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example of how to use HTML and CSS to create UI
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/B4W3iveA/" title="HTML/CSS UI" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/443090/'>Open Project ↗</Link>

--- a/docs/tutorials/information-hotspots.md
+++ b/docs/tutorials/information-hotspots.md
@@ -12,4 +12,4 @@ Sample showing information hotspots on a scene.
     <iframe loading="lazy" src="https://playcanv.as/p/9yrH9xRZ/" title="Information hotspots" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/438515/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/438515/'>Open Project ↗</Link>

--- a/docs/tutorials/information-hotspots.md
+++ b/docs/tutorials/information-hotspots.md
@@ -4,8 +4,12 @@ tags: [rendering, camera, raycast, tutorial, input]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438515/CA0481-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing information hotspots on a scene.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/9yrH9xRZ/" title="Information hotspots" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/438515/'>Open Project ↗</Link>

--- a/docs/tutorials/load-assets-with-a-progress-bar.md
+++ b/docs/tutorials/load-assets-with-a-progress-bar.md
@@ -12,4 +12,4 @@ Sample showing how to load multiple assets at runtime with a progress bar.
     <iframe loading="lazy" src="https://playcanv.as/p/MGKfj6jm/" title="Load assets with a progress bar" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/436584/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/436584/'>Open Project ↗</Link>

--- a/docs/tutorials/load-assets-with-a-progress-bar.md
+++ b/docs/tutorials/load-assets-with-a-progress-bar.md
@@ -4,8 +4,12 @@ tags: [assets, tutorial, scripts]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/436584/204B9A-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing how to load multiple assets at runtime with a progress bar.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/MGKfj6jm/" title="Load assets with a progress bar" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/436584/'>Open Project ↗</Link>

--- a/docs/tutorials/load-multiple-assets-at-runtime.md
+++ b/docs/tutorials/load-multiple-assets-at-runtime.md
@@ -4,8 +4,12 @@ tags: [loading, assets, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/439131/AC1AEB-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing how to load multiple assets at runtime.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/P7eFFj4u/" title="Load multiple assets at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/439131/'>Open Project ↗</Link>

--- a/docs/tutorials/load-multiple-assets-at-runtime.md
+++ b/docs/tutorials/load-multiple-assets-at-runtime.md
@@ -12,4 +12,4 @@ Sample showing how to load multiple assets at runtime.
     <iframe loading="lazy" src="https://playcanv.as/p/P7eFFj4u/" title="Load multiple assets at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/439131/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/439131/'>Open Project ↗</Link>

--- a/docs/tutorials/loading-an-asset-at-runtime.md
+++ b/docs/tutorials/loading-an-asset-at-runtime.md
@@ -4,8 +4,12 @@ tags: [loading, assets, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/439122/FA68B8-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing how to load an asset at runtime so you don't have to preload it at the start if it is not used.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/xIkPLoyX/" title="Loading an asset at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/439122/'>Open Project ↗</Link>

--- a/docs/tutorials/loading-an-asset-at-runtime.md
+++ b/docs/tutorials/loading-an-asset-at-runtime.md
@@ -12,4 +12,4 @@ Sample showing how to load an asset at runtime so you don't have to preload it a
     <iframe loading="lazy" src="https://playcanv.as/p/xIkPLoyX/" title="Loading an asset at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/439122/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/439122/'>Open Project ↗</Link>

--- a/docs/tutorials/loading-circle-ui.md
+++ b/docs/tutorials/loading-circle-ui.md
@@ -12,4 +12,4 @@ An example of a radial loading circle
     <iframe loading="lazy" src="https://playcanv.as/p/WVAhW4ft/" title="Loading Circle UI" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/705273/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/705273/'>Open Project ↗</Link>

--- a/docs/tutorials/loading-circle-ui.md
+++ b/docs/tutorials/loading-circle-ui.md
@@ -4,8 +4,12 @@ tags: [materials, ui, animation, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/705273/8B52B3-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 An example of a radial loading circle
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/WVAhW4ft/" title="Loading Circle UI" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/705273/'>Open Project ↗</Link>

--- a/docs/tutorials/loading-draco-compressed-glbs.md
+++ b/docs/tutorials/loading-draco-compressed-glbs.md
@@ -16,4 +16,4 @@ See https://github.com/CesiumGS/gltf-pipeline for the tool to compress glTF mode
     <iframe loading="lazy" src="https://playcanv.as/p/2uU2aYDh/" title="Loading Draco Compressed GLBs" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/730372/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/730372/'>Open Project ↗</Link>

--- a/docs/tutorials/loading-draco-compressed-glbs.md
+++ b/docs/tutorials/loading-draco-compressed-glbs.md
@@ -4,6 +4,8 @@ tags: [rendering, assets, tutorial, scripts]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/730372/61CE32-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 How to load a Draco compressed GLB. 
 
 See https://google.github.io/draco/ for more information on Draco 3D Data Compression.
@@ -13,3 +15,5 @@ See https://github.com/CesiumGS/gltf-pipeline for the tool to compress glTF mode
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/2uU2aYDh/" title="Loading Draco Compressed GLBs" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/730372/'>Open Project ↗</Link>

--- a/docs/tutorials/loading-gltf-glbs.md
+++ b/docs/tutorials/loading-gltf-glbs.md
@@ -12,4 +12,4 @@ How to load a GLB as a binary asset.
     <iframe loading="lazy" src="https://playcanv.as/p/RIN6pM0I/" title="Loading glTF GLBs" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/730738/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/730738/'>Open Project ↗</Link>

--- a/docs/tutorials/loading-gltf-glbs.md
+++ b/docs/tutorials/loading-gltf-glbs.md
@@ -4,8 +4,12 @@ tags: [rendering, assets, tutorial, scripts]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/730738/0641C2-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 How to load a GLB as a binary asset.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/RIN6pM0I/" title="Loading glTF GLBs" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/730738/'>Open Project ↗</Link>

--- a/docs/tutorials/locking-the-mouse.md
+++ b/docs/tutorials/locking-the-mouse.md
@@ -12,4 +12,4 @@ A sample showing how to lock the mouse upon clicking.
     <iframe loading="lazy" src="https://playcanv.as/p/2Epvl0CT/" title="Locking the mouse" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/438440/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/438440/'>Open Project ↗</Link>

--- a/docs/tutorials/locking-the-mouse.md
+++ b/docs/tutorials/locking-the-mouse.md
@@ -4,8 +4,12 @@ tags: [input, camera, mouse, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438440/941913-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 A sample showing how to lock the mouse upon clicking.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/2Epvl0CT/" title="Locking the mouse" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/438440/'>Open Project ↗</Link>

--- a/docs/tutorials/mobile-ui-safe-areas.md
+++ b/docs/tutorials/mobile-ui-safe-areas.md
@@ -4,8 +4,12 @@ tags: [ui, tutorial, scripts]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/828118/9F85DB-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example project to handle safe areas on the UI - https://developer.playcanvas.com/user-manual/user-interface/safe-area/
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/z5pXervL/" title="Mobile UI Safe Areas" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/828118/'>Open Project ↗</Link>

--- a/docs/tutorials/mobile-ui-safe-areas.md
+++ b/docs/tutorials/mobile-ui-safe-areas.md
@@ -12,4 +12,4 @@ Example project to handle safe areas on the UI - https://developer.playcanvas.co
     <iframe loading="lazy" src="https://playcanv.as/p/z5pXervL/" title="Mobile UI Safe Areas" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/828118/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/828118/'>Open Project ↗</Link>

--- a/docs/tutorials/multiple-camera-layers.md
+++ b/docs/tutorials/multiple-camera-layers.md
@@ -4,8 +4,12 @@ tags: [rendering, camera, ui, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/593374/DF6C72-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Demonstration project that shows how to use multiple cameras and layers to render a mixed user interface of UI elements and world-space objects.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/h7V3tWZK/" title="Multiple Camera Layers" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/593374/'>Open Project ↗</Link>

--- a/docs/tutorials/multiple-camera-layers.md
+++ b/docs/tutorials/multiple-camera-layers.md
@@ -12,4 +12,4 @@ Demonstration project that shows how to use multiple cameras and layers to rende
     <iframe loading="lazy" src="https://playcanv.as/p/h7V3tWZK/" title="Multiple Camera Layers" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/593374/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/593374/'>Open Project ↗</Link>

--- a/docs/tutorials/multiple-viewport-rendering.md
+++ b/docs/tutorials/multiple-viewport-rendering.md
@@ -12,4 +12,4 @@ A sample showing how to render multiple viewports by modifying the viewport prop
     <iframe loading="lazy" src="https://playcanv.as/p/bkLdoYPQ/" title="Multiple Viewport Rendering" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/443666/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/443666/'>Open Project ↗</Link>

--- a/docs/tutorials/multiple-viewport-rendering.md
+++ b/docs/tutorials/multiple-viewport-rendering.md
@@ -4,8 +4,12 @@ tags: [rendering, camera, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/443666/FA3675-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 A sample showing how to render multiple viewports by modifying the viewport properties on the cameras
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/bkLdoYPQ/" title="Multiple Viewport Rendering" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/443666/'>Open Project ↗</Link>

--- a/docs/tutorials/multitouch-input.md
+++ b/docs/tutorials/multitouch-input.md
@@ -4,8 +4,12 @@ tags: [touch, input, mobile, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/437474/C0A0E1-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample that draws lines between all the current touches on the screen.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/p56cF89z/" title="Multitouch input" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/437474/'>Open Project ↗</Link>

--- a/docs/tutorials/multitouch-input.md
+++ b/docs/tutorials/multitouch-input.md
@@ -12,4 +12,4 @@ Sample that draws lines between all the current touches on the screen.
     <iframe loading="lazy" src="https://playcanv.as/p/p56cF89z/" title="Multitouch input" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/437474/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/437474/'>Open Project ↗</Link>

--- a/docs/tutorials/orange-room.md
+++ b/docs/tutorials/orange-room.md
@@ -4,8 +4,12 @@ tags: [vr, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/345310/BKST60-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Interactive interior visualisation with dynamic reflections and HDR lightmaps.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/1ha5glKf/" title="Orange Room" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/345310/'>Open Project ↗</Link>

--- a/docs/tutorials/orange-room.md
+++ b/docs/tutorials/orange-room.md
@@ -12,4 +12,4 @@ Interactive interior visualisation with dynamic reflections and HDR lightmaps.
     <iframe loading="lazy" src="https://playcanv.as/p/1ha5glKf/" title="Orange Room" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/345310/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/345310/'>Open Project ↗</Link>

--- a/docs/tutorials/orbit-camera.md
+++ b/docs/tutorials/orbit-camera.md
@@ -4,8 +4,12 @@ tags: [input, camera, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438243/FDA218-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample with an orbit camera around an entity with both mouse and touch. Scroll wheel and 'pinch to zoom' is used to zoom in and out.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/fI6jSYjK/" title="Orbit camera" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/438243/'>Open Project ↗</Link>

--- a/docs/tutorials/orbit-camera.md
+++ b/docs/tutorials/orbit-camera.md
@@ -12,4 +12,4 @@ Sample with an orbit camera around an entity with both mouse and touch. Scroll w
     <iframe loading="lazy" src="https://playcanv.as/p/fI6jSYjK/" title="Orbit camera" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/438243/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/438243/'>Open Project ↗</Link>

--- a/docs/tutorials/pan-camera-to-target.md
+++ b/docs/tutorials/pan-camera-to-target.md
@@ -14,4 +14,4 @@ Credit: https://playcanvas.com/lexxik
     <iframe loading="lazy" src="https://playcanv.as/p/5SJsWtg3/" title="Pan Camera to Target" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/693889/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/693889/'>Open Project ↗</Link>

--- a/docs/tutorials/pan-camera-to-target.md
+++ b/docs/tutorials/pan-camera-to-target.md
@@ -4,6 +4,8 @@ tags: [input, camera, animation, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/693889/B745F1-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 An example shows how to focus a camera on target location
 
 Credit: https://playcanvas.com/lexxik
@@ -11,3 +13,5 @@ Credit: https://playcanvas.com/lexxik
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/5SJsWtg3/" title="Pan Camera to Target" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/693889/'>Open Project ↗</Link>

--- a/docs/tutorials/pauseplay-application.md
+++ b/docs/tutorials/pauseplay-application.md
@@ -12,4 +12,4 @@ A sample showing how to pause and resume an app by modifying the timeScale prope
     <iframe loading="lazy" src="https://playcanv.as/p/sNoeqOZL/" title="Pause/Play application" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/437707/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/437707/'>Open Project ↗</Link>

--- a/docs/tutorials/pauseplay-application.md
+++ b/docs/tutorials/pauseplay-application.md
@@ -4,8 +4,12 @@ tags: [tutorial, time]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/437707/9D3648-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 A sample showing how to pause and resume an app by modifying the timeScale property. Click to pause/play the app
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/sNoeqOZL/" title="Pause/Play application" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/437707/'>Open Project ↗</Link>

--- a/docs/tutorials/physics-raycasting-by-tag.md
+++ b/docs/tutorials/physics-raycasting-by-tag.md
@@ -4,8 +4,12 @@ tags: [input, physics, raycast, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/691309/22953E-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing how to pick an entity by tag using raycastAll
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/j1aT7giL/" title="Physics raycasting by tag" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/691309/'>Open Project ↗</Link>

--- a/docs/tutorials/physics-raycasting-by-tag.md
+++ b/docs/tutorials/physics-raycasting-by-tag.md
@@ -12,4 +12,4 @@ Sample showing how to pick an entity by tag using raycastAll
     <iframe loading="lazy" src="https://playcanv.as/p/j1aT7giL/" title="Physics raycasting by tag" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/691309/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/691309/'>Open Project ↗</Link>

--- a/docs/tutorials/physics-with-ccd.md
+++ b/docs/tutorials/physics-with-ccd.md
@@ -4,8 +4,12 @@ tags: [physics, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/447023/525467-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 A sample with a script to setup and enable CCD for very fast moving physics objects
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/jBMFj7l2/" title="Physics with CCD" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/447023/'>Open Project ↗</Link>

--- a/docs/tutorials/physics-with-ccd.md
+++ b/docs/tutorials/physics-with-ccd.md
@@ -12,4 +12,4 @@ A sample with a script to setup and enable CCD for very fast moving physics obje
     <iframe loading="lazy" src="https://playcanv.as/p/jBMFj7l2/" title="Physics with CCD" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/447023/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/447023/'>Open Project ↗</Link>

--- a/docs/tutorials/place-an-entity-with-physics.md
+++ b/docs/tutorials/place-an-entity-with-physics.md
@@ -12,4 +12,4 @@ A sample showing how to place objects in the world by using physics. Click on gr
     <iframe loading="lazy" src="https://playcanv.as/p/JCW3CUKx/" title="Place an entity with physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/437836/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/437836/'>Open Project ↗</Link>

--- a/docs/tutorials/place-an-entity-with-physics.md
+++ b/docs/tutorials/place-an-entity-with-physics.md
@@ -4,8 +4,12 @@ tags: [input, physics, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/437836/9F4675-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 A sample showing how to place objects in the world by using physics. Click on ground to place a box.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/JCW3CUKx/" title="Place an entity with physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/437836/'>Open Project ↗</Link>

--- a/docs/tutorials/place-entity-without-physics.md
+++ b/docs/tutorials/place-entity-without-physics.md
@@ -4,8 +4,12 @@ tags: [input, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/437894/2D9F7B-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 A sample showing how to place objects in the world without using physics. Click on the ground to place boxes.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/Z2ieIwf8/" title="Place entity without physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/437894/'>Open Project ↗</Link>

--- a/docs/tutorials/place-entity-without-physics.md
+++ b/docs/tutorials/place-entity-without-physics.md
@@ -12,4 +12,4 @@ A sample showing how to place objects in the world without using physics. Click 
     <iframe loading="lazy" src="https://playcanv.as/p/Z2ieIwf8/" title="Place entity without physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/437894/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/437894/'>Open Project ↗</Link>

--- a/docs/tutorials/planar-mirror-reflection.md
+++ b/docs/tutorials/planar-mirror-reflection.md
@@ -14,4 +14,4 @@ Example of creating a planar reflection being used for a transparent mirror/wate
     <iframe loading="lazy" src="https://playcanv.as/p/bQE35vbj/" title="Planar Mirror Reflection" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/717166/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/717166/'>Open Project ↗</Link>

--- a/docs/tutorials/planar-mirror-reflection.md
+++ b/docs/tutorials/planar-mirror-reflection.md
@@ -4,6 +4,8 @@ tags: [rendering, shaders, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/717166/FEA6FF-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Credit: https://playcanvas.com/lexxik
 
 Example of creating a planar reflection being used for a transparent mirror/water like surface.
@@ -11,3 +13,5 @@ Example of creating a planar reflection being used for a transparent mirror/wate
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/bQE35vbj/" title="Planar Mirror Reflection" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/717166/'>Open Project ↗</Link>

--- a/docs/tutorials/planet-earth.md
+++ b/docs/tutorials/planet-earth.md
@@ -10,4 +10,4 @@ import Link from '@docusaurus/Link';
     <iframe loading="lazy" src="https://playcanv.as/p/kU1mx35y/" title="Planet Earth" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/419706/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/419706/'>Open Project ↗</Link>

--- a/docs/tutorials/planet-earth.md
+++ b/docs/tutorials/planet-earth.md
@@ -4,6 +4,10 @@ tags: [textures, rendering, materials, shaders, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/419706/12261C-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/kU1mx35y/" title="Planet Earth" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/419706/'>Open Project ↗</Link>

--- a/docs/tutorials/point-and-click-movement.md
+++ b/docs/tutorials/point-and-click-movement.md
@@ -12,4 +12,4 @@ Sample showing a simple point and click system to move an object where you user 
     <iframe loading="lazy" src="https://playcanv.as/p/RQAovNH6/" title="Point and click movement" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/461494/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/461494/'>Open Project ↗</Link>

--- a/docs/tutorials/point-and-click-movement.md
+++ b/docs/tutorials/point-and-click-movement.md
@@ -4,9 +4,12 @@ tags: [touch, input, mouse, raycast, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/461494/9F45F6-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing a simple point and click system to move an object where you user has clicked
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/RQAovNH6/" title="Point and click movement" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
+<Link to='https://playcanvas.com/editor/project/461494/'>Open Project ↗</Link>

--- a/docs/tutorials/procedural-gradient-texture.md
+++ b/docs/tutorials/procedural-gradient-texture.md
@@ -4,8 +4,12 @@ tags: [textures, rendering, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/708598/6E96B8-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example of creating a procedural texture with a gradient effect by LeXXik
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/5qggchI4/" title="Procedural Gradient Texture" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/708598/'>Open Project ↗</Link>

--- a/docs/tutorials/procedural-gradient-texture.md
+++ b/docs/tutorials/procedural-gradient-texture.md
@@ -12,4 +12,4 @@ Example of creating a procedural texture with a gradient effect by LeXXik
     <iframe loading="lazy" src="https://playcanv.as/p/5qggchI4/" title="Procedural Gradient Texture" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/708598/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/708598/'>Open Project ↗</Link>

--- a/docs/tutorials/rainbow-trail-with-mesh-api.md
+++ b/docs/tutorials/rainbow-trail-with-mesh-api.md
@@ -12,4 +12,4 @@ A rainbow trail using the pc.Mesh API
     <iframe loading="lazy" src="https://playcanv.as/p/jGeaTg6B/" title="Rainbow Trail with Mesh API" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/1029772/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/1029772/'>Open Project ↗</Link>

--- a/docs/tutorials/rainbow-trail-with-mesh-api.md
+++ b/docs/tutorials/rainbow-trail-with-mesh-api.md
@@ -4,8 +4,12 @@ tags: [rendering, shaders, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/733569/6226C8-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 A rainbow trail using the pc.Mesh API
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/jGeaTg6B/" title="Rainbow Trail with Mesh API" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/1029772/'>Open Project ↗</Link>

--- a/docs/tutorials/raycast-with-camera-viewports.md
+++ b/docs/tutorials/raycast-with-camera-viewports.md
@@ -12,4 +12,4 @@ Raycasting with multiple camera viewports. Click on the shapes in each view
     <iframe loading="lazy" src="https://playcanv.as/p/dXvrDzH2/" title="Raycast with Camera Viewports" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/964118/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/964118/'>Open Project ↗</Link>

--- a/docs/tutorials/raycast-with-camera-viewports.md
+++ b/docs/tutorials/raycast-with-camera-viewports.md
@@ -4,8 +4,12 @@ tags: [input, camera, physics, raycast, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/964118/E9A5F1-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Raycasting with multiple camera viewports. Click on the shapes in each view
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/dXvrDzH2/" title="Raycast with Camera Viewports" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/964118/'>Open Project ↗</Link>

--- a/docs/tutorials/render-3d-world-to-ui.md
+++ b/docs/tutorials/render-3d-world-to-ui.md
@@ -12,4 +12,4 @@ Render 3D objects as part of the UI
     <iframe loading="lazy" src="https://playcanv.as/p/CQzD8zlM/" title="Render 3D World to UI" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/855150/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/855150/'>Open Project ↗</Link>

--- a/docs/tutorials/render-3d-world-to-ui.md
+++ b/docs/tutorials/render-3d-world-to-ui.md
@@ -4,8 +4,12 @@ tags: [rendering, camera, ui, tutorial, scripts]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/855150/6398DC-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Render 3D objects as part of the UI
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/CQzD8zlM/" title="Render 3D World to UI" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/855150/'>Open Project ↗</Link>

--- a/docs/tutorials/resolution-scaling.md
+++ b/docs/tutorials/resolution-scaling.md
@@ -12,4 +12,4 @@ Example project on rendering the world at different resolutions without the UI b
     <iframe loading="lazy" src="https://playcanv.as/p/qx7PyE7q/" title="Resolution Scaling" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/708300/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/708300/'>Open Project ↗</Link>

--- a/docs/tutorials/resolution-scaling.md
+++ b/docs/tutorials/resolution-scaling.md
@@ -4,8 +4,12 @@ tags: [mobile, rendering, resolution, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/708300/702D33-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example project on rendering the world at different resolutions without the UI being affected
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/qx7PyE7q/" title="Resolution Scaling" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/708300/'>Open Project ↗</Link>

--- a/docs/tutorials/right-to-left-language-support.md
+++ b/docs/tutorials/right-to-left-language-support.md
@@ -12,4 +12,4 @@ Scripts to use for RTL language support such Arabic
     <iframe loading="lazy" src="https://playcanv.as/p/k2TruV1u/" title="Right to left language support" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/764309/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/764309/'>Open Project ↗</Link>

--- a/docs/tutorials/right-to-left-language-support.md
+++ b/docs/tutorials/right-to-left-language-support.md
@@ -4,8 +4,12 @@ tags: [ui, tutorial, scripts]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/764309/A62C41-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Scripts to use for RTL language support such Arabic
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/k2TruV1u/" title="Right to left language support" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/764309/'>Open Project ↗</Link>

--- a/docs/tutorials/rotating-objects-with-mouse.md
+++ b/docs/tutorials/rotating-objects-with-mouse.md
@@ -4,8 +4,12 @@ tags: [touch, input, mouse, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/442490/AD8ABB-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing how to rotate an object using the mouse in screen space
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/BgbpyC0Y/" title="Rotating Objects with Mouse" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/442490/'>Open Project ↗</Link>

--- a/docs/tutorials/rotating-objects-with-mouse.md
+++ b/docs/tutorials/rotating-objects-with-mouse.md
@@ -12,4 +12,4 @@ Sample showing how to rotate an object using the mouse in screen space
     <iframe loading="lazy" src="https://playcanv.as/p/BgbpyC0Y/" title="Rotating Objects with Mouse" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/442490/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/442490/'>Open Project ↗</Link>

--- a/docs/tutorials/shockwave.md
+++ b/docs/tutorials/shockwave.md
@@ -4,8 +4,12 @@ tags: [tutorial, posteffects]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/440868/136A8D-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Shockwave ripple post effect
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/c16yO94k/" title="Shockwave" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/440868/'>Open Project ↗</Link>

--- a/docs/tutorials/shockwave.md
+++ b/docs/tutorials/shockwave.md
@@ -12,4 +12,4 @@ Shockwave ripple post effect
     <iframe loading="lazy" src="https://playcanv.as/p/c16yO94k/" title="Shockwave" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/440868/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/440868/'>Open Project ↗</Link>

--- a/docs/tutorials/simple-shape-raycasting.md
+++ b/docs/tutorials/simple-shape-raycasting.md
@@ -12,4 +12,4 @@ Sample showing how to pick at an entity
     <iframe loading="lazy" src="https://playcanv.as/p/QGiL8OdM/" title="Simple shape raycasting" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/457922/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/457922/'>Open Project ↗</Link>

--- a/docs/tutorials/simple-shape-raycasting.md
+++ b/docs/tutorials/simple-shape-raycasting.md
@@ -4,8 +4,12 @@ tags: [input, physics, raycast, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/457922/D9DAC0-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing how to pick at an entity
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/QGiL8OdM/" title="Simple shape raycasting" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/457922/'>Open Project ↗</Link>

--- a/docs/tutorials/simple-water-surface.md
+++ b/docs/tutorials/simple-water-surface.md
@@ -4,6 +4,10 @@ tags: [rendering, materials, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438476/6F2C27-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/NeYgvM9z/" title="Simple water surface" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/438476/'>Open Project ↗</Link>

--- a/docs/tutorials/simple-water-surface.md
+++ b/docs/tutorials/simple-water-surface.md
@@ -10,4 +10,4 @@ import Link from '@docusaurus/Link';
     <iframe loading="lazy" src="https://playcanv.as/p/NeYgvM9z/" title="Simple water surface" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/438476/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/438476/'>Open Project ↗</Link>

--- a/docs/tutorials/smooth-camera-movement.md
+++ b/docs/tutorials/smooth-camera-movement.md
@@ -4,8 +4,12 @@ tags: [camera, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/437461/2E89D4-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample with a smooth transition of a camera from one position and rotation to another using the Lerp and Slerp functions.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/T7VKMrs8/" title="Smooth camera movement" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/437461/'>Open Project ↗</Link>

--- a/docs/tutorials/smooth-camera-movement.md
+++ b/docs/tutorials/smooth-camera-movement.md
@@ -12,4 +12,4 @@ Sample with a smooth transition of a camera from one position and rotation to an
     <iframe loading="lazy" src="https://playcanv.as/p/T7VKMrs8/" title="Smooth camera movement" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/437461/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/437461/'>Open Project ↗</Link>

--- a/docs/tutorials/sound-volume-control-using-curve.md
+++ b/docs/tutorials/sound-volume-control-using-curve.md
@@ -4,8 +4,12 @@ tags: [audio, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/436116/1F5514-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing how to control the volume of a sound slot using curve data. Click on the scene to start the audio.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/hmRciuNn/" title="Sound volume control using curve" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/436116/'>Open Project ↗</Link>

--- a/docs/tutorials/sound-volume-control-using-curve.md
+++ b/docs/tutorials/sound-volume-control-using-curve.md
@@ -12,4 +12,4 @@ Sample showing how to control the volume of a sound slot using curve data. Click
     <iframe loading="lazy" src="https://playcanv.as/p/hmRciuNn/" title="Sound volume control using curve" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/436116/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/436116/'>Open Project ↗</Link>

--- a/docs/tutorials/space-rocks.md
+++ b/docs/tutorials/space-rocks.md
@@ -4,8 +4,12 @@ tags: [games, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/1029772/10FC7E-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Get started making your own space shooter game by forking this template Asteroids shooter! Aim with your mouse and fire with your left button. Survive as long as you can!
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/cAFbOEtL/" title="Space Rocks!" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/1029772/'>Open Project ↗</Link>

--- a/docs/tutorials/space-rocks.md
+++ b/docs/tutorials/space-rocks.md
@@ -12,4 +12,4 @@ Get started making your own space shooter game by forking this template Asteroid
     <iframe loading="lazy" src="https://playcanv.as/p/cAFbOEtL/" title="Space Rocks!" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/1029772/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/1029772/'>Open Project ↗</Link>

--- a/docs/tutorials/static-batching.md
+++ b/docs/tutorials/static-batching.md
@@ -10,4 +10,4 @@ import Link from '@docusaurus/Link';
     <iframe loading="lazy" src="https://playcanv.as/p/Qo7T1kqU/" title="Static Batching" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/520389/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/520389/'>Open Project ↗</Link>

--- a/docs/tutorials/static-batching.md
+++ b/docs/tutorials/static-batching.md
@@ -4,6 +4,10 @@ tags: [rendering, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/520389/C1E49E-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/Qo7T1kqU/" title="Static Batching" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/520389/'>Open Project ↗</Link>

--- a/docs/tutorials/stencil-buffer---3d-magic-card.md
+++ b/docs/tutorials/stencil-buffer---3d-magic-card.md
@@ -14,4 +14,4 @@ Credit: @ alexanderrdx for the original project
     <iframe loading="lazy" src="https://playcanv.as/p/RAQhfemb/" title="Stencil Buffer - 3D Magic Card" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/855103/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/855103/'>Open Project ↗</Link>

--- a/docs/tutorials/stencil-buffer---3d-magic-card.md
+++ b/docs/tutorials/stencil-buffer---3d-magic-card.md
@@ -4,6 +4,8 @@ tags: [rendering, culling, materials, tutorial, scripts]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/855103/3B0AC0-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example project that uses the stencil buffer to create a magic window like effect on a card.
 
 Credit: @ alexanderrdx for the original project
@@ -11,3 +13,5 @@ Credit: @ alexanderrdx for the original project
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/RAQhfemb/" title="Stencil Buffer - 3D Magic Card" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/855103/'>Open Project ↗</Link>

--- a/docs/tutorials/switching-materials-at-runtime.md
+++ b/docs/tutorials/switching-materials-at-runtime.md
@@ -4,8 +4,12 @@ tags: [materials, assets, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/437442/709ED5-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample switching on a model materials at runtime.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/7EZvdnZd/" title="Switching materials at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/437442/'>Open Project ↗</Link>

--- a/docs/tutorials/switching-materials-at-runtime.md
+++ b/docs/tutorials/switching-materials-at-runtime.md
@@ -12,4 +12,4 @@ Sample switching on a model materials at runtime.
     <iframe loading="lazy" src="https://playcanv.as/p/7EZvdnZd/" title="Switching materials at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/437442/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/437442/'>Open Project ↗</Link>

--- a/docs/tutorials/third-person-controller.md
+++ b/docs/tutorials/third-person-controller.md
@@ -4,8 +4,12 @@ tags: [input, camera, physics, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/705595/FA7C28-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 A simple third person controller.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/Q7CJA9Ku/" title="Third Person Controller" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/705595/'>Open Project ↗</Link>

--- a/docs/tutorials/third-person-controller.md
+++ b/docs/tutorials/third-person-controller.md
@@ -12,4 +12,4 @@ A simple third person controller.
     <iframe loading="lazy" src="https://playcanv.as/p/Q7CJA9Ku/" title="Third Person Controller" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/705595/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/705595/'>Open Project ↗</Link>

--- a/docs/tutorials/tic-tac-toe.md
+++ b/docs/tutorials/tic-tac-toe.md
@@ -12,4 +12,4 @@ The classic game Tic Tac Toe
     <iframe loading="lazy" src="https://playcanv.as/p/i5csiIb9/" title="Tic Tac Toe" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/671439/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/671439/'>Open Project ↗</Link>

--- a/docs/tutorials/tic-tac-toe.md
+++ b/docs/tutorials/tic-tac-toe.md
@@ -4,8 +4,12 @@ tags: [games, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/671439/C24512-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 The classic game Tic Tac Toe
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/i5csiIb9/" title="Tic Tac Toe" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/671439/'>Open Project ↗</Link>

--- a/docs/tutorials/timers.md
+++ b/docs/tutorials/timers.md
@@ -4,8 +4,12 @@ tags: [tutorial, time]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/691984/71DABB-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example of extending the PlayCanvas engine to create one shot timers. Press P to pause time.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/WsI6QA7y/" title="Timers" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/691984/'>Open Project ↗</Link>

--- a/docs/tutorials/timers.md
+++ b/docs/tutorials/timers.md
@@ -12,4 +12,4 @@ Example of extending the PlayCanvas engine to create one shot timers. Press P to
     <iframe loading="lazy" src="https://playcanv.as/p/WsI6QA7y/" title="Timers" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/691984/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/691984/'>Open Project ↗</Link>

--- a/docs/tutorials/tutorial-layout-groups.md
+++ b/docs/tutorials/tutorial-layout-groups.md
@@ -12,4 +12,4 @@ Use the Layout Group component to build a user interface.
     <iframe loading="lazy" src="https://playcanv.as/p/y4JwxWTI/" title="Tutorial: Layout Groups" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/553515/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/553515/'>Open Project ↗</Link>

--- a/docs/tutorials/tutorial-layout-groups.md
+++ b/docs/tutorials/tutorial-layout-groups.md
@@ -4,8 +4,12 @@ tags: [ui, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/553515/D4C290-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Use the Layout Group component to build a user interface.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/y4JwxWTI/" title="Tutorial: Layout Groups" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/553515/'>Open Project ↗</Link>

--- a/docs/tutorials/tutorial-normal-mapped-text.md
+++ b/docs/tutorials/tutorial-normal-mapped-text.md
@@ -12,4 +12,4 @@ Dynamically generate normal maps and parallax maps for text
     <iframe loading="lazy" src="https://playcanv.as/p/MbMb81DM/" title="Tutorial: Normal Mapped Text" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/855103/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/855103/'>Open Project ↗</Link>

--- a/docs/tutorials/tutorial-normal-mapped-text.md
+++ b/docs/tutorials/tutorial-normal-mapped-text.md
@@ -4,8 +4,12 @@ tags: [textures, rendering, materials, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/371210/C1FNWI-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Dynamically generate normal maps and parallax maps for text
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/MbMb81DM/" title="Tutorial: Normal Mapped Text" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/855103/'>Open Project ↗</Link>

--- a/docs/tutorials/tutorial-plasma-shader-chunk.md
+++ b/docs/tutorials/tutorial-plasma-shader-chunk.md
@@ -12,4 +12,4 @@ A demonstration of a GLSL effect from Shadertoy being used in a shader chunk on 
     <iframe loading="lazy" src="https://playcanv.as/p/NLgp097Q/" title="Tutorial: Plasma Shader Chunk" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/453304/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/453304/'>Open Project ↗</Link>

--- a/docs/tutorials/tutorial-plasma-shader-chunk.md
+++ b/docs/tutorials/tutorial-plasma-shader-chunk.md
@@ -4,8 +4,12 @@ tags: [shaders, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/453304/09CE3A-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 A demonstration of a GLSL effect from Shadertoy being used in a shader chunk on a PlayCanvas material
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/NLgp097Q/" title="Tutorial: Plasma Shader Chunk" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/453304/'>Open Project ↗</Link>

--- a/docs/tutorials/tutorial-shop-user-interface.md
+++ b/docs/tutorials/tutorial-shop-user-interface.md
@@ -4,8 +4,12 @@ tags: [ui, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/559492/CBFB0A-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Build a Shop User Interface screen using UI Elements, Layout Groups, Button components, Sprites and Texture Atlases
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/yN4CxzAs/" title="Tutorial: Shop User Interface" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/559492/'>Open Project ↗</Link>

--- a/docs/tutorials/tutorial-shop-user-interface.md
+++ b/docs/tutorials/tutorial-shop-user-interface.md
@@ -12,4 +12,4 @@ Build a Shop User Interface screen using UI Elements, Layout Groups, Button comp
     <iframe loading="lazy" src="https://playcanv.as/p/yN4CxzAs/" title="Tutorial: Shop User Interface" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/559492/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/559492/'>Open Project ↗</Link>

--- a/docs/tutorials/using-events-with-scripts.md
+++ b/docs/tutorials/using-events-with-scripts.md
@@ -4,8 +4,12 @@ tags: [events, tutorial, scripts]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/437673/ED3EC5-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample showing how to communicate between scripts using events.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/HXrtITkb/" title="Using events with scripts" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/437673/'>Open Project ↗</Link>

--- a/docs/tutorials/using-events-with-scripts.md
+++ b/docs/tutorials/using-events-with-scripts.md
@@ -12,4 +12,4 @@ Sample showing how to communicate between scripts using events.
     <iframe loading="lazy" src="https://playcanv.as/p/HXrtITkb/" title="Using events with scripts" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/437673/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/437673/'>Open Project ↗</Link>

--- a/docs/tutorials/vehicle-physics.md
+++ b/docs/tutorials/vehicle-physics.md
@@ -4,8 +4,12 @@ tags: [collision, vr, physics, tutorial, raycast]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/643289/28741D-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 An implementation of vehicle physics in PlayCanvas, using the RaycastVehicle API in ammo.js. Supports desktop, mobile and VR.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/CxgnAp22/" title="Vehicle Physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/643289/'>Open Project ↗</Link>

--- a/docs/tutorials/vehicle-physics.md
+++ b/docs/tutorials/vehicle-physics.md
@@ -12,4 +12,4 @@ An implementation of vehicle physics in PlayCanvas, using the RaycastVehicle API
     <iframe loading="lazy" src="https://playcanv.as/p/CxgnAp22/" title="Vehicle Physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/643289/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/643289/'>Open Project ↗</Link>

--- a/docs/tutorials/vhscrt-post-effect.md
+++ b/docs/tutorials/vhscrt-post-effect.md
@@ -4,8 +4,12 @@ tags: [tutorial, posteffects]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/373076/0WJ6Y8-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Basic fullscreen effect simulating a bad video screen like an old CRT.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/6hhSiHG3/" title="VHS/CRT Post Effect" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/373076/'>Open Project ↗</Link>

--- a/docs/tutorials/vhscrt-post-effect.md
+++ b/docs/tutorials/vhscrt-post-effect.md
@@ -12,4 +12,4 @@ Basic fullscreen effect simulating a bad video screen like an old CRT.
     <iframe loading="lazy" src="https://playcanv.as/p/6hhSiHG3/" title="VHS/CRT Post Effect" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/373076/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/373076/'>Open Project ↗</Link>

--- a/docs/tutorials/vignette-abberation.md
+++ b/docs/tutorials/vignette-abberation.md
@@ -4,6 +4,10 @@ tags: [tutorial, posteffects]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/440854/0F743E-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/UwEmhiJf/" title="Vignette Abberation" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/440854/'>Open Project ↗</Link>

--- a/docs/tutorials/vignette-abberation.md
+++ b/docs/tutorials/vignette-abberation.md
@@ -10,4 +10,4 @@ import Link from '@docusaurus/Link';
     <iframe loading="lazy" src="https://playcanv.as/p/UwEmhiJf/" title="Vignette Abberation" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/440854/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/440854/'>Open Project ↗</Link>

--- a/docs/tutorials/warp-a-sprite-with-glsl.md
+++ b/docs/tutorials/warp-a-sprite-with-glsl.md
@@ -4,6 +4,10 @@ tags: [rendering, shaders, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/426038/2C7C85-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/3NdgiVsp/" title="Warp a Sprite with GLSL" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/426038/'>Open Project ↗</Link>

--- a/docs/tutorials/warp-a-sprite-with-glsl.md
+++ b/docs/tutorials/warp-a-sprite-with-glsl.md
@@ -10,4 +10,4 @@ import Link from '@docusaurus/Link';
     <iframe loading="lazy" src="https://playcanv.as/p/3NdgiVsp/" title="Warp a Sprite with GLSL" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/426038/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/426038/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-360-image.md
+++ b/docs/tutorials/webxr-360-image.md
@@ -12,4 +12,4 @@ import Link from '@docusaurus/Link';
     <iframe loading="lazy" src="https://playcanv.as/p/v6qoi4Yt/" title="WebXR 360 Image" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/434266/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/434266/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-360-image.md
+++ b/docs/tutorials/webxr-360-image.md
@@ -4,8 +4,12 @@ tags: [vr, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/434266/3B51C6-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 360 Image with WebXR support | Image Credit: Bob Dass from https://www.flickr.com/photos/54144402@N03/
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/v6qoi4Yt/" title="WebXR 360 Image" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/434266/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-360-video.md
+++ b/docs/tutorials/webxr-360-video.md
@@ -12,4 +12,4 @@ import Link from '@docusaurus/Link';
     <iframe loading="lazy" src="https://playcanv.as/p/G0d8FneG/" title="WebXR 360 Video" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/434444/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/434444/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-360-video.md
+++ b/docs/tutorials/webxr-360-video.md
@@ -4,8 +4,12 @@ tags: [vr, video, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/434444/6E87E1-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 360 Video with WebXR support
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/G0d8FneG/" title="WebXR 360 Video" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/434444/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-ar-dom-overlay.md
+++ b/docs/tutorials/webxr-ar-dom-overlay.md
@@ -12,4 +12,4 @@ Example of how to use DOM (HTML + CSS) with WebXR AR session.
     <iframe loading="lazy" src="https://playcanv.as/p/S01LYTIU/" title="WebXR AR: DOM Overlay" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/691979/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/691979/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-ar-dom-overlay.md
+++ b/docs/tutorials/webxr-ar-dom-overlay.md
@@ -4,8 +4,12 @@ tags: [camera, ar, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/747233/D92E6B-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example of how to use DOM (HTML + CSS) with WebXR AR session.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/S01LYTIU/" title="WebXR AR: DOM Overlay" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/691979/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-ar-hit-test.md
+++ b/docs/tutorials/webxr-ar-hit-test.md
@@ -4,8 +4,12 @@ tags: [camera, ar, tutorial, raycast]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/672464/DAC6E9-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example of how to use WebXR Hit Test API. That allows to hit test real world geometry.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/Kjol3uRS/" title="WebXR AR: Hit Test" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/672464/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-ar-hit-test.md
+++ b/docs/tutorials/webxr-ar-hit-test.md
@@ -12,4 +12,4 @@ Example of how to use WebXR Hit Test API. That allows to hit test real world geo
     <iframe loading="lazy" src="https://playcanv.as/p/Kjol3uRS/" title="WebXR AR: Hit Test" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/672464/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/672464/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-ar-image-tracking.md
+++ b/docs/tutorials/webxr-ar-image-tracking.md
@@ -12,4 +12,4 @@ Example of how to use WebXR Augmented Reality: Image Tracking API. That allows t
     <iframe loading="lazy" src="https://playcanv.as/p/PCsSvN5h/" title="WebXR: AR Image Tracking" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/739875/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/739875/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-ar-image-tracking.md
+++ b/docs/tutorials/webxr-ar-image-tracking.md
@@ -4,8 +4,12 @@ tags: [camera, ar, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/739875/A3DDF5-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example of how to use WebXR Augmented Reality: Image Tracking API. That allows to *actively* track real world images based on provided sample.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/PCsSvN5h/" title="WebXR: AR Image Tracking" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/739875/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-ar-raycasting-shapes.md
+++ b/docs/tutorials/webxr-ar-raycasting-shapes.md
@@ -4,6 +4,8 @@ tags: [input, ar, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/884783/E2030C-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example of how to raycast in the PlayCanvas scene when using WebXR AR.
 
 Tap the shapes to change their color!
@@ -11,3 +13,5 @@ Tap the shapes to change their color!
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/qiLEOeL7/" title="WebXR AR Raycasting Shapes" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/884783/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-ar-raycasting-shapes.md
+++ b/docs/tutorials/webxr-ar-raycasting-shapes.md
@@ -14,4 +14,4 @@ Tap the shapes to change their color!
     <iframe loading="lazy" src="https://playcanv.as/p/qiLEOeL7/" title="WebXR AR Raycasting Shapes" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/884783/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/884783/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-hands.md
+++ b/docs/tutorials/webxr-hands.md
@@ -4,8 +4,12 @@ tags: [input, vr, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/705931/2507B5-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample application with WebXR Hands Tracking.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/VmHVW3Wb/" title="WebXR Hands" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/705931/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-hands.md
+++ b/docs/tutorials/webxr-hands.md
@@ -12,4 +12,4 @@ Sample application with WebXR Hands Tracking.
     <iframe loading="lazy" src="https://playcanv.as/p/VmHVW3Wb/" title="WebXR Hands" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/705931/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/705931/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-hello-world.md
+++ b/docs/tutorials/webxr-hello-world.md
@@ -12,4 +12,4 @@ Basic scene with support for VR camera
     <iframe loading="lazy" src="https://playcanv.as/p/z7myUkHP/" title="WebXR Hello World" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/433339/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/433339/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-hello-world.md
+++ b/docs/tutorials/webxr-hello-world.md
@@ -4,8 +4,12 @@ tags: [vr, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/433339/4FCAA6-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Basic scene with support for VR camera
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/z7myUkHP/" title="WebXR Hello World" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/433339/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-plane-detection.md
+++ b/docs/tutorials/webxr-plane-detection.md
@@ -12,4 +12,4 @@ Example of how to use WebXR Augmented Reality: Plane Detection API. That allows 
     <iframe loading="lazy" src="https://playcanv.as/p/f2ESRGge/" title="WebXR: Plane Detection" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/782753/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/782753/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-plane-detection.md
+++ b/docs/tutorials/webxr-plane-detection.md
@@ -4,8 +4,12 @@ tags: [camera, ar, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/782753/602922-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Example of how to use WebXR Augmented Reality: Plane Detection API. That allows to *actively* track real world surface estimations.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/f2ESRGge/" title="WebXR: Plane Detection" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/782753/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-realistic-hands.md
+++ b/docs/tutorials/webxr-realistic-hands.md
@@ -4,8 +4,12 @@ tags: [input, vr, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/771952/F9B95C-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Realistic hands in VR!
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/pG6tosLX/" title="WebXR Realistic Hands" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/771952/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-realistic-hands.md
+++ b/docs/tutorials/webxr-realistic-hands.md
@@ -12,4 +12,4 @@ Realistic hands in VR!
     <iframe loading="lazy" src="https://playcanv.as/p/pG6tosLX/" title="WebXR Realistic Hands" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/771952/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/771952/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-tracked-controllers.md
+++ b/docs/tutorials/webxr-tracked-controllers.md
@@ -12,4 +12,4 @@ A sample application with boilerplate code for WebXR support with tracked contro
     <iframe loading="lazy" src="https://playcanv.as/p/TUBZkBEl/" title="WebXR Tracked Controllers" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/457917/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/457917/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-tracked-controllers.md
+++ b/docs/tutorials/webxr-tracked-controllers.md
@@ -4,8 +4,12 @@ tags: [input, vr, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/457917/EF3EDA-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 A sample application with boilerplate code for WebXR support with tracked controllers using PlayCanvas.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/TUBZkBEl/" title="WebXR Tracked Controllers" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/457917/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-vr-lab.md
+++ b/docs/tutorials/webxr-vr-lab.md
@@ -4,8 +4,12 @@ tags: [input, vr, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/446331/CAAA6B-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 A living project built by the PlayCanvas team to help developers learn about creating scalable and responsive WebXR VR applications for all devices
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/sAsiDvtC/" title="WebXR VR Lab" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/446331/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-vr-lab.md
+++ b/docs/tutorials/webxr-vr-lab.md
@@ -12,4 +12,4 @@ A living project built by the PlayCanvas team to help developers learn about cre
     <iframe loading="lazy" src="https://playcanv.as/p/sAsiDvtC/" title="WebXR VR Lab" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/446331/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/446331/'>Open Project ↗</Link>

--- a/docs/tutorials/world-space-ui-rendering-on-top.md
+++ b/docs/tutorials/world-space-ui-rendering-on-top.md
@@ -4,8 +4,12 @@ tags: [rendering, ui, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/691979/606E3E-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Learn how to render world space UI over the top of the world
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/0Ycgs0n7/" title="World space UI rendering on top" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/691979/'>Open Project ↗</Link>

--- a/docs/tutorials/world-space-ui-rendering-on-top.md
+++ b/docs/tutorials/world-space-ui-rendering-on-top.md
@@ -12,4 +12,4 @@ Learn how to render world space UI over the top of the world
     <iframe loading="lazy" src="https://playcanv.as/p/0Ycgs0n7/" title="World space UI rendering on top" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/691979/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/691979/'>Open Project ↗</Link>

--- a/docs/tutorials/world-to-ui-screen-space.md
+++ b/docs/tutorials/world-to-ui-screen-space.md
@@ -12,4 +12,4 @@ Sample in which a UI Element is positioned over a world space point.
     <iframe loading="lazy" src="https://playcanv.as/p/xU0TSSIY/" title="World to UI Screen space" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/679740/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/679740/'>Open Project ↗</Link>

--- a/docs/tutorials/world-to-ui-screen-space.md
+++ b/docs/tutorials/world-to-ui-screen-space.md
@@ -4,8 +4,12 @@ tags: [camera, ui, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/679740/EB1B6D-image-75.jpg
 ---
 
+import Link from '@docusaurus/Link';
+
 Sample in which a UI Element is positioned over a world space point.
 
 <div className="iframe-container">
     <iframe loading="lazy" src="https://playcanv.as/p/xU0TSSIY/" title="World to UI Screen space" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
+
+<Link to='https://playcanvas.com/editor/project/679740/'>Open Project ↗</Link>

--- a/docs/user-manual/editor/loading-screen.md
+++ b/docs/user-manual/editor/loading-screen.md
@@ -3,6 +3,8 @@ title: Loading Screen
 sidebar_position: 8
 ---
 
+import Link from '@docusaurus/Link';
+
 If you want to create a custom loading screen, you can go to the [Scene Settings][1] and click **Create Default** in the *Loading Screen* section. If you already have a valid loading screen script you can drag and drop it on the loading screen panel or click on **Select Existing**:
 
 <img loading="lazy" alt="Loading Screen" src="/images/user-manual/editor/loading-screen/loading-screen.png" />
@@ -123,3 +125,5 @@ pc.script.createLoadingScreen(function (app) {
 ```
 
 [1]: /user-manual/editor/settings
+
+<Link to='https://playcanvas.com/editor/project/458028/'>Open Project ↗</Link>

--- a/docs/user-manual/editor/loading-screen.md
+++ b/docs/user-manual/editor/loading-screen.md
@@ -126,4 +126,4 @@ pc.script.createLoadingScreen(function (app) {
 
 [1]: /user-manual/editor/settings
 
-<Link to='https://playcanvas.com/editor/project/458028/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/458028/'>Open Project ↗</Link>


### PR DESCRIPTION
this PR replaces all `/editor` tutorial links to the corresponding`/project` page which allows users to fork.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
