### PR TITLE
Add crawler-name to GH Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Algolia Crawler Automatic Crawl
         uses: algolia/algoliasearch-crawler-github-actions@v1.1.10
         with: # mandatory parameters
+          crawler-name: developer.playcanvas.com
           crawler-user-id: ${{ secrets.CRAWLER_USER_ID }}
           crawler-api-key: ${{ secrets.CRAWLER_API_KEY }}
           algolia-app-id: ${{ secrets.ALGOLIA_APP_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Algolia Crawler Automatic Crawl
         uses: algolia/algoliasearch-crawler-github-actions@v1.1.10
         with: # mandatory parameters
-          crawler-name: developer.playcanvas.com
+          crawler-name: developer.playcanvas
           crawler-user-id: ${{ secrets.CRAWLER_USER_ID }}
           crawler-api-key: ${{ secrets.CRAWLER_API_KEY }}
           algolia-app-id: ${{ secrets.ALGOLIA_APP_ID }}


### PR DESCRIPTION
Adding crawler-name property to GH action to fix algolia crawl issue in Github Actions

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
