### PR TITLE
Update tutorial links to project

### DIFF
--- a/docs/tutorials/360-lookaround-camera.md
+++ b/docs/tutorials/360-lookaround-camera.md
@@ -13,4 +13,4 @@ Sample showing how to move the camera with mouse and touch to look around
     <iframe loading="lazy" src="https://playcanv.as/p/TMrb4ucs/" title="360 lookaround camera" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/438216/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/438216/'>Open Project ↗</Link>

--- a/docs/tutorials/animate-entities-with-curves.md
+++ b/docs/tutorials/animate-entities-with-curves.md
@@ -12,4 +12,4 @@ Sample showing use of curves to do basic animation with curves.
     <iframe loading="lazy" src="https://playcanv.as/p/cp3OGFrJ/" title="Animate entities with curves" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/438191/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/438191/'>Open Project ↗</Link>

--- a/docs/tutorials/animation-without-state-graph.md
+++ b/docs/tutorials/animation-without-state-graph.md
@@ -12,4 +12,4 @@ Example project on how to add and play animations without using a state graph
     <iframe loading="lazy" src="https://playcanv.as/p/xrWromyG/" title="Animation without State Graph" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/841793/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/841793/'>Open Project ↗</Link>

--- a/docs/tutorials/basic-touch-input.md
+++ b/docs/tutorials/basic-touch-input.md
@@ -12,4 +12,4 @@ Tutorial demonstrating basic touch input in PlayCanvas. Touch the box and move i
     <iframe loading="lazy" src="https://playcanv.as/p/iEIZxwBC/" title="Basic touch input" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/438010/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/438010/'>Open Project ↗</Link>

--- a/docs/tutorials/billboards.md
+++ b/docs/tutorials/billboards.md
@@ -12,4 +12,4 @@ Simple example of planes that always face the camera. i.e. billboards. Click on 
     <iframe loading="lazy" src="https://playcanv.as/p/ZCD1bSXQ/" title="Billboards" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/353938/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/353938/'>Open Project ↗</Link>

--- a/docs/tutorials/camera-following-a-path.md
+++ b/docs/tutorials/camera-following-a-path.md
@@ -12,4 +12,4 @@ Sample of a camera following points on a spline path.
     <iframe loading="lazy" src="https://playcanv.as/p/LuNJjRCr/" title="Camera following a path" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/438429/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/438429/'>Open Project ↗</Link>

--- a/docs/tutorials/camera-model-masking.md
+++ b/docs/tutorials/camera-model-masking.md
@@ -12,4 +12,4 @@ Sample showing to use render masking on the lights and models to enable lighting
     <iframe loading="lazy" src="https://playcanv.as/p/D4ZYtQrG/" title="Camera model masking" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/436772/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/436772/'>Open Project ↗</Link>

--- a/docs/tutorials/capturing-a-screenshot.md
+++ b/docs/tutorials/capturing-a-screenshot.md
@@ -12,4 +12,4 @@ A sample showing how capture a screenshot from a camera and download as a PNG
     <iframe loading="lazy" src="https://playcanv.as/p/Qlf6YvOV/" title="Capturing a screenshot" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0"/>
 </div>
 
-<Link to='https://playcanvas.com/editor/project/438437/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/438437/'>Open Project ↗</Link>

--- a/docs/tutorials/changing-textures-at-runtime.md
+++ b/docs/tutorials/changing-textures-at-runtime.md
@@ -12,4 +12,4 @@ A sample showing how to change a materials texture through a script
     <iframe loading="lazy" src="https://playcanv.as/p/Ivdxse42/" title="Changing textures at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/437446/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/437446/'>Open Project ↗</Link>

--- a/docs/tutorials/create-qr-code-at-runtime.md
+++ b/docs/tutorials/create-qr-code-at-runtime.md
@@ -12,4 +12,4 @@ Create QR codes at runtime with https://github.com/davidshimjs/qrcodejs
     <iframe loading="lazy" src="https://playcanv.as/p/O5MDA13T/" title="Create QR Code at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/1025199/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/1025199/'>Open Project ↗</Link>

--- a/docs/tutorials/creating-rigid-bodies-in-code.md
+++ b/docs/tutorials/creating-rigid-bodies-in-code.md
@@ -10,4 +10,4 @@ import Link from '@docusaurus/Link';
     <iframe loading="lazy" src="https://playcanv.as/p/w8Hhxovk/" title="Creating Rigid Bodies in Code" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/442322/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/442322/'>Open Project ↗</Link>

