### PR TITLE
removes vec3 from enum

### DIFF
--- a/docs/user-manual/scripting/script-attributes.md
+++ b/docs/user-manual/scripting/script-attributes.md
@@ -133,7 +133,7 @@ MyScript.attributes.add('value', {
 });
 ```
 
-Use the enum property to declare the list of possible values for your enumeration. Property is an array of objects where each object is an option where `key` is a title of an option and `value` is a value for attribute. This property can be used for various attribute types, e.g. `number`, `string`, `vec3`.
+Use the enum property to declare the list of possible values for your enumeration. Property is an array of objects where each object is an option where `key` is a title of an option and `value` is a value for attribute. This property can be used for various attribute types, e.g. `number`, `string`.
 
 ### JSON attribute
 


### PR DESCRIPTION
Removes vec3 from enum documentation as it's not supported.

Fixes https://github.com/playcanvas/developer.playcanvas.com/issues/647

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/main/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