--- a/docs/tutorials/detecting-a-double-click.md
+++ b/docs/tutorials/detecting-a-double-click.md
@@ -12,4 +12,4 @@ Double click on the screen to move the camera
     <iframe loading="lazy" src="https://playcanv.as/p/BSSXwNAj/" title="Detecting a double click" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/436526/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/436526/'>Open Project ↗</Link>

--- a/docs/tutorials/detecting-a-double-tap.md
+++ b/docs/tutorials/detecting-a-double-tap.md
@@ -12,4 +12,4 @@ Sample showing how to detect a double tap on a touch screen.
     <iframe loading="lazy" src="https://playcanv.as/p/adm70VcR/" title="Detecting a double tap" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/436531/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/436531/'>Open Project ↗</Link>

--- a/docs/tutorials/detecting-a-long-press.md
+++ b/docs/tutorials/detecting-a-long-press.md
@@ -12,4 +12,4 @@ Sample showing how to detect a long press/touch to perform an action.
     <iframe loading="lazy" src="https://playcanv.as/p/kuSZj1KM/" title="Detecting a long press" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/438459/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/438459/'>Open Project ↗</Link>

--- a/docs/tutorials/dynamic-ui-scroll-view.md
+++ b/docs/tutorials/dynamic-ui-scroll-view.md
@@ -12,4 +12,4 @@ An example of adding and removing elements from the scroll view in the UI
     <iframe loading="lazy" src="https://playcanv.as/p/XIarUWAW/" title="Dynamic UI Scroll View" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/734864/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/734864/'>Open Project ↗</Link>

--- a/docs/tutorials/entity-picking-using-physics.md
+++ b/docs/tutorials/entity-picking-using-physics.md
@@ -12,4 +12,4 @@ A sample showing how to use the physics raycast to pick entities
     <iframe loading="lazy" src="https://playcanv.as/p/J02HZ0PC/" title="Entity picking using physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/410547/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/410547/'>Open Project ↗</Link>

--- a/docs/tutorials/entity-picking-without-physics.md
+++ b/docs/tutorials/entity-picking-without-physics.md
@@ -12,4 +12,4 @@ Sample showing how to pick at objects without using the physics system (extra 1M
     <iframe loading="lazy" src="https://playcanv.as/p/Sd7PcPNL/" title="Entity picking without physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/436809/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/436809/'>Open Project ↗</Link>

--- a/docs/tutorials/explosion-particle-effect.md
+++ b/docs/tutorials/explosion-particle-effect.md
@@ -12,4 +12,4 @@ Sample project showing a multi layered particle effect with screen shake.
     <iframe loading="lazy" src="https://playcanv.as/p/0hjGM2Lh/" title="Explosion Particle Effect" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/439297/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/439297/'>Open Project ↗</Link>

--- a/docs/tutorials/fading-objects-in-and-out.md
+++ b/docs/tutorials/fading-objects-in-and-out.md
@@ -12,4 +12,4 @@ Sample showing how to fade a model in and out using on a per model basis.
     <iframe loading="lazy" src="https://playcanv.as/p/kvToWplO/" title="Fading objects in and out" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/436566/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/436566/'>Open Project ↗</Link>

--- a/docs/tutorials/first-person-shooter-starter-kit.md
+++ b/docs/tutorials/first-person-shooter-starter-kit.md
@@ -12,4 +12,4 @@ Example project that extends the First Person Camera tutorial to move and jump a
     <iframe loading="lazy" src="https://playcanv.as/p/deRCEGms/" title="First Person Shooter Starter Kit" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/626211/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/626211/'>Open Project ↗</Link>

--- a/docs/tutorials/flaming-fireball.md
+++ b/docs/tutorials/flaming-fireball.md
@@ -12,4 +12,4 @@ Sample with a fireball that moves with the mouse
     <iframe loading="lazy" src="https://playcanv.as/p/eavVneJi/" title="Flaming fireball" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/439385/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/439385/'>Open Project ↗</Link>

--- a/docs/tutorials/flappy-bird.md
+++ b/docs/tutorials/flappy-bird.md
@@ -12,4 +12,4 @@ Flappy's Back! Guide Flappy Bird through as many pipes as you can. Made with @pl
     <iframe loading="lazy" src="https://playcanv.as/p/2OlkUaxF/" title="Flappy Bird" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/375389/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/375389/'>Open Project ↗</Link>

--- a/docs/tutorials/frames-per-sec-fps-counter.md
+++ b/docs/tutorials/frames-per-sec-fps-counter.md
@@ -12,4 +12,4 @@ Sample with self contained FPS counter that can be used in other projects.
     <iframe loading="lazy" src="https://playcanv.as/p/VRCXOsxi/" title="Frames Per Sec (FPS) counter" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/433323/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/433323/'>Open Project ↗</Link>

--- a/docs/tutorials/htmlcss---live-updates.md
+++ b/docs/tutorials/htmlcss---live-updates.md
@@ -12,4 +12,4 @@ Example of how to use live HTML and CSS editing.
     <iframe loading="lazy" src="https://playcanv.as/p/KqqOGvVi/" title="HTML/CSS - Live Updates" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/354600/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/354600/'>Open Project ↗</Link>

--- a/docs/tutorials/htmlcss-ui.md
+++ b/docs/tutorials/htmlcss-ui.md
@@ -12,4 +12,4 @@ Example of how to use HTML and CSS to create UI
     <iframe loading="lazy" src="https://playcanv.as/p/B4W3iveA/" title="HTML/CSS UI" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/443090/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/443090/'>Open Project ↗</Link>

--- a/docs/tutorials/information-hotspots.md
+++ b/docs/tutorials/information-hotspots.md
@@ -12,4 +12,4 @@ Sample showing information hotspots on a scene.
     <iframe loading="lazy" src="https://playcanv.as/p/9yrH9xRZ/" title="Information hotspots" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/438515/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/438515/'>Open Project ↗</Link>

--- a/docs/tutorials/load-assets-with-a-progress-bar.md
+++ b/docs/tutorials/load-assets-with-a-progress-bar.md
@@ -12,4 +12,4 @@ Sample showing how to load multiple assets at runtime with a progress bar.
     <iframe loading="lazy" src="https://playcanv.as/p/MGKfj6jm/" title="Load assets with a progress bar" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/436584/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/436584/'>Open Project ↗</Link>

--- a/docs/tutorials/load-multiple-assets-at-runtime.md
+++ b/docs/tutorials/load-multiple-assets-at-runtime.md
@@ -12,4 +12,4 @@ Sample showing how to load multiple assets at runtime.
     <iframe loading="lazy" src="https://playcanv.as/p/P7eFFj4u/" title="Load multiple assets at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/439131/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/439131/'>Open Project ↗</Link>

--- a/docs/tutorials/loading-an-asset-at-runtime.md
+++ b/docs/tutorials/loading-an-asset-at-runtime.md
@@ -12,4 +12,4 @@ Sample showing how to load an asset at runtime so you don't have to preload it a
     <iframe loading="lazy" src="https://playcanv.as/p/xIkPLoyX/" title="Loading an asset at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/439122/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/439122/'>Open Project ↗</Link>

--- a/docs/tutorials/loading-circle-ui.md
+++ b/docs/tutorials/loading-circle-ui.md
@@ -12,4 +12,4 @@ An example of a radial loading circle
     <iframe loading="lazy" src="https://playcanv.as/p/WVAhW4ft/" title="Loading Circle UI" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/705273/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/705273/'>Open Project ↗</Link>

--- a/docs/tutorials/loading-draco-compressed-glbs.md
+++ b/docs/tutorials/loading-draco-compressed-glbs.md
@@ -16,4 +16,4 @@ See https://github.com/CesiumGS/gltf-pipeline for the tool to compress glTF mode
     <iframe loading="lazy" src="https://playcanv.as/p/2uU2aYDh/" title="Loading Draco Compressed GLBs" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/730372/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/730372/'>Open Project ↗</Link>

--- a/docs/tutorials/loading-gltf-glbs.md
+++ b/docs/tutorials/loading-gltf-glbs.md
@@ -12,4 +12,4 @@ How to load a GLB as a binary asset.
     <iframe loading="lazy" src="https://playcanv.as/p/RIN6pM0I/" title="Loading glTF GLBs" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/730738/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/730738/'>Open Project ↗</Link>

--- a/docs/tutorials/locking-the-mouse.md
+++ b/docs/tutorials/locking-the-mouse.md
@@ -12,4 +12,4 @@ A sample showing how to lock the mouse upon clicking.
     <iframe loading="lazy" src="https://playcanv.as/p/2Epvl0CT/" title="Locking the mouse" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/438440/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/438440/'>Open Project ↗</Link>

--- a/docs/tutorials/mobile-ui-safe-areas.md
+++ b/docs/tutorials/mobile-ui-safe-areas.md
@@ -12,4 +12,4 @@ Example project to handle safe areas on the UI - https://developer.playcanvas.co
     <iframe loading="lazy" src="https://playcanv.as/p/z5pXervL/" title="Mobile UI Safe Areas" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/828118/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/828118/'>Open Project ↗</Link>

--- a/docs/tutorials/multiple-camera-layers.md
+++ b/docs/tutorials/multiple-camera-layers.md
@@ -12,4 +12,4 @@ Demonstration project that shows how to use multiple cameras and layers to rende
     <iframe loading="lazy" src="https://playcanv.as/p/h7V3tWZK/" title="Multiple Camera Layers" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/593374/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/593374/'>Open Project ↗</Link>

--- a/docs/tutorials/multiple-viewport-rendering.md
+++ b/docs/tutorials/multiple-viewport-rendering.md
@@ -12,4 +12,4 @@ A sample showing how to render multiple viewports by modifying the viewport prop
     <iframe loading="lazy" src="https://playcanv.as/p/bkLdoYPQ/" title="Multiple Viewport Rendering" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/443666/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/443666/'>Open Project ↗</Link>

--- a/docs/tutorials/multitouch-input.md
+++ b/docs/tutorials/multitouch-input.md
@@ -12,4 +12,4 @@ Sample that draws lines between all the current touches on the screen.
     <iframe loading="lazy" src="https://playcanv.as/p/p56cF89z/" title="Multitouch input" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/437474/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/437474/'>Open Project ↗</Link>

--- a/docs/tutorials/orange-room.md
+++ b/docs/tutorials/orange-room.md
@@ -12,4 +12,4 @@ Interactive interior visualisation with dynamic reflections and HDR lightmaps.
     <iframe loading="lazy" src="https://playcanv.as/p/1ha5glKf/" title="Orange Room" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/345310/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/345310/'>Open Project ↗</Link>

--- a/docs/tutorials/orbit-camera.md
+++ b/docs/tutorials/orbit-camera.md
@@ -12,4 +12,4 @@ Sample with an orbit camera around an entity with both mouse and touch. Scroll w
     <iframe loading="lazy" src="https://playcanv.as/p/fI6jSYjK/" title="Orbit camera" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/438243/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/438243/'>Open Project ↗</Link>

--- a/docs/tutorials/pan-camera-to-target.md
+++ b/docs/tutorials/pan-camera-to-target.md
@@ -14,4 +14,4 @@ Credit: https://playcanvas.com/lexxik
     <iframe loading="lazy" src="https://playcanv.as/p/5SJsWtg3/" title="Pan Camera to Target" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/693889/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/693889/'>Open Project ↗</Link>

--- a/docs/tutorials/pauseplay-application.md
+++ b/docs/tutorials/pauseplay-application.md
@@ -12,4 +12,4 @@ A sample showing how to pause and resume an app by modifying the timeScale prope
     <iframe loading="lazy" src="https://playcanv.as/p/sNoeqOZL/" title="Pause/Play application" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/437707/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/437707/'>Open Project ↗</Link>

--- a/docs/tutorials/physics-raycasting-by-tag.md
+++ b/docs/tutorials/physics-raycasting-by-tag.md
@@ -12,4 +12,4 @@ Sample showing how to pick an entity by tag using raycastAll
     <iframe loading="lazy" src="https://playcanv.as/p/j1aT7giL/" title="Physics raycasting by tag" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/691309/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/691309/'>Open Project ↗</Link>

--- a/docs/tutorials/physics-with-ccd.md
+++ b/docs/tutorials/physics-with-ccd.md
@@ -12,4 +12,4 @@ A sample with a script to setup and enable CCD for very fast moving physics obje
     <iframe loading="lazy" src="https://playcanv.as/p/jBMFj7l2/" title="Physics with CCD" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/447023/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/447023/'>Open Project ↗</Link>

--- a/docs/tutorials/place-an-entity-with-physics.md
+++ b/docs/tutorials/place-an-entity-with-physics.md
@@ -12,4 +12,4 @@ A sample showing how to place objects in the world by using physics. Click on gr
     <iframe loading="lazy" src="https://playcanv.as/p/JCW3CUKx/" title="Place an entity with physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/437836/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/437836/'>Open Project ↗</Link>

--- a/docs/tutorials/place-entity-without-physics.md
+++ b/docs/tutorials/place-entity-without-physics.md
@@ -12,4 +12,4 @@ A sample showing how to place objects in the world without using physics. Click 
     <iframe loading="lazy" src="https://playcanv.as/p/Z2ieIwf8/" title="Place entity without physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/437894/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/437894/'>Open Project ↗</Link>

--- a/docs/tutorials/planar-mirror-reflection.md
+++ b/docs/tutorials/planar-mirror-reflection.md
@@ -14,4 +14,4 @@ Example of creating a planar reflection being used for a transparent mirror/wate
     <iframe loading="lazy" src="https://playcanv.as/p/bQE35vbj/" title="Planar Mirror Reflection" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/717166/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/717166/'>Open Project ↗</Link>

--- a/docs/tutorials/planet-earth.md
+++ b/docs/tutorials/planet-earth.md
@@ -10,4 +10,4 @@ import Link from '@docusaurus/Link';
     <iframe loading="lazy" src="https://playcanv.as/p/kU1mx35y/" title="Planet Earth" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/419706/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/419706/'>Open Project ↗</Link>

--- a/docs/tutorials/point-and-click-movement.md
+++ b/docs/tutorials/point-and-click-movement.md
@@ -12,4 +12,4 @@ Sample showing a simple point and click system to move an object where you user 
     <iframe loading="lazy" src="https://playcanv.as/p/RQAovNH6/" title="Point and click movement" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/461494/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/461494/'>Open Project ↗</Link>

--- a/docs/tutorials/procedural-gradient-texture.md
+++ b/docs/tutorials/procedural-gradient-texture.md
@@ -12,4 +12,4 @@ Example of creating a procedural texture with a gradient effect by LeXXik
     <iframe loading="lazy" src="https://playcanv.as/p/5qggchI4/" title="Procedural Gradient Texture" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/708598/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/708598/'>Open Project ↗</Link>

--- a/docs/tutorials/rainbow-trail-with-mesh-api.md
+++ b/docs/tutorials/rainbow-trail-with-mesh-api.md
@@ -12,4 +12,4 @@ A rainbow trail using the pc.Mesh API
     <iframe loading="lazy" src="https://playcanv.as/p/jGeaTg6B/" title="Rainbow Trail with Mesh API" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/1029772/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/1029772/'>Open Project ↗</Link>

--- a/docs/tutorials/raycast-with-camera-viewports.md
+++ b/docs/tutorials/raycast-with-camera-viewports.md
@@ -12,4 +12,4 @@ Raycasting with multiple camera viewports. Click on the shapes in each view
     <iframe loading="lazy" src="https://playcanv.as/p/dXvrDzH2/" title="Raycast with Camera Viewports" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/964118/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/964118/'>Open Project ↗</Link>

--- a/docs/tutorials/render-3d-world-to-ui.md
+++ b/docs/tutorials/render-3d-world-to-ui.md
@@ -12,4 +12,4 @@ Render 3D objects as part of the UI
     <iframe loading="lazy" src="https://playcanv.as/p/CQzD8zlM/" title="Render 3D World to UI" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/855150/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/855150/'>Open Project ↗</Link>

--- a/docs/tutorials/resolution-scaling.md
+++ b/docs/tutorials/resolution-scaling.md
@@ -12,4 +12,4 @@ Example project on rendering the world at different resolutions without the UI b
     <iframe loading="lazy" src="https://playcanv.as/p/qx7PyE7q/" title="Resolution Scaling" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/708300/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/708300/'>Open Project ↗</Link>

--- a/docs/tutorials/right-to-left-language-support.md
+++ b/docs/tutorials/right-to-left-language-support.md
@@ -12,4 +12,4 @@ Scripts to use for RTL language support such Arabic
     <iframe loading="lazy" src="https://playcanv.as/p/k2TruV1u/" title="Right to left language support" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/764309/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/764309/'>Open Project ↗</Link>

--- a/docs/tutorials/rotating-objects-with-mouse.md
+++ b/docs/tutorials/rotating-objects-with-mouse.md
@@ -12,4 +12,4 @@ Sample showing how to rotate an object using the mouse in screen space
     <iframe loading="lazy" src="https://playcanv.as/p/BgbpyC0Y/" title="Rotating Objects with Mouse" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/442490/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/442490/'>Open Project ↗</Link>

--- a/docs/tutorials/shockwave.md
+++ b/docs/tutorials/shockwave.md
@@ -12,4 +12,4 @@ Shockwave ripple post effect
     <iframe loading="lazy" src="https://playcanv.as/p/c16yO94k/" title="Shockwave" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/440868/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/440868/'>Open Project ↗</Link>

--- a/docs/tutorials/simple-shape-raycasting.md
+++ b/docs/tutorials/simple-shape-raycasting.md
@@ -12,4 +12,4 @@ Sample showing how to pick at an entity
     <iframe loading="lazy" src="https://playcanv.as/p/QGiL8OdM/" title="Simple shape raycasting" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/457922/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/457922/'>Open Project ↗</Link>

--- a/docs/tutorials/simple-water-surface.md
+++ b/docs/tutorials/simple-water-surface.md
@@ -10,4 +10,4 @@ import Link from '@docusaurus/Link';
     <iframe loading="lazy" src="https://playcanv.as/p/NeYgvM9z/" title="Simple water surface" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/438476/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/438476/'>Open Project ↗</Link>

--- a/docs/tutorials/smooth-camera-movement.md
+++ b/docs/tutorials/smooth-camera-movement.md
@@ -12,4 +12,4 @@ Sample with a smooth transition of a camera from one position and rotation to an
     <iframe loading="lazy" src="https://playcanv.as/p/T7VKMrs8/" title="Smooth camera movement" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/437461/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/437461/'>Open Project ↗</Link>

--- a/docs/tutorials/sound-volume-control-using-curve.md
+++ b/docs/tutorials/sound-volume-control-using-curve.md
@@ -12,4 +12,4 @@ Sample showing how to control the volume of a sound slot using curve data. Click
     <iframe loading="lazy" src="https://playcanv.as/p/hmRciuNn/" title="Sound volume control using curve" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/436116/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/436116/'>Open Project ↗</Link>

--- a/docs/tutorials/space-rocks.md
+++ b/docs/tutorials/space-rocks.md
@@ -12,4 +12,4 @@ Get started making your own space shooter game by forking this template Asteroid
     <iframe loading="lazy" src="https://playcanv.as/p/cAFbOEtL/" title="Space Rocks!" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/1029772/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/1029772/'>Open Project ↗</Link>

--- a/docs/tutorials/static-batching.md
+++ b/docs/tutorials/static-batching.md
@@ -10,4 +10,4 @@ import Link from '@docusaurus/Link';
     <iframe loading="lazy" src="https://playcanv.as/p/Qo7T1kqU/" title="Static Batching" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/520389/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/520389/'>Open Project ↗</Link>

--- a/docs/tutorials/stencil-buffer---3d-magic-card.md
+++ b/docs/tutorials/stencil-buffer---3d-magic-card.md
@@ -14,4 +14,4 @@ Credit: @ alexanderrdx for the original project
     <iframe loading="lazy" src="https://playcanv.as/p/RAQhfemb/" title="Stencil Buffer - 3D Magic Card" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/855103/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/855103/'>Open Project ↗</Link>

--- a/docs/tutorials/switching-materials-at-runtime.md
+++ b/docs/tutorials/switching-materials-at-runtime.md
@@ -12,4 +12,4 @@ Sample switching on a model materials at runtime.
     <iframe loading="lazy" src="https://playcanv.as/p/7EZvdnZd/" title="Switching materials at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/437442/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/437442/'>Open Project ↗</Link>

--- a/docs/tutorials/third-person-controller.md
+++ b/docs/tutorials/third-person-controller.md
@@ -12,4 +12,4 @@ A simple third person controller.
     <iframe loading="lazy" src="https://playcanv.as/p/Q7CJA9Ku/" title="Third Person Controller" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/705595/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/705595/'>Open Project ↗</Link>

--- a/docs/tutorials/tic-tac-toe.md
+++ b/docs/tutorials/tic-tac-toe.md
@@ -12,4 +12,4 @@ The classic game Tic Tac Toe
     <iframe loading="lazy" src="https://playcanv.as/p/i5csiIb9/" title="Tic Tac Toe" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/671439/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/671439/'>Open Project ↗</Link>

--- a/docs/tutorials/timers.md
+++ b/docs/tutorials/timers.md
@@ -12,4 +12,4 @@ Example of extending the PlayCanvas engine to create one shot timers. Press P to
     <iframe loading="lazy" src="https://playcanv.as/p/WsI6QA7y/" title="Timers" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/691984/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/691984/'>Open Project ↗</Link>

--- a/docs/tutorials/tutorial-layout-groups.md
+++ b/docs/tutorials/tutorial-layout-groups.md
@@ -12,4 +12,4 @@ Use the Layout Group component to build a user interface.
     <iframe loading="lazy" src="https://playcanv.as/p/y4JwxWTI/" title="Tutorial: Layout Groups" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/553515/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/553515/'>Open Project ↗</Link>

--- a/docs/tutorials/tutorial-normal-mapped-text.md
+++ b/docs/tutorials/tutorial-normal-mapped-text.md
@@ -12,4 +12,4 @@ Dynamically generate normal maps and parallax maps for text
     <iframe loading="lazy" src="https://playcanv.as/p/MbMb81DM/" title="Tutorial: Normal Mapped Text" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/855103/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/855103/'>Open Project ↗</Link>

--- a/docs/tutorials/tutorial-plasma-shader-chunk.md
+++ b/docs/tutorials/tutorial-plasma-shader-chunk.md
@@ -12,4 +12,4 @@ A demonstration of a GLSL effect from Shadertoy being used in a shader chunk on 
     <iframe loading="lazy" src="https://playcanv.as/p/NLgp097Q/" title="Tutorial: Plasma Shader Chunk" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/453304/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/453304/'>Open Project ↗</Link>

--- a/docs/tutorials/tutorial-shop-user-interface.md
+++ b/docs/tutorials/tutorial-shop-user-interface.md
@@ -12,4 +12,4 @@ Build a Shop User Interface screen using UI Elements, Layout Groups, Button comp
     <iframe loading="lazy" src="https://playcanv.as/p/yN4CxzAs/" title="Tutorial: Shop User Interface" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/559492/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/559492/'>Open Project ↗</Link>

--- a/docs/tutorials/using-events-with-scripts.md
+++ b/docs/tutorials/using-events-with-scripts.md
@@ -12,4 +12,4 @@ Sample showing how to communicate between scripts using events.
     <iframe loading="lazy" src="https://playcanv.as/p/HXrtITkb/" title="Using events with scripts" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/437673/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/437673/'>Open Project ↗</Link>

--- a/docs/tutorials/vehicle-physics.md
+++ b/docs/tutorials/vehicle-physics.md
@@ -12,4 +12,4 @@ An implementation of vehicle physics in PlayCanvas, using the RaycastVehicle API
     <iframe loading="lazy" src="https://playcanv.as/p/CxgnAp22/" title="Vehicle Physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/643289/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/643289/'>Open Project ↗</Link>

--- a/docs/tutorials/vhscrt-post-effect.md
+++ b/docs/tutorials/vhscrt-post-effect.md
@@ -12,4 +12,4 @@ Basic fullscreen effect simulating a bad video screen like an old CRT.
     <iframe loading="lazy" src="https://playcanv.as/p/6hhSiHG3/" title="VHS/CRT Post Effect" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/373076/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/373076/'>Open Project ↗</Link>

--- a/docs/tutorials/vignette-abberation.md
+++ b/docs/tutorials/vignette-abberation.md
@@ -10,4 +10,4 @@ import Link from '@docusaurus/Link';
     <iframe loading="lazy" src="https://playcanv.as/p/UwEmhiJf/" title="Vignette Abberation" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/440854/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/440854/'>Open Project ↗</Link>

--- a/docs/tutorials/warp-a-sprite-with-glsl.md
+++ b/docs/tutorials/warp-a-sprite-with-glsl.md
@@ -10,4 +10,4 @@ import Link from '@docusaurus/Link';
     <iframe loading="lazy" src="https://playcanv.as/p/3NdgiVsp/" title="Warp a Sprite with GLSL" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/426038/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/426038/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-360-image.md
+++ b/docs/tutorials/webxr-360-image.md
@@ -12,4 +12,4 @@ import Link from '@docusaurus/Link';
     <iframe loading="lazy" src="https://playcanv.as/p/v6qoi4Yt/" title="WebXR 360 Image" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/434266/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/434266/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-360-video.md
+++ b/docs/tutorials/webxr-360-video.md
@@ -12,4 +12,4 @@ import Link from '@docusaurus/Link';
     <iframe loading="lazy" src="https://playcanv.as/p/G0d8FneG/" title="WebXR 360 Video" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/434444/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/434444/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-ar-dom-overlay.md
+++ b/docs/tutorials/webxr-ar-dom-overlay.md
@@ -12,4 +12,4 @@ Example of how to use DOM (HTML + CSS) with WebXR AR session.
     <iframe loading="lazy" src="https://playcanv.as/p/S01LYTIU/" title="WebXR AR: DOM Overlay" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/691979/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/691979/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-ar-hit-test.md
+++ b/docs/tutorials/webxr-ar-hit-test.md
@@ -12,4 +12,4 @@ Example of how to use WebXR Hit Test API. That allows to hit test real world geo
     <iframe loading="lazy" src="https://playcanv.as/p/Kjol3uRS/" title="WebXR AR: Hit Test" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/672464/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/672464/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-ar-image-tracking.md
+++ b/docs/tutorials/webxr-ar-image-tracking.md
@@ -12,4 +12,4 @@ Example of how to use WebXR Augmented Reality: Image Tracking API. That allows t
     <iframe loading="lazy" src="https://playcanv.as/p/PCsSvN5h/" title="WebXR: AR Image Tracking" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/739875/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/739875/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-ar-raycasting-shapes.md
+++ b/docs/tutorials/webxr-ar-raycasting-shapes.md
@@ -14,4 +14,4 @@ Tap the shapes to change their color!
     <iframe loading="lazy" src="https://playcanv.as/p/qiLEOeL7/" title="WebXR AR Raycasting Shapes" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/884783/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/884783/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-hands.md
+++ b/docs/tutorials/webxr-hands.md
@@ -12,4 +12,4 @@ Sample application with WebXR Hands Tracking.
     <iframe loading="lazy" src="https://playcanv.as/p/VmHVW3Wb/" title="WebXR Hands" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/705931/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/705931/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-hello-world.md
+++ b/docs/tutorials/webxr-hello-world.md
@@ -12,4 +12,4 @@ Basic scene with support for VR camera
     <iframe loading="lazy" src="https://playcanv.as/p/z7myUkHP/" title="WebXR Hello World" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/433339/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/433339/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-plane-detection.md
+++ b/docs/tutorials/webxr-plane-detection.md
@@ -12,4 +12,4 @@ Example of how to use WebXR Augmented Reality: Plane Detection API. That allows 
     <iframe loading="lazy" src="https://playcanv.as/p/f2ESRGge/" title="WebXR: Plane Detection" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/782753/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/782753/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-realistic-hands.md
+++ b/docs/tutorials/webxr-realistic-hands.md
@@ -12,4 +12,4 @@ Realistic hands in VR!
     <iframe loading="lazy" src="https://playcanv.as/p/pG6tosLX/" title="WebXR Realistic Hands" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/771952/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/771952/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-tracked-controllers.md
+++ b/docs/tutorials/webxr-tracked-controllers.md
@@ -12,4 +12,4 @@ A sample application with boilerplate code for WebXR support with tracked contro
     <iframe loading="lazy" src="https://playcanv.as/p/TUBZkBEl/" title="WebXR Tracked Controllers" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/457917/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/457917/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-vr-lab.md
+++ b/docs/tutorials/webxr-vr-lab.md
@@ -12,4 +12,4 @@ A living project built by the PlayCanvas team to help developers learn about cre
     <iframe loading="lazy" src="https://playcanv.as/p/sAsiDvtC/" title="WebXR VR Lab" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/446331/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/446331/'>Open Project ↗</Link>

--- a/docs/tutorials/world-space-ui-rendering-on-top.md
+++ b/docs/tutorials/world-space-ui-rendering-on-top.md
@@ -12,4 +12,4 @@ Learn how to render world space UI over the top of the world
     <iframe loading="lazy" src="https://playcanv.as/p/0Ycgs0n7/" title="World space UI rendering on top" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/691979/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/691979/'>Open Project ↗</Link>

--- a/docs/tutorials/world-to-ui-screen-space.md
+++ b/docs/tutorials/world-to-ui-screen-space.md
@@ -12,4 +12,4 @@ Sample in which a UI Element is positioned over a world space point.
     <iframe loading="lazy" src="https://playcanv.as/p/xU0TSSIY/" title="World to UI Screen space" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
 </div>
 
-<Link to='https://playcanvas.com/editor/project/679740/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/679740/'>Open Project ↗</Link>

--- a/docs/user-manual/editor/loading-screen.md
+++ b/docs/user-manual/editor/loading-screen.md
@@ -126,4 +126,4 @@ pc.script.createLoadingScreen(function (app) {
 
 [1]: /user-manual/editor/settings
 
-<Link to='https://playcanvas.com/editor/project/458028/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/458028/'>Open Project ↗</Link>


### PR DESCRIPTION
This PR updates all the tutorial links that were pointing to `/editor` to now open in the project page

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
