### PR TITLE
Make iframes consistent and XR and fullscreen capable

### DIFF
--- a/docs/tutorials/360-lookaround-camera.md
+++ b/docs/tutorials/360-lookaround-camera.md
@@ -10,7 +10,7 @@ import Link from '@docusaurus/Link';
 Sample showing how to move the camera with mouse and touch to look around
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/TMrb4ucs/" title="360 lookaround camera" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/TMrb4ucs/" title="360 lookaround camera" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/438216/'>Open Project ↗</Link>

--- a/docs/tutorials/Using-forces-on-rigid-bodies.md
+++ b/docs/tutorials/Using-forces-on-rigid-bodies.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className='iframe-container'>
-    <iframe loading="lazy" src="https://playcanv.as/p/8LTSuf4F/" title="Forces and Impulses" />
+    <iframe src="https://playcanv.as/p/8LTSuf4F/" title="Forces and Impulses" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *Use the cursor keys to apply impulses, the WASD keys to apply torques and rotate the cube. Press and hold F to apply a constant upward force to cancel gravity effects.*

--- a/docs/tutorials/additive-loading-scenes.md
+++ b/docs/tutorials/additive-loading-scenes.md
@@ -7,7 +7,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/6850
 Full documentation for Loading Scenes is now in the [User Manual][documentation-page].
 
 <div className='iframe-container'>
-    <iframe loading="lazy" src="https://playcanv.as/e/p/cjBInud1/" title="Additive Loading Scenes"></iframe>
+    <iframe src="https://playcanv.as/e/p/cjBInud1/" title="Additive Loading Scenes"></iframe>
 </div>
 
 [documentation-page]: /user-manual/scenes/loading-scenes/

--- a/docs/tutorials/additive-loading-scenes.md
+++ b/docs/tutorials/additive-loading-scenes.md
@@ -7,7 +7,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/6850
 Full documentation for Loading Scenes is now in the [User Manual][documentation-page].
 
 <div className='iframe-container'>
-    <iframe src="https://playcanv.as/e/p/cjBInud1/" title="Additive Loading Scenes"></iframe>
+    <iframe src="https://playcanv.as/e/p/cjBInud1/" title="Additive Loading Scenes" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 [documentation-page]: /user-manual/scenes/loading-scenes/

--- a/docs/tutorials/advance-loading-screen.md
+++ b/docs/tutorials/advance-loading-screen.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Project sample showing how to use project image assets in the loading screen
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Di3Fb3fx/" title="Advance loading screen" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/Di3Fb3fx/" title="Advance loading screen" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/458028/'>Open Project ↗</Link>

--- a/docs/tutorials/anim-blending.md
+++ b/docs/tutorials/anim-blending.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className='iframe-container'>
-    <iframe loading="lazy" src="https://playcanv.as/p/HI8kniOx/" title="Anim State Graph Blending"></iframe>
+    <iframe src="https://playcanv.as/p/HI8kniOx/" title="Anim State Graph Blending"></iframe>
 </div>
 
 :::info

--- a/docs/tutorials/anim-blending.md
+++ b/docs/tutorials/anim-blending.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className='iframe-container'>
-    <iframe src="https://playcanv.as/p/HI8kniOx/" title="Anim State Graph Blending"></iframe>
+    <iframe src="https://playcanv.as/p/HI8kniOx/" title="Anim State Graph Blending" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 :::info

--- a/docs/tutorials/animate-entities-with-curves.md
+++ b/docs/tutorials/animate-entities-with-curves.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample showing use of curves to do basic animation with curves.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/cp3OGFrJ/" title="Animate entities with curves" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/cp3OGFrJ/" title="Animate entities with curves" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/438191/'>Open Project ↗</Link>

--- a/docs/tutorials/animated-textures.md
+++ b/docs/tutorials/animated-textures.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className='iframe-container'>
-    <iframe src="https://playcanv.as/p/BM93v05L/" title="Animated Textures"></iframe>
+    <iframe src="https://playcanv.as/p/BM93v05L/" title="Animated Textures" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *See the [full project][1].*

--- a/docs/tutorials/animated-textures.md
+++ b/docs/tutorials/animated-textures.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className='iframe-container'>
-    <iframe loading="lazy" src="https://playcanv.as/p/BM93v05L/" title="Animated Textures"></iframe>
+    <iframe src="https://playcanv.as/p/BM93v05L/" title="Animated Textures"></iframe>
 </div>
 
 *See the [full project][1].*

--- a/docs/tutorials/animation-blending.md
+++ b/docs/tutorials/animation-blending.md
@@ -11,7 +11,7 @@ This tutorial uses the deprecated Model and Animation components. Please refer t
 :::
 
 <div className='iframe-container'>
-    <iframe src="https://playcanv.as/p/HI8kniOx/" title="Animation Blending"></iframe>
+    <iframe src="https://playcanv.as/p/HI8kniOx/" title="Animation Blending" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 :::info

--- a/docs/tutorials/animation-blending.md
+++ b/docs/tutorials/animation-blending.md
@@ -11,7 +11,7 @@ This tutorial uses the deprecated Model and Animation components. Please refer t
 :::
 
 <div className='iframe-container'>
-    <iframe loading="lazy" src="https://playcanv.as/p/HI8kniOx/" title="Animation Blending"></iframe>
+    <iframe src="https://playcanv.as/p/HI8kniOx/" title="Animation Blending"></iframe>
 </div>
 
 :::info

--- a/docs/tutorials/animation-without-state-graph.md
+++ b/docs/tutorials/animation-without-state-graph.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Example project on how to add and play animations without using a state graph
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/xrWromyG/" title="Animation without State Graph" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/xrWromyG/" title="Animation without State Graph" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/841793/'>Open Project ↗</Link>

--- a/docs/tutorials/audio-effects.md
+++ b/docs/tutorials/audio-effects.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/1nS6AnC9/" title="Audio Effects"></iframe>
+    <iframe src="https://playcanv.as/p/1nS6AnC9/" title="Audio Effects"></iframe>
 </div>
 
 *Click on the various buttons to try out different sound effects.*

--- a/docs/tutorials/audio-effects.md
+++ b/docs/tutorials/audio-effects.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/1nS6AnC9/" title="Audio Effects"></iframe>
+    <iframe src="https://playcanv.as/p/1nS6AnC9/" title="Audio Effects" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *Click on the various buttons to try out different sound effects.*

--- a/docs/tutorials/basic-audio.md
+++ b/docs/tutorials/basic-audio.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/XqMw92Zl/" title="Basic Audio"></iframe>
+    <iframe src="https://playcanv.as/p/XqMw92Zl/" title="Basic Audio"></iframe>
 </div>
 
 *The tank is moving around the robot. You can shoot by clicking anywhere on the game.*

--- a/docs/tutorials/basic-audio.md
+++ b/docs/tutorials/basic-audio.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/XqMw92Zl/" title="Basic Audio"></iframe>
+    <iframe src="https://playcanv.as/p/XqMw92Zl/" title="Basic Audio" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *The tank is moving around the robot. You can shoot by clicking anywhere on the game.*

--- a/docs/tutorials/basic-touch-input.md
+++ b/docs/tutorials/basic-touch-input.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Tutorial demonstrating basic touch input in PlayCanvas. Touch the box and move it around the screen!
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/iEIZxwBC/" title="Basic touch input" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/iEIZxwBC/" title="Basic touch input" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/438010/'>Open Project ↗</Link>

--- a/docs/tutorials/billboards.md
+++ b/docs/tutorials/billboards.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Simple example of planes that always face the camera. i.e. billboards. Click on the box and fly around the scene with WASD
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/ZCD1bSXQ/" title="Billboards" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/ZCD1bSXQ/" title="Billboards" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/353938/'>Open Project ↗</Link>

--- a/docs/tutorials/camera-following-a-path.md
+++ b/docs/tutorials/camera-following-a-path.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample of a camera following points on a spline path.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/LuNJjRCr/" title="Camera following a path" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/LuNJjRCr/" title="Camera following a path" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/438429/'>Open Project ↗</Link>

--- a/docs/tutorials/camera-model-masking.md
+++ b/docs/tutorials/camera-model-masking.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample showing to use render masking on the lights and models to enable lighting to only affect certain models and cameras to render certain models.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/D4ZYtQrG/" title="Camera model masking" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/D4ZYtQrG/" title="Camera model masking" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/436772/'>Open Project ↗</Link>

--- a/docs/tutorials/capturing-a-screenshot.md
+++ b/docs/tutorials/capturing-a-screenshot.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 A sample showing how capture a screenshot from a camera and download as a PNG
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Qlf6YvOV/" title="Capturing a screenshot" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0"/>
+    <iframe src="https://playcanv.as/p/Qlf6YvOV/" title="Capturing a screenshot" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0"/>
 </div>
 
 <Link to='https://playcanvas.com/project/438437/'>Open Project ↗</Link>

--- a/docs/tutorials/changing-scenes.md
+++ b/docs/tutorials/changing-scenes.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Full documentation for Loading Scenes is now in the [User Manual][documentation-page].
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/e/p/IP7FtbDj/" title="Changing Scenes"></iframe>
+    <iframe src="https://playcanv.as/e/p/IP7FtbDj/" title="Changing Scenes"></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/437633/'>Open Project ↗</Link>

--- a/docs/tutorials/changing-scenes.md
+++ b/docs/tutorials/changing-scenes.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Full documentation for Loading Scenes is now in the [User Manual][documentation-page].
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/e/p/IP7FtbDj/" title="Changing Scenes"></iframe>
+    <iframe src="https://playcanv.as/e/p/IP7FtbDj/" title="Changing Scenes" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/437633/'>Open Project ↗</Link>

--- a/docs/tutorials/changing-textures-at-runtime.md
+++ b/docs/tutorials/changing-textures-at-runtime.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 A sample showing how to change a materials texture through a script
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Ivdxse42/" title="Changing textures at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/Ivdxse42/" title="Changing textures at runtime" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/437446/'>Open Project ↗</Link>

--- a/docs/tutorials/collision-and-triggers.md
+++ b/docs/tutorials/collision-and-triggers.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/1Hj5fX2I/" title="Collision and Triggers"></iframe>
+    <iframe src="https://playcanv.as/p/1Hj5fX2I/" title="Collision and Triggers" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *Rigidbodies collide with each other, a sound is played on a collision and a trigger volume resets the shapes.*

--- a/docs/tutorials/collision-and-triggers.md
+++ b/docs/tutorials/collision-and-triggers.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/1Hj5fX2I/" title="Collision and Triggers"></iframe>
+    <iframe src="https://playcanv.as/p/1Hj5fX2I/" title="Collision and Triggers"></iframe>
 </div>
 
 *Rigidbodies collide with each other, a sound is played on a collision and a trigger volume resets the shapes.*

--- a/docs/tutorials/compound-physics-shapes.md
+++ b/docs/tutorials/compound-physics-shapes.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Full documentation for Compound Physics Shapes is now in the [User Manual][documentation-page].
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/KXZ5Lsda/" title="Compound Physics Shapes"></iframe>
+    <iframe src="https://playcanv.as/p/KXZ5Lsda/" title="Compound Physics Shapes" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/688146/'>Open Project ↗</Link>

--- a/docs/tutorials/compound-physics-shapes.md
+++ b/docs/tutorials/compound-physics-shapes.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Full documentation for Compound Physics Shapes is now in the [User Manual][documentation-page].
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/KXZ5Lsda/" title="Compound Physics Shapes"></iframe>
+    <iframe src="https://playcanv.as/p/KXZ5Lsda/" title="Compound Physics Shapes"></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/688146/'>Open Project ↗</Link>

--- a/docs/tutorials/controlling-lights.md
+++ b/docs/tutorials/controlling-lights.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/tiKpka9M/" title="Controlling Lights"></iframe>
+    <iframe src="https://playcanv.as/p/tiKpka9M/" title="Controlling Lights"></iframe>
 </div>
 
 *Press 1, 2 or 3 to enable/disable the spot, point and directional lights respectively.*

--- a/docs/tutorials/controlling-lights.md
+++ b/docs/tutorials/controlling-lights.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/tiKpka9M/" title="Controlling Lights"></iframe>
+    <iframe src="https://playcanv.as/p/tiKpka9M/" title="Controlling Lights" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *Press 1, 2 or 3 to enable/disable the spot, point and directional lights respectively.*

--- a/docs/tutorials/crash-course.md
+++ b/docs/tutorials/crash-course.md
@@ -23,7 +23,7 @@ This was recorded for [JS GameDev Summit][js-gamedev-summit] and the video is ho
 Play below! Try to get as many food items as you can before the timer runs out! Use WASD for movement.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/dCoHvsRY/" title="Food Run - Full Project"></iframe>
+    <iframe src="https://playcanv.as/p/dCoHvsRY/" title="Food Run - Full Project"></iframe>
 </div>
 
 ## Timestamps

--- a/docs/tutorials/crash-course.md
+++ b/docs/tutorials/crash-course.md
@@ -23,7 +23,7 @@ This was recorded for [JS GameDev Summit][js-gamedev-summit] and the video is ho
 Play below! Try to get as many food items as you can before the timer runs out! Use WASD for movement.
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/dCoHvsRY/" title="Food Run - Full Project"></iframe>
+    <iframe src="https://playcanv.as/p/dCoHvsRY/" title="Food Run - Full Project" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 ## Timestamps

--- a/docs/tutorials/create-qr-code-at-runtime.md
+++ b/docs/tutorials/create-qr-code-at-runtime.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Create QR codes at runtime with https://github.com/davidshimjs/qrcodejs
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/O5MDA13T/" title="Create QR Code at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/O5MDA13T/" title="Create QR Code at runtime" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/1025199/'>Open Project ↗</Link>

--- a/docs/tutorials/creating-rigid-bodies-in-code.md
+++ b/docs/tutorials/creating-rigid-bodies-in-code.md
@@ -7,7 +7,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4423
 import Link from '@docusaurus/Link';
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/w8Hhxovk/" title="Creating Rigid Bodies in Code" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/w8Hhxovk/" title="Creating Rigid Bodies in Code" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/442322/'>Open Project ↗</Link>

--- a/docs/tutorials/custom-posteffect.md
+++ b/docs/tutorials/custom-posteffect.md
@@ -7,7 +7,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 In this tutorial, you'll learn how to create a custom watercolor post effect in PlayCanvas that applies a softening filter and a paper grain texture to your scene. By the end of this guide, you'll have a visually appealing watercolor effect that you can apply to any 3D scene.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/3je0YP0q/" title="Custom Post Effects"></iframe>
+    <iframe src="https://playcanv.as/p/3je0YP0q/" title="Custom Post Effects"></iframe>
 </div>
 
 ## Step 1: Setting Up Your Shaders

--- a/docs/tutorials/custom-posteffect.md
+++ b/docs/tutorials/custom-posteffect.md
@@ -7,7 +7,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 In this tutorial, you'll learn how to create a custom watercolor post effect in PlayCanvas that applies a softening filter and a paper grain texture to your scene. By the end of this guide, you'll have a visually appealing watercolor effect that you can apply to any 3D scene.
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/3je0YP0q/" title="Custom Post Effects"></iframe>
+    <iframe src="https://playcanv.as/p/3je0YP0q/" title="Custom Post Effects" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 ## Step 1: Setting Up Your Shaders

--- a/docs/tutorials/custom-shaders.md
+++ b/docs/tutorials/custom-shaders.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/zwvhLoS9/" title="Custom Shaders"></iframe>
+    <iframe src="https://playcanv.as/p/zwvhLoS9/" title="Custom Shaders" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 :::info

--- a/docs/tutorials/custom-shaders.md
+++ b/docs/tutorials/custom-shaders.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/zwvhLoS9/" title="Custom Shaders"></iframe>
+    <iframe src="https://playcanv.as/p/zwvhLoS9/" title="Custom Shaders"></iframe>
 </div>
 
 :::info

--- a/docs/tutorials/detecting-a-double-click.md
+++ b/docs/tutorials/detecting-a-double-click.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Double click on the screen to move the camera
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/BSSXwNAj/" title="Detecting a double click" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/BSSXwNAj/" title="Detecting a double click" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/436526/'>Open Project ↗</Link>

--- a/docs/tutorials/detecting-a-double-tap.md
+++ b/docs/tutorials/detecting-a-double-tap.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample showing how to detect a double tap on a touch screen.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/adm70VcR/" title="Detecting a double tap" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/adm70VcR/" title="Detecting a double tap" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/436531/'>Open Project ↗</Link>

--- a/docs/tutorials/detecting-a-long-press.md
+++ b/docs/tutorials/detecting-a-long-press.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample showing how to detect a long press/touch to perform an action.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/kuSZj1KM/" title="Detecting a long press" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/kuSZj1KM/" title="Detecting a long press" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/438459/'>Open Project ↗</Link>

--- a/docs/tutorials/dynamic-ui-scroll-view.md
+++ b/docs/tutorials/dynamic-ui-scroll-view.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 An example of adding and removing elements from the scroll view in the UI
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/XIarUWAW/" title="Dynamic UI Scroll View" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/XIarUWAW/" title="Dynamic UI Scroll View" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/734864/'>Open Project ↗</Link>

--- a/docs/tutorials/entity-picking-using-physics.md
+++ b/docs/tutorials/entity-picking-using-physics.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 A sample showing how to use the physics raycast to pick entities
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/J02HZ0PC/" title="Entity picking using physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/J02HZ0PC/" title="Entity picking using physics" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/410547/'>Open Project ↗</Link>

--- a/docs/tutorials/entity-picking-without-physics.md
+++ b/docs/tutorials/entity-picking-without-physics.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample showing how to pick at objects without using the physics system (extra 1MB to published project) or the frame buffer.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Sd7PcPNL/" title="Entity picking without physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/Sd7PcPNL/" title="Entity picking without physics" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/436809/'>Open Project ↗</Link>

--- a/docs/tutorials/entity-picking.md
+++ b/docs/tutorials/entity-picking.md
@@ -7,7 +7,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 Collision Picking - click to select a shape
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/b/Ps1tTzWn/" title="Collision Picking"></iframe>
+    <iframe src="https://playcanv.as/b/Ps1tTzWn/" title="Collision Picking"></iframe>
 </div>
 
 ---
@@ -15,7 +15,7 @@ Collision Picking - click to select a shape
 Frame Buffer Picking - click to select a grey shape. The red shapes are set to be not pickable.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/b/ZQVQqgGU/" title="Frame Buffer Picking"></iframe>
+    <iframe src="https://playcanv.as/b/ZQVQqgGU/" title="Frame Buffer Picking"></iframe>
 </div>
 
 ---

--- a/docs/tutorials/entity-picking.md
+++ b/docs/tutorials/entity-picking.md
@@ -7,7 +7,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 Collision Picking - click to select a shape
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/b/Ps1tTzWn/" title="Collision Picking"></iframe>
+    <iframe src="https://playcanv.as/b/Ps1tTzWn/" title="Collision Picking" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 ---
@@ -15,7 +15,7 @@ Collision Picking - click to select a shape
 Frame Buffer Picking - click to select a grey shape. The red shapes are set to be not pickable.
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/b/ZQVQqgGU/" title="Frame Buffer Picking"></iframe>
+    <iframe src="https://playcanv.as/b/ZQVQqgGU/" title="Frame Buffer Picking" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 ---

--- a/docs/tutorials/explosion-particle-effect.md
+++ b/docs/tutorials/explosion-particle-effect.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample project showing a multi layered particle effect with screen shake.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/0hjGM2Lh/" title="Explosion Particle Effect" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/0hjGM2Lh/" title="Explosion Particle Effect" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/439297/'>Open Project ↗</Link>

--- a/docs/tutorials/facebook-api.md
+++ b/docs/tutorials/facebook-api.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/StXUSCXN/" title="Facebook API"></iframe>
+    <iframe src="https://playcanv.as/p/StXUSCXN/" title="Facebook API"></iframe>
 </div>
 
 :::info

--- a/docs/tutorials/facebook-api.md
+++ b/docs/tutorials/facebook-api.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/StXUSCXN/" title="Facebook API"></iframe>
+    <iframe src="https://playcanv.as/p/StXUSCXN/" title="Facebook API" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 :::info

--- a/docs/tutorials/fading-objects-in-and-out.md
+++ b/docs/tutorials/fading-objects-in-and-out.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample showing how to fade a model in and out using on a per model basis.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/kvToWplO/" title="Fading objects in and out" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/kvToWplO/" title="Fading objects in and out" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/436566/'>Open Project ↗</Link>

--- a/docs/tutorials/first-person-movement.md
+++ b/docs/tutorials/first-person-movement.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/HzOzlZOC/" title="First Person Movement"></iframe>
+    <iframe src="https://playcanv.as/p/HzOzlZOC/" title="First Person Movement"></iframe>
 </div>
 
 This is an application that implements first person character movement.

--- a/docs/tutorials/first-person-movement.md
+++ b/docs/tutorials/first-person-movement.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/HzOzlZOC/" title="First Person Movement"></iframe>
+    <iframe src="https://playcanv.as/p/HzOzlZOC/" title="First Person Movement" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 This is an application that implements first person character movement.

--- a/docs/tutorials/first-person-shooter-starter-kit.md
+++ b/docs/tutorials/first-person-shooter-starter-kit.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Example project that extends the First Person Camera tutorial to move and jump around a 3D level
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/deRCEGms/" title="First Person Shooter Starter Kit" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/deRCEGms/" title="First Person Shooter Starter Kit" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/626211/'>Open Project ↗</Link>

--- a/docs/tutorials/flaming-fireball.md
+++ b/docs/tutorials/flaming-fireball.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample with a fireball that moves with the mouse
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/eavVneJi/" title="Flaming fireball" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/eavVneJi/" title="Flaming fireball" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/439385/'>Open Project ↗</Link>

--- a/docs/tutorials/flappy-bird.md
+++ b/docs/tutorials/flappy-bird.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Flappy's Back! Guide Flappy Bird through as many pipes as you can. Made with @playcanvas
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/2OlkUaxF/" title="Flappy Bird" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/2OlkUaxF/" title="Flappy Bird" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/375389/'>Open Project ↗</Link>

--- a/docs/tutorials/frames-per-sec-fps-counter.md
+++ b/docs/tutorials/frames-per-sec-fps-counter.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample with self contained FPS counter that can be used in other projects.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/VRCXOsxi/" title="Frames Per Sec (FPS) counter" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/VRCXOsxi/" title="Frames Per Sec (FPS) counter" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/433323/'>Open Project ↗</Link>

--- a/docs/tutorials/google-ads-for-games.md
+++ b/docs/tutorials/google-ads-for-games.md
@@ -33,7 +33,7 @@ For the tutorial we are going to fork the [Google H5 Ad Tutorial (Start)][tutori
 The end result will look like this where we can call the interstitial and rewarded ads via button clicks and the refresh button will be used to check if the rewarded ads can be shown (more on this later).
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/e/p/OkynewOO/" title="Finished Tutorial"></iframe>
+    <iframe src="https://playcanv.as/e/p/OkynewOO/" title="Finished Tutorial" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 ## Setting up

--- a/docs/tutorials/google-ads-for-games.md
+++ b/docs/tutorials/google-ads-for-games.md
@@ -33,7 +33,7 @@ For the tutorial we are going to fork the [Google H5 Ad Tutorial (Start)][tutori
 The end result will look like this where we can call the interstitial and rewarded ads via button clicks and the refresh button will be used to check if the rewarded ads can be shown (more on this later).
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/e/p/OkynewOO/" title="Finished Tutorial"></iframe>
+    <iframe src="https://playcanv.as/e/p/OkynewOO/" title="Finished Tutorial"></iframe>
 </div>
 
 ## Setting up

--- a/docs/tutorials/htmlcss---live-updates.md
+++ b/docs/tutorials/htmlcss---live-updates.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Example of how to use live HTML and CSS editing.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/KqqOGvVi/" title="HTML/CSS - Live Updates" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/KqqOGvVi/" title="HTML/CSS - Live Updates" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/354600/'>Open Project ↗</Link>

--- a/docs/tutorials/htmlcss-ui.md
+++ b/docs/tutorials/htmlcss-ui.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Example of how to use HTML and CSS to create UI
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/B4W3iveA/" title="HTML/CSS UI" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/B4W3iveA/" title="HTML/CSS UI" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/443090/'>Open Project ↗</Link>

--- a/docs/tutorials/importing-first-model-and-animation.md
+++ b/docs/tutorials/importing-first-model-and-animation.md
@@ -5,7 +5,7 @@ thumb: /img/tutorials/importing-first-model-and-animation/thumbnail.jpg
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://www.youtube.com/embed/r0LYQw7laRA" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe src="https://www.youtube.com/embed/r0LYQw7laRA" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 ## Overview

--- a/docs/tutorials/information-hotspots.md
+++ b/docs/tutorials/information-hotspots.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample showing information hotspots on a scene.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/9yrH9xRZ/" title="Information hotspots" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/9yrH9xRZ/" title="Information hotspots" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/438515/'>Open Project ↗</Link>

--- a/docs/tutorials/keepyup-part-five.md
+++ b/docs/tutorials/keepyup-part-five.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 5"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 5" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *You can find the [full project here][9]. If you haven't see [Part 1][1], [Part 2][2], [Part 3][3] and [Part 4][4] read them first.*

--- a/docs/tutorials/keepyup-part-five.md
+++ b/docs/tutorials/keepyup-part-five.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 5"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 5"></iframe>
 </div>
 
 *You can find the [full project here][9]. If you haven't see [Part 1][1], [Part 2][2], [Part 3][3] and [Part 4][4] read them first.*

--- a/docs/tutorials/keepyup-part-four.md
+++ b/docs/tutorials/keepyup-part-four.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 4"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 4" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *You can find the [full project here][6]. If you haven't see [Part 1][1], [Part 2][2] and [Part 3][3] read them first.*

--- a/docs/tutorials/keepyup-part-four.md
+++ b/docs/tutorials/keepyup-part-four.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 4"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 4"></iframe>
 </div>
 
 *You can find the [full project here][6]. If you haven't see [Part 1][1], [Part 2][2] and [Part 3][3] read them first.*

--- a/docs/tutorials/keepyup-part-one.md
+++ b/docs/tutorials/keepyup-part-one.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 1"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 1"></iframe>
 </div>
 
 *You can find the [full project here][3]*

--- a/docs/tutorials/keepyup-part-one.md
+++ b/docs/tutorials/keepyup-part-one.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 1"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 1" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *You can find the [full project here][3]*

--- a/docs/tutorials/keepyup-part-six.md
+++ b/docs/tutorials/keepyup-part-six.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 6"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 6" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *You can find the [full project here][11]. If you haven't see [Part 1][1], [Part 2][2], [Part 3][3], [Part 4][4] and [Part 5][5] read them first.*

--- a/docs/tutorials/keepyup-part-six.md
+++ b/docs/tutorials/keepyup-part-six.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 6"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 6"></iframe>
 </div>
 
 *You can find the [full project here][11]. If you haven't see [Part 1][1], [Part 2][2], [Part 3][3], [Part 4][4] and [Part 5][5] read them first.*

--- a/docs/tutorials/keepyup-part-three.md
+++ b/docs/tutorials/keepyup-part-three.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 3"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 3"></iframe>
 </div>
 
 *You can find the [full project here][4]. If you haven't see [Part 1][1] and [Part 2][2] read them first.*

--- a/docs/tutorials/keepyup-part-three.md
+++ b/docs/tutorials/keepyup-part-three.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 3"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 3" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *You can find the [full project here][4]. If you haven't see [Part 1][1] and [Part 2][2] read them first.*

--- a/docs/tutorials/keepyup-part-two.md
+++ b/docs/tutorials/keepyup-part-two.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 2"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 2" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *You can find the [full project here][16]. If you haven't seen [Part 1][1] read it first.*

--- a/docs/tutorials/keepyup-part-two.md
+++ b/docs/tutorials/keepyup-part-two.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 2"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 2"></iframe>
 </div>
 
 *You can find the [full project here][16]. If you haven't seen [Part 1][1] read it first.*

--- a/docs/tutorials/keyboard-input.md
+++ b/docs/tutorials/keyboard-input.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/rFZGQWCi/?overlay=false" title="Basic Keyboard Input"></iframe>
+    <iframe src="https://playcanv.as/p/rFZGQWCi/?overlay=false" title="Basic Keyboard Input" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *Click to focus, then press `left arrow`, `right arrow` and `spacebar` to rotate the cube. Press and release the 'a' key to change color.*

--- a/docs/tutorials/keyboard-input.md
+++ b/docs/tutorials/keyboard-input.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/rFZGQWCi/?overlay=false" title="Basic Keyboard Input"></iframe>
+    <iframe src="https://playcanv.as/p/rFZGQWCi/?overlay=false" title="Basic Keyboard Input"></iframe>
 </div>
 
 *Click to focus, then press `left arrow`, `right arrow` and `spacebar` to rotate the cube. Press and release the 'a' key to change color.*

--- a/docs/tutorials/light-cookies.md
+++ b/docs/tutorials/light-cookies.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4097
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/AGtssoOU/" title="Light Cookies"></iframe>
+    <iframe src="https://playcanv.as/p/AGtssoOU/" title="Light Cookies"></iframe>
 </div>
 
 Find out more by forking the [full project][1].

--- a/docs/tutorials/light-cookies.md
+++ b/docs/tutorials/light-cookies.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4097
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/AGtssoOU/" title="Light Cookies"></iframe>
+    <iframe src="https://playcanv.as/p/AGtssoOU/" title="Light Cookies" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 Find out more by forking the [full project][1].

--- a/docs/tutorials/light-halos.md
+++ b/docs/tutorials/light-halos.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/rnIUbXws/" title="Light Halos"></iframe>
+    <iframe src="https://playcanv.as/p/rnIUbXws/" title="Light Halos"></iframe>
 </div>
 
 Find out more by forking the [full project][4].

--- a/docs/tutorials/light-halos.md
+++ b/docs/tutorials/light-halos.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/rnIUbXws/" title="Light Halos"></iframe>
+    <iframe src="https://playcanv.as/p/rnIUbXws/" title="Light Halos" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 Find out more by forking the [full project][4].

--- a/docs/tutorials/load-assets-with-a-progress-bar.md
+++ b/docs/tutorials/load-assets-with-a-progress-bar.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample showing how to load multiple assets at runtime with a progress bar.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/MGKfj6jm/" title="Load assets with a progress bar" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/MGKfj6jm/" title="Load assets with a progress bar" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/436584/'>Open Project ↗</Link>

--- a/docs/tutorials/load-multiple-assets-at-runtime.md
+++ b/docs/tutorials/load-multiple-assets-at-runtime.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample showing how to load multiple assets at runtime.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/P7eFFj4u/" title="Load multiple assets at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/P7eFFj4u/" title="Load multiple assets at runtime" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/439131/'>Open Project ↗</Link>

--- a/docs/tutorials/loading-an-asset-at-runtime.md
+++ b/docs/tutorials/loading-an-asset-at-runtime.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample showing how to load an asset at runtime so you don't have to preload it at the start if it is not used.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/xIkPLoyX/" title="Loading an asset at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/xIkPLoyX/" title="Loading an asset at runtime" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/439122/'>Open Project ↗</Link>

--- a/docs/tutorials/loading-circle-ui.md
+++ b/docs/tutorials/loading-circle-ui.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 An example of a radial loading circle
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/WVAhW4ft/" title="Loading Circle UI" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/WVAhW4ft/" title="Loading Circle UI" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/705273/'>Open Project ↗</Link>

--- a/docs/tutorials/loading-draco-compressed-glbs.md
+++ b/docs/tutorials/loading-draco-compressed-glbs.md
@@ -13,7 +13,7 @@ See https://google.github.io/draco/ for more information on Draco 3D Data Compre
 See https://github.com/CesiumGS/gltf-pipeline for the tool to compress glTF models.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/2uU2aYDh/" title="Loading Draco Compressed GLBs" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/2uU2aYDh/" title="Loading Draco Compressed GLBs" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/730372/'>Open Project ↗</Link>

--- a/docs/tutorials/loading-gltf-glbs.md
+++ b/docs/tutorials/loading-gltf-glbs.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 How to load a GLB as a binary asset.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/RIN6pM0I/" title="Loading glTF GLBs" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/RIN6pM0I/" title="Loading glTF GLBs" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/730738/'>Open Project ↗</Link>

--- a/docs/tutorials/loading-json.md
+++ b/docs/tutorials/loading-json.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/cHnXIXoN/" title="Loading JSON Data"></iframe>
+    <iframe src="https://playcanv.as/p/cHnXIXoN/" title="Loading JSON Data"></iframe>
 </div>
 
 [This project][1] shows you how to load JSON data in two ways. First, from an asset in the project. Second, over HTTP from a remote server.

--- a/docs/tutorials/loading-json.md
+++ b/docs/tutorials/loading-json.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/cHnXIXoN/" title="Loading JSON Data"></iframe>
+    <iframe src="https://playcanv.as/p/cHnXIXoN/" title="Loading JSON Data" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 [This project][1] shows you how to load JSON data in two ways. First, from an asset in the project. Second, over HTTP from a remote server.

--- a/docs/tutorials/locking-the-mouse.md
+++ b/docs/tutorials/locking-the-mouse.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 A sample showing how to lock the mouse upon clicking.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/2Epvl0CT/" title="Locking the mouse" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/2Epvl0CT/" title="Locking the mouse" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/438440/'>Open Project ↗</Link>

--- a/docs/tutorials/mobile-ui-safe-areas.md
+++ b/docs/tutorials/mobile-ui-safe-areas.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Example project to handle safe areas on the UI - https://developer.playcanvas.com/user-manual/user-interface/safe-area/
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/z5pXervL/" title="Mobile UI Safe Areas" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/z5pXervL/" title="Mobile UI Safe Areas" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/828118/'>Open Project ↗</Link>

--- a/docs/tutorials/more-cameras.md
+++ b/docs/tutorials/more-cameras.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/5yUf1fvg/" title="More Cameras"></iframe>
+    <iframe src="https://playcanv.as/p/5yUf1fvg/" title="More Cameras"></iframe>
 </div>
 
 *Click to focus, then press `space` to zoom in and out, press `left arrow` and `right arrow` to switch to the left and right cameras*

--- a/docs/tutorials/more-cameras.md
+++ b/docs/tutorials/more-cameras.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/5yUf1fvg/" title="More Cameras"></iframe>
+    <iframe src="https://playcanv.as/p/5yUf1fvg/" title="More Cameras" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *Click to focus, then press `space` to zoom in and out, press `left arrow` and `right arrow` to switch to the left and right cameras*

--- a/docs/tutorials/mouse-input.md
+++ b/docs/tutorials/mouse-input.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/MHIdZgaj/?overlay=false" title="Basic Mouse Input"></iframe>
+    <iframe src="https://playcanv.as/p/MHIdZgaj/?overlay=false" title="Basic Mouse Input" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 :::info

--- a/docs/tutorials/mouse-input.md
+++ b/docs/tutorials/mouse-input.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/MHIdZgaj/?overlay=false" title="Basic Mouse Input"></iframe>
+    <iframe src="https://playcanv.as/p/MHIdZgaj/?overlay=false" title="Basic Mouse Input"></iframe>
 </div>
 
 :::info

--- a/docs/tutorials/multiple-camera-layers.md
+++ b/docs/tutorials/multiple-camera-layers.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Demonstration project that shows how to use multiple cameras and layers to render a mixed user interface of UI elements and world-space objects.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/h7V3tWZK/" title="Multiple Camera Layers" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/h7V3tWZK/" title="Multiple Camera Layers" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/593374/'>Open Project ↗</Link>

--- a/docs/tutorials/multiple-viewport-rendering.md
+++ b/docs/tutorials/multiple-viewport-rendering.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 A sample showing how to render multiple viewports by modifying the viewport properties on the cameras
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/bkLdoYPQ/" title="Multiple Viewport Rendering" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/bkLdoYPQ/" title="Multiple Viewport Rendering" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/443666/'>Open Project ↗</Link>

--- a/docs/tutorials/multitouch-input.md
+++ b/docs/tutorials/multitouch-input.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample that draws lines between all the current touches on the screen.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/p56cF89z/" title="Multitouch input" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/p56cF89z/" title="Multitouch input" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/437474/'>Open Project ↗</Link>

--- a/docs/tutorials/music-visualizer.md
+++ b/docs/tutorials/music-visualizer.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/BqhCi6oy/" title="Creating a Music Visualizer"></iframe>
+    <iframe src="https://playcanv.as/p/BqhCi6oy/" title="Creating a Music Visualizer"></iframe>
 </div>
 
 *Find out more by forking the [full project][1].*

--- a/docs/tutorials/music-visualizer.md
+++ b/docs/tutorials/music-visualizer.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/BqhCi6oy/" title="Creating a Music Visualizer"></iframe>
+    <iframe src="https://playcanv.as/p/BqhCi6oy/" title="Creating a Music Visualizer" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *Find out more by forking the [full project][1].*

--- a/docs/tutorials/orange-room.md
+++ b/docs/tutorials/orange-room.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Interactive interior visualisation with dynamic reflections and HDR lightmaps.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/1ha5glKf/" title="Orange Room" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/1ha5glKf/" title="Orange Room" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/345310/'>Open Project ↗</Link>

--- a/docs/tutorials/orbit-camera.md
+++ b/docs/tutorials/orbit-camera.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample with an orbit camera around an entity with both mouse and touch. Scroll wheel and 'pinch to zoom' is used to zoom in and out.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/fI6jSYjK/" title="Orbit camera" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/fI6jSYjK/" title="Orbit camera" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/438243/'>Open Project ↗</Link>

--- a/docs/tutorials/pan-camera-to-target.md
+++ b/docs/tutorials/pan-camera-to-target.md
@@ -11,7 +11,7 @@ An example shows how to focus a camera on target location
 Credit: https://playcanvas.com/user/lexxik
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/5SJsWtg3/" title="Pan Camera to Target" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/5SJsWtg3/" title="Pan Camera to Target" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/693889/'>Open Project ↗</Link>

--- a/docs/tutorials/pauseplay-application.md
+++ b/docs/tutorials/pauseplay-application.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 A sample showing how to pause and resume an app by modifying the timeScale property. Click to pause/play the app
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/sNoeqOZL/" title="Pause/Play application" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/sNoeqOZL/" title="Pause/Play application" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/437707/'>Open Project ↗</Link>

--- a/docs/tutorials/physics-raycasting-by-tag.md
+++ b/docs/tutorials/physics-raycasting-by-tag.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample showing how to pick an entity by tag using raycastAll
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/j1aT7giL/" title="Physics raycasting by tag" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/j1aT7giL/" title="Physics raycasting by tag" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/691309/'>Open Project ↗</Link>

--- a/docs/tutorials/physics-with-ccd.md
+++ b/docs/tutorials/physics-with-ccd.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 A sample with a script to setup and enable CCD for very fast moving physics objects
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/jBMFj7l2/" title="Physics with CCD" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/jBMFj7l2/" title="Physics with CCD" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/447023/'>Open Project ↗</Link>

--- a/docs/tutorials/place-an-entity-with-physics.md
+++ b/docs/tutorials/place-an-entity-with-physics.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 A sample showing how to place objects in the world by using physics. Click on ground to place a box.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/JCW3CUKx/" title="Place an entity with physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/JCW3CUKx/" title="Place an entity with physics" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/437836/'>Open Project ↗</Link>

--- a/docs/tutorials/place-entity-without-physics.md
+++ b/docs/tutorials/place-entity-without-physics.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 A sample showing how to place objects in the world without using physics. Click on the ground to place boxes.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Z2ieIwf8/" title="Place entity without physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/Z2ieIwf8/" title="Place entity without physics" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/437894/'>Open Project ↗</Link>

--- a/docs/tutorials/planar-mirror-reflection.md
+++ b/docs/tutorials/planar-mirror-reflection.md
@@ -11,7 +11,7 @@ Credit: https://playcanvas.com/user/lexxik
 Example of creating a planar reflection being used for a transparent mirror/water like surface.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/bQE35vbj/" title="Planar Mirror Reflection" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/bQE35vbj/" title="Planar Mirror Reflection" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/717166/'>Open Project ↗</Link>

--- a/docs/tutorials/planet-earth.md
+++ b/docs/tutorials/planet-earth.md
@@ -7,7 +7,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4197
 import Link from '@docusaurus/Link';
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/kU1mx35y/" title="Planet Earth" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/kU1mx35y/" title="Planet Earth" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/419706/'>Open Project ↗</Link>

--- a/docs/tutorials/point-and-click-movement.md
+++ b/docs/tutorials/point-and-click-movement.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample showing a simple point and click system to move an object where you user has clicked
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/RQAovNH6/" title="Point and click movement" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/RQAovNH6/" title="Point and click movement" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/461494/'>Open Project ↗</Link>

--- a/docs/tutorials/procedural-gradient-texture.md
+++ b/docs/tutorials/procedural-gradient-texture.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Example of creating a procedural texture with a gradient effect by LeXXik
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/5qggchI4/" title="Procedural Gradient Texture" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/5qggchI4/" title="Procedural Gradient Texture" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/708598/'>Open Project ↗</Link>

--- a/docs/tutorials/procedural-levels.md
+++ b/docs/tutorials/procedural-levels.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/smskdMrk/" title="Procedural Levels"></iframe>
+    <iframe src="https://playcanv.as/p/smskdMrk/" title="Procedural Levels" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 This project uses [clone()][1] function on the Entity to randomly generate a level from Entities that have been created in the Editor.

--- a/docs/tutorials/procedural-levels.md
+++ b/docs/tutorials/procedural-levels.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/smskdMrk/" title="Procedural Levels"></iframe>
+    <iframe src="https://playcanv.as/p/smskdMrk/" title="Procedural Levels"></iframe>
 </div>
 
 This project uses [clone()][1] function on the Entity to randomly generate a level from Entities that have been created in the Editor.

--- a/docs/tutorials/programmatically-creating.md
+++ b/docs/tutorials/programmatically-creating.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/1VjdIY7v/" title="Programmatically Creating Entities"></iframe>
+    <iframe src="https://playcanv.as/p/1VjdIY7v/" title="Programmatically Creating Entities"></iframe>
 </div>
 
 Usually you will be creating Entities via the PlayCanvas Editor, building up collections of Components and scripts to create the various parts of your game. However, in some cases it is convenient to create Entities in your scripts. This tutorial shows you how.

--- a/docs/tutorials/programmatically-creating.md
+++ b/docs/tutorials/programmatically-creating.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/1VjdIY7v/" title="Programmatically Creating Entities"></iframe>
+    <iframe src="https://playcanv.as/p/1VjdIY7v/" title="Programmatically Creating Entities" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 Usually you will be creating Entities via the PlayCanvas Editor, building up collections of Components and scripts to create the various parts of your game. However, in some cases it is convenient to create Entities in your scripts. This tutorial shows you how.

--- a/docs/tutorials/rainbow-trail-with-mesh-api.md
+++ b/docs/tutorials/rainbow-trail-with-mesh-api.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 A rainbow trail using the pc.Mesh API
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/jGeaTg6B/" title="Rainbow Trail with Mesh API" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/jGeaTg6B/" title="Rainbow Trail with Mesh API" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/733569/'>Open Project ↗</Link>

--- a/docs/tutorials/raycast-with-camera-viewports.md
+++ b/docs/tutorials/raycast-with-camera-viewports.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Raycasting with multiple camera viewports. Click on the shapes in each view
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/dXvrDzH2/" title="Raycast with Camera Viewports" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/dXvrDzH2/" title="Raycast with Camera Viewports" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/964118/'>Open Project ↗</Link>

--- a/docs/tutorials/real-time-multiplayer-colyseus.md
+++ b/docs/tutorials/real-time-multiplayer-colyseus.md
@@ -5,7 +5,7 @@ thumb: https://avatars.githubusercontent.com/u/28384334?s=300&v=4
 ---
 
 <div className="iframe-container">
-  <iframe loading="lazy" src="https://playcanv.as/p/1QoAsx7r/" title="Real-time Multiplayer with Colyseus"></iframe>
+  <iframe src="https://playcanv.as/p/1QoAsx7r/" title="Real-time Multiplayer with Colyseus"></iframe>
 </div>
 
 > *Select create game to open a new game. And click anywhere on the floor to move the object.*

--- a/docs/tutorials/real-time-multiplayer-colyseus.md
+++ b/docs/tutorials/real-time-multiplayer-colyseus.md
@@ -5,7 +5,7 @@ thumb: https://avatars.githubusercontent.com/u/28384334?s=300&v=4
 ---
 
 <div className="iframe-container">
-  <iframe src="https://playcanv.as/p/1QoAsx7r/" title="Real-time Multiplayer with Colyseus"></iframe>
+  <iframe src="https://playcanv.as/p/1QoAsx7r/" title="Real-time Multiplayer with Colyseus" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 > *Select create game to open a new game. And click anywhere on the floor to move the object.*

--- a/docs/tutorials/real-time-multiplayer-photon.md
+++ b/docs/tutorials/real-time-multiplayer-photon.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/9269
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/e/p/dvJYXs1Y/" title="Real-time Multiplayer with Photon - including matchmaking"></iframe>
+    <iframe src="https://playcanv.as/e/p/dvJYXs1Y/" title="Real-time Multiplayer with Photon - including matchmaking"></iframe>
 </div>
 
 :::info

--- a/docs/tutorials/real-time-multiplayer-photon.md
+++ b/docs/tutorials/real-time-multiplayer-photon.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/9269
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/e/p/dvJYXs1Y/" title="Real-time Multiplayer with Photon - including matchmaking"></iframe>
+    <iframe src="https://playcanv.as/e/p/dvJYXs1Y/" title="Real-time Multiplayer with Photon - including matchmaking" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 :::info

--- a/docs/tutorials/real-time-multiplayer.md
+++ b/docs/tutorials/real-time-multiplayer.md
@@ -11,7 +11,7 @@ This tutorial covers how to start creating your own multiplayer from scratch. If
 :::
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/XFp1Ty3X/" title="Real Time Multiplayer"></iframe>
+    <iframe src="https://playcanv.as/p/XFp1Ty3X/" title="Real Time Multiplayer"></iframe>
 </div>
 
 *Use WASD to move the player around. If you only see one capsule, try opening this page in another tab or on another computer.*

--- a/docs/tutorials/real-time-multiplayer.md
+++ b/docs/tutorials/real-time-multiplayer.md
@@ -11,7 +11,7 @@ This tutorial covers how to start creating your own multiplayer from scratch. If
 :::
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/XFp1Ty3X/" title="Real Time Multiplayer"></iframe>
+    <iframe src="https://playcanv.as/p/XFp1Ty3X/" title="Real Time Multiplayer" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *Use WASD to move the player around. If you only see one capsule, try opening this page in another tab or on another computer.*

--- a/docs/tutorials/render-3d-world-to-ui.md
+++ b/docs/tutorials/render-3d-world-to-ui.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Render 3D objects as part of the UI
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/CQzD8zlM/" title="Render 3D World to UI" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/CQzD8zlM/" title="Render 3D World to UI" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/855150/'>Open Project ↗</Link>

--- a/docs/tutorials/resolution-scaling.md
+++ b/docs/tutorials/resolution-scaling.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Example project on rendering the world at different resolutions without the UI being affected
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/qx7PyE7q/" title="Resolution Scaling" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/qx7PyE7q/" title="Resolution Scaling" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/708300/'>Open Project ↗</Link>

--- a/docs/tutorials/right-to-left-language-support.md
+++ b/docs/tutorials/right-to-left-language-support.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Scripts to use for RTL language support such Arabic
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/k2TruV1u/" title="Right to left language support" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/k2TruV1u/" title="Right to left language support" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/764309/'>Open Project ↗</Link>

--- a/docs/tutorials/rotating-objects-with-mouse.md
+++ b/docs/tutorials/rotating-objects-with-mouse.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample showing how to rotate an object using the mouse in screen space
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/BgbpyC0Y/" title="Rotating Objects with Mouse" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/BgbpyC0Y/" title="Rotating Objects with Mouse" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/442490/'>Open Project ↗</Link>

--- a/docs/tutorials/shockwave.md
+++ b/docs/tutorials/shockwave.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Shockwave ripple post effect
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/c16yO94k/" title="Shockwave" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/c16yO94k/" title="Shockwave" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/440868/'>Open Project ↗</Link>

--- a/docs/tutorials/simple-shape-raycasting.md
+++ b/docs/tutorials/simple-shape-raycasting.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample showing how to pick at an entity
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/QGiL8OdM/" title="Simple shape raycasting" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/QGiL8OdM/" title="Simple shape raycasting" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/457922/'>Open Project ↗</Link>

--- a/docs/tutorials/simple-water-surface.md
+++ b/docs/tutorials/simple-water-surface.md
@@ -7,7 +7,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4384
 import Link from '@docusaurus/Link';
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/NeYgvM9z/" title="Simple water surface" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/NeYgvM9z/" title="Simple water surface" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/438476/'>Open Project ↗</Link>

--- a/docs/tutorials/smooth-camera-movement.md
+++ b/docs/tutorials/smooth-camera-movement.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample with a smooth transition of a camera from one position and rotation to another using the Lerp and Slerp functions.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/T7VKMrs8/" title="Smooth camera movement" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/T7VKMrs8/" title="Smooth camera movement" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/437461/'>Open Project ↗</Link>

--- a/docs/tutorials/sound-volume-control-using-curve.md
+++ b/docs/tutorials/sound-volume-control-using-curve.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample showing how to control the volume of a sound slot using curve data. Click on the scene to start the audio.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/hmRciuNn/" title="Sound volume control using curve" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/hmRciuNn/" title="Sound volume control using curve" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/436116/'>Open Project ↗</Link>

--- a/docs/tutorials/space-rocks.md
+++ b/docs/tutorials/space-rocks.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Get started making your own space shooter game by forking this template Asteroids shooter! Aim with your mouse and fire with your left button. Survive as long as you can!
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/cAFbOEtL/" title="Space Rocks!" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/cAFbOEtL/" title="Space Rocks!" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/1029772/'>Open Project ↗</Link>

--- a/docs/tutorials/static-batching.md
+++ b/docs/tutorials/static-batching.md
@@ -7,7 +7,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/5203
 import Link from '@docusaurus/Link';
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Qo7T1kqU/" title="Static Batching" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/Qo7T1kqU/" title="Static Batching" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/520389/'>Open Project ↗</Link>

--- a/docs/tutorials/stencil-buffer---3d-magic-card.md
+++ b/docs/tutorials/stencil-buffer---3d-magic-card.md
@@ -11,7 +11,7 @@ Example project that uses the stencil buffer to create a magic window like effec
 Credit: @ alexanderrdx for the original project
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/RAQhfemb/" title="Stencil Buffer - 3D Magic Card" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/RAQhfemb/" title="Stencil Buffer - 3D Magic Card" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/855103/'>Open Project ↗</Link>

--- a/docs/tutorials/switch-full-scene.md
+++ b/docs/tutorials/switch-full-scene.md
@@ -7,7 +7,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/6919
 Full documentation for Loading Scenes is now in the [User Manual][documentation-page].
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/e/p/zsQcbehI/" title="Switch Full Scene"></iframe>
+    <iframe src="https://playcanv.as/e/p/zsQcbehI/" title="Switch Full Scene"></iframe>
 </div>
 
 [documentation-page]: /user-manual/scenes/loading-scenes/

--- a/docs/tutorials/switch-full-scene.md
+++ b/docs/tutorials/switch-full-scene.md
@@ -7,7 +7,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/6919
 Full documentation for Loading Scenes is now in the [User Manual][documentation-page].
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/e/p/zsQcbehI/" title="Switch Full Scene"></iframe>
+    <iframe src="https://playcanv.as/e/p/zsQcbehI/" title="Switch Full Scene" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 [documentation-page]: /user-manual/scenes/loading-scenes/

--- a/docs/tutorials/switching-materials-at-runtime.md
+++ b/docs/tutorials/switching-materials-at-runtime.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample switching on a model materials at runtime.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/7EZvdnZd/" title="Switching materials at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/7EZvdnZd/" title="Switching materials at runtime" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/437442/'>Open Project ↗</Link>

--- a/docs/tutorials/terrain-generation.md
+++ b/docs/tutorials/terrain-generation.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/CmcIlmPb/" title="Terrain Generation from Heightmap"></iframe>
+    <iframe src="https://playcanv.as/p/CmcIlmPb/" title="Terrain Generation from Heightmap" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 This project uses the [`pc.Mesh`][1] API to procedurally generate and texture a rolling hillside from a heightmap texture.

--- a/docs/tutorials/terrain-generation.md
+++ b/docs/tutorials/terrain-generation.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/CmcIlmPb/" title="Terrain Generation from Heightmap"></iframe>
+    <iframe src="https://playcanv.as/p/CmcIlmPb/" title="Terrain Generation from Heightmap"></iframe>
 </div>
 
 This project uses the [`pc.Mesh`][1] API to procedurally generate and texture a rolling hillside from a heightmap texture.

--- a/docs/tutorials/third-person-controller.md
+++ b/docs/tutorials/third-person-controller.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 A simple third person controller.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Q7CJA9Ku/" title="Third Person Controller" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/Q7CJA9Ku/" title="Third Person Controller" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/705595/'>Open Project ↗</Link>

--- a/docs/tutorials/tic-tac-toe.md
+++ b/docs/tutorials/tic-tac-toe.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 The classic game Tic Tac Toe
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/i5csiIb9/" title="Tic Tac Toe" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/i5csiIb9/" title="Tic Tac Toe" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/671439/'>Open Project ↗</Link>

--- a/docs/tutorials/timers.md
+++ b/docs/tutorials/timers.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Example of extending the PlayCanvas engine to create one shot timers. Press P to pause time.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/WsI6QA7y/" title="Timers" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/WsI6QA7y/" title="Timers" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/691984/'>Open Project ↗</Link>

--- a/docs/tutorials/touch-joypad.md
+++ b/docs/tutorials/touch-joypad.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/1007
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/kvE0iJWc/" title="Touchscreen Joypad Controls"></iframe>
+    <iframe src="https://playcanv.as/p/kvE0iJWc/" title="Touchscreen Joypad Controls" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 [Click here to see the project][project-link].

--- a/docs/tutorials/touch-joypad.md
+++ b/docs/tutorials/touch-joypad.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/1007
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/kvE0iJWc/" title="Touchscreen Joypad Controls"></iframe>
+    <iframe src="https://playcanv.as/p/kvE0iJWc/" title="Touchscreen Joypad Controls"></iframe>
 </div>
 
 [Click here to see the project][project-link].

--- a/docs/tutorials/tutorial-layout-groups.md
+++ b/docs/tutorials/tutorial-layout-groups.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Use the Layout Group component to build a user interface.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/y4JwxWTI/" title="Tutorial: Layout Groups" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/y4JwxWTI/" title="Tutorial: Layout Groups" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/553515/'>Open Project ↗</Link>

--- a/docs/tutorials/tutorial-normal-mapped-text.md
+++ b/docs/tutorials/tutorial-normal-mapped-text.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Dynamically generate normal maps and parallax maps for text
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/MbMb81DM/" title="Tutorial: Normal Mapped Text" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/MbMb81DM/" title="Tutorial: Normal Mapped Text" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/855103/'>Open Project ↗</Link>

--- a/docs/tutorials/tutorial-plasma-shader-chunk.md
+++ b/docs/tutorials/tutorial-plasma-shader-chunk.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 A demonstration of a GLSL effect from Shadertoy being used in a shader chunk on a PlayCanvas material
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/NLgp097Q/" title="Tutorial: Plasma Shader Chunk" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/NLgp097Q/" title="Tutorial: Plasma Shader Chunk" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/453304/'>Open Project ↗</Link>

--- a/docs/tutorials/tutorial-shop-user-interface.md
+++ b/docs/tutorials/tutorial-shop-user-interface.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Build a Shop User Interface screen using UI Elements, Layout Groups, Button components, Sprites and Texture Atlases
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/yN4CxzAs/" title="Tutorial: Shop User Interface" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/yN4CxzAs/" title="Tutorial: Shop User Interface" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/559492/'>Open Project ↗</Link>

--- a/docs/tutorials/tweening.md
+++ b/docs/tutorials/tweening.md
@@ -34,7 +34,7 @@ this.entity
 Here is an example on how to tween the local rotation of an Entity:
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/b/H8553dGa/" title="Tween Local Rotation"></iframe>
+    <iframe src="https://playcanv.as/b/H8553dGa/" title="Tween Local Rotation" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 Here are links to the [Project][2] and the [Editor][4] for this example.
@@ -53,7 +53,7 @@ this.entity
 Here's how to tween the local scale of an Entity:
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/b/ndTiHCpD/" title="Tween Local Scale"></iframe>
+    <iframe src="https://playcanv.as/b/ndTiHCpD/" title="Tween Local Scale" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 Here are links to the [Project][2] and the [Editor][5] for this example.
@@ -72,7 +72,7 @@ this.entity
 And finally here's a way to tween colors:
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/b/aoRYsYrc/" title="Tween Material Color"></iframe>
+    <iframe src="https://playcanv.as/b/aoRYsYrc/" title="Tween Material Color" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 Here are links to the [Project][2] and the [Editor][6] for this example.

--- a/docs/tutorials/tweening.md
+++ b/docs/tutorials/tweening.md
@@ -15,7 +15,7 @@ entity.tween(entity.getLocalPosition()).to({x: 10, y: 0, z: 0}, 1, pc.SineOut);
 Here is an example on how to tween the local position of an Entity:
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/b/wEftzstB/" title="Using the Tween library"></iframe>
+    <iframe src="https://playcanv.as/b/wEftzstB/" title="Using the Tween library" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 Here are links to the [Project][2] and the [Editor][3] for this example.
@@ -34,7 +34,7 @@ this.entity
 Here is an example on how to tween the local rotation of an Entity:
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/b/H8553dGa/" title="Tween Local Rotation"></iframe>
+    <iframe src="https://playcanv.as/b/H8553dGa/" title="Tween Local Rotation"></iframe>
 </div>
 
 Here are links to the [Project][2] and the [Editor][4] for this example.
@@ -53,7 +53,7 @@ this.entity
 Here's how to tween the local scale of an Entity:
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/b/ndTiHCpD/" title="Tween Local Scale"></iframe>
+    <iframe src="https://playcanv.as/b/ndTiHCpD/" title="Tween Local Scale"></iframe>
 </div>
 
 Here are links to the [Project][2] and the [Editor][5] for this example.
@@ -72,7 +72,7 @@ this.entity
 And finally here's a way to tween colors:
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/b/aoRYsYrc/" title="Tween Material Color"></iframe>
+    <iframe src="https://playcanv.as/b/aoRYsYrc/" title="Tween Material Color"></iframe>
 </div>
 
 Here are links to the [Project][2] and the [Editor][6] for this example.

--- a/docs/tutorials/ui-elements-buttons.md
+++ b/docs/tutorials/ui-elements-buttons.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/5019
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/jpRiV53D/" title="User Interface - Buttons"></iframe>
+    <iframe src="https://playcanv.as/p/jpRiV53D/" title="User Interface - Buttons" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *Simple buttons using Element and Button components. See the [full scene][1].*

--- a/docs/tutorials/ui-elements-leaderboard.md
+++ b/docs/tutorials/ui-elements-leaderboard.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/5019
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/nbMbtAGH/" title="User Interface - Leaderboard"></iframe>
+    <iframe src="https://playcanv.as/p/nbMbtAGH/" title="User Interface - Leaderboard" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *A leaderboard using Element components. See the [full scene][1].*

--- a/docs/tutorials/ui-elements-progress.md
+++ b/docs/tutorials/ui-elements-progress.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/5019
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/FlebHmLs/" title="User Interface - Progress Bar"></iframe>
+    <iframe src="https://playcanv.as/p/FlebHmLs/" title="User Interface - Progress Bar" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *A progress bar using Element components. See the [full scene][1].*

--- a/docs/tutorials/ui-elements-stats-counter.md
+++ b/docs/tutorials/ui-elements-stats-counter.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/5019
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/XVLr9TWc/" title="User Interface - Stats Counter"></iframe>
+    <iframe src="https://playcanv.as/p/XVLr9TWc/" title="User Interface - Stats Counter" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *How to use buttons, progress bars and interact with elements. See the [full scene][1].*

--- a/docs/tutorials/ui-text-input.md
+++ b/docs/tutorials/ui-text-input.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/1005
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/8ZQaDGf8/" title="User Interface - Text Input"></iframe>
+    <iframe src="https://playcanv.as/p/8ZQaDGf8/" title="User Interface - Text Input" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 [Click here to see the project][project-link].

--- a/docs/tutorials/using-assets.md
+++ b/docs/tutorials/using-assets.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4060
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/QwDM4qaF/" title="Using the Asset Registry"></iframe>
+    <iframe src="https://playcanv.as/p/QwDM4qaF/" title="Using the Asset Registry" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 :::info

--- a/docs/tutorials/using-events-with-scripts.md
+++ b/docs/tutorials/using-events-with-scripts.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample showing how to communicate between scripts using events.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/HXrtITkb/" title="Using events with scripts" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/HXrtITkb/" title="Using events with scripts" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/437673/'>Open Project ↗</Link>

--- a/docs/tutorials/vehicle-physics.md
+++ b/docs/tutorials/vehicle-physics.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 An implementation of vehicle physics in PlayCanvas, using the RaycastVehicle API in ammo.js. Supports desktop, mobile and VR.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/CxgnAp22/" title="Vehicle Physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/CxgnAp22/" title="Vehicle Physics" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/643289/'>Open Project ↗</Link>

--- a/docs/tutorials/vhscrt-post-effect.md
+++ b/docs/tutorials/vhscrt-post-effect.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Basic fullscreen effect simulating a bad video screen like an old CRT.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/6hhSiHG3/" title="VHS/CRT Post Effect" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/6hhSiHG3/" title="VHS/CRT Post Effect" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/373076/'>Open Project ↗</Link>

--- a/docs/tutorials/video-textures.md
+++ b/docs/tutorials/video-textures.md
@@ -5,7 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4058
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/6wt5T87E/" title="Video Textures"></iframe>
+    <iframe src="https://playcanv.as/p/6wt5T87E/" title="Video Textures" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 Try it from the Editor in the [tutorial project.][1]

--- a/docs/tutorials/vignette-abberation.md
+++ b/docs/tutorials/vignette-abberation.md
@@ -7,7 +7,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4408
 import Link from '@docusaurus/Link';
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/UwEmhiJf/" title="Vignette Abberation" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/UwEmhiJf/" title="Vignette Abberation" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/440854/'>Open Project ↗</Link>

--- a/docs/tutorials/warp-a-sprite-with-glsl.md
+++ b/docs/tutorials/warp-a-sprite-with-glsl.md
@@ -7,7 +7,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4260
 import Link from '@docusaurus/Link';
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/3NdgiVsp/" title="Warp a Sprite with GLSL" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/3NdgiVsp/" title="Warp a Sprite with GLSL" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/426038/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-360-image.md
+++ b/docs/tutorials/webxr-360-image.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 360 Image with WebXR support | Image Credit: Bob Dass from https://www.flickr.com/photos/54144402@N03/
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/v6qoi4Yt/" title="WebXR 360 Image" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay;xr-spatial-tracking" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/v6qoi4Yt/" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/434266/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-360-video.md
+++ b/docs/tutorials/webxr-360-video.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 360 Video with WebXR support
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/G0d8FneG/" title="WebXR 360 Video" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay;xr-spatial-tracking" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/G0d8FneG/" title="WebXR 360 Video" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/434444/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-ar-dom-overlay.md
+++ b/docs/tutorials/webxr-ar-dom-overlay.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Example of how to use DOM (HTML + CSS) with WebXR AR session.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/S01LYTIU/" title="WebXR AR: DOM Overlay" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay;xr-spatial-tracking" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/S01LYTIU/" title="WebXR AR: DOM Overlay" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/691979/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-ar-hit-test.md
+++ b/docs/tutorials/webxr-ar-hit-test.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Example of how to use WebXR Hit Test API. That allows to hit test real world geometry.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Kjol3uRS/" title="WebXR AR: Hit Test" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay;xr-spatial-tracking" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/Kjol3uRS/" title="WebXR AR: Hit Test" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/672464/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-ar-image-tracking.md
+++ b/docs/tutorials/webxr-ar-image-tracking.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Example of how to use WebXR Augmented Reality: Image Tracking API. That allows to *actively* track real world images based on provided sample.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/PCsSvN5h/" title="WebXR: AR Image Tracking" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay;xr-spatial-tracking" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/PCsSvN5h/" title="WebXR: AR Image Tracking" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/739875/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-ar-raycasting-shapes.md
+++ b/docs/tutorials/webxr-ar-raycasting-shapes.md
@@ -11,7 +11,7 @@ Example of how to raycast in the PlayCanvas scene when using WebXR AR.
 Tap the shapes to change their color!
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/qiLEOeL7/" title="WebXR AR Raycasting Shapes" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay;xr-spatial-tracking" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/qiLEOeL7/" title="WebXR AR Raycasting Shapes" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/884783/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-controllerhand-models.md
+++ b/docs/tutorials/webxr-controllerhand-models.md
@@ -7,5 +7,5 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/7066
 Sample application with WebXR controller/hand models loaded based on input source profile. Models sourced from: https://github.com/immersive-web/webxr-input-profiles
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/g7uSJhuo/" title="WebXR Controller/Hand Models" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay;xr-spatial-tracking" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/g7uSJhuo/" title="WebXR Controller/Hand Models" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/docs/tutorials/webxr-hands.md
+++ b/docs/tutorials/webxr-hands.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample application with WebXR Hands Tracking.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/VmHVW3Wb/" title="WebXR Hands" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay;xr-spatial-tracking" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/VmHVW3Wb/" title="WebXR Hands" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/705931/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-hello-world.md
+++ b/docs/tutorials/webxr-hello-world.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Basic scene with support for VR camera
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/z7myUkHP/" title="WebXR Hello World" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay;xr-spatial-tracking" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/z7myUkHP/" title="WebXR Hello World" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/433339/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-plane-detection.md
+++ b/docs/tutorials/webxr-plane-detection.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Example of how to use WebXR Augmented Reality: Plane Detection API. That allows to *actively* track real world surface estimations.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/f2ESRGge/" title="WebXR: Plane Detection" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay;xr-spatial-tracking" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/f2ESRGge/" title="WebXR: Plane Detection" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/782753/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-ray-input.md
+++ b/docs/tutorials/webxr-ray-input.md
@@ -5,13 +5,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4604
 ---
 
 <div className="iframe-container">
-    <iframe
-        loading="lazy"
-        src="https://playcanv.as/p/TAYVQgU2/"
-        title="WebXR UI Interaction"
-        allow="camera; microphone; xr-spatial-tracking; fullscreen"
-        allowfullscreen
-    ></iframe>
+    <iframe src="https://playcanv.as/p/TAYVQgU2/" title="WebXR UI Interaction" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *Click the VR/AR button if you have a VR/AR compatible device/headset.*

--- a/docs/tutorials/webxr-realistic-hands.md
+++ b/docs/tutorials/webxr-realistic-hands.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Realistic hands in VR!
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/pG6tosLX/" title="WebXR Realistic Hands" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay;xr-spatial-tracking" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/pG6tosLX/" title="WebXR Realistic Hands" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/771952/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-tracked-controllers.md
+++ b/docs/tutorials/webxr-tracked-controllers.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 A sample application with boilerplate code for WebXR support with tracked controllers using PlayCanvas.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/TUBZkBEl/" title="WebXR Tracked Controllers" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay;xr-spatial-tracking" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/TUBZkBEl/" title="WebXR Tracked Controllers" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/457917/'>Open Project ↗</Link>

--- a/docs/tutorials/webxr-vr-lab.md
+++ b/docs/tutorials/webxr-vr-lab.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 A living project built by the PlayCanvas team to help developers learn about creating scalable and responsive WebXR VR applications for all devices
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/sAsiDvtC/" title="WebXR VR Lab" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay;xr-spatial-tracking" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/sAsiDvtC/" title="WebXR VR Lab" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/446331/'>Open Project ↗</Link>

--- a/docs/tutorials/world-space-ui-rendering-on-top.md
+++ b/docs/tutorials/world-space-ui-rendering-on-top.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Learn how to render world space UI over the top of the world
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/0Ycgs0n7/" title="World space UI rendering on top" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay;xr-spatial-tracking" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/0Ycgs0n7/" title="World space UI rendering on top" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/691979/'>Open Project ↗</Link>

--- a/docs/tutorials/world-to-ui-screen-space.md
+++ b/docs/tutorials/world-to-ui-screen-space.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Sample in which a UI Element is positioned over a world space point.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/xU0TSSIY/" title="World to UI Screen space" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay;xr-spatial-tracking" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/xU0TSSIY/" title="World to UI Screen space" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/679740/'>Open Project ↗</Link>

--- a/docs/user-manual/assets/types/cubemap.md
+++ b/docs/user-manual/assets/types/cubemap.md
@@ -8,7 +8,7 @@ Cubemaps are a special type of texture asset. They are formed from 6 texture ass
 2. A cubemap can add reflections to any material. Imagine a shiny, chrome ball bearing in your scene. The ball reflects the surrounding scene. For open environments, you would normally set the scene's sky box cubemap as the cubemap on a reflective object's materials.
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/b/xp7v1oFB/" title="Cubemap"></iframe>
+    <iframe src="https://playcanv.as/b/xp7v1oFB/" title="Cubemap" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 ## Importing Cubemap Textures

--- a/docs/user-manual/assets/types/cubemap.md
+++ b/docs/user-manual/assets/types/cubemap.md
@@ -8,7 +8,7 @@ Cubemaps are a special type of texture asset. They are formed from 6 texture ass
 2. A cubemap can add reflections to any material. Imagine a shiny, chrome ball bearing in your scene. The ball reflects the surrounding scene. For open environments, you would normally set the scene's sky box cubemap as the cubemap on a reflective object's materials.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/b/xp7v1oFB/" title="Cubemap"></iframe>
+    <iframe src="https://playcanv.as/b/xp7v1oFB/" title="Cubemap"></iframe>
 </div>
 
 ## Importing Cubemap Textures

--- a/docs/user-manual/getting-started/index.md
+++ b/docs/user-manual/getting-started/index.md
@@ -14,7 +14,7 @@ PlayCanvas is a visual development platform for interactive web content. Both th
 The PlayCanvas Editor is a visual editing tool that lets you build scenes, applications and games in record time. Use the Editor to manage your project assets, to add interactivity and to communicate and work with your team. The Editor is collaborative in real-time which means you can immediately see changes made by your team and you can build and test your application across all devices instantly
 
 <div className="iframe-container">
-    <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/PS4oMLPyYfI" title="PlayCanvas Editor Live Link" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/PS4oMLPyYfI" title="PlayCanvas Editor Live Link" allowfullscreen></iframe>
 </div>
 
 Find out more in the [editor][5] section.

--- a/docs/user-manual/getting-started/made-with-playcanvas.md
+++ b/docs/user-manual/getting-started/made-with-playcanvas.md
@@ -12,7 +12,7 @@ Find more fantastic games and experiences made by our users in the [PlayCanvas A
 Links to the content showcased can be found on the [blog post][2022-blog-post].
 
 <div className="iframe-container">
-    <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/46f73gp1_TU" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/46f73gp1_TU" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 ## PlayCanvas Showcase 2021
@@ -20,7 +20,7 @@ Links to the content showcased can be found on the [blog post][2022-blog-post].
 Links to the content showcased can be found on the [blog post][2021-blog-post].
 
 <div className="iframe-container">
-    <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/FrUUrVRpbzg" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/FrUUrVRpbzg" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 [awesome-playcanvas]: https://github.com/playcanvas/awesome-playcanvas

--- a/docs/user-manual/getting-started/your-first-app.md
+++ b/docs/user-manual/getting-started/your-first-app.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 Developing applications in PlayCanvas is easy and fun. Let's spend a few minutes learning the basics. We'll recreate the following simple 3D app:
 
 <div className="iframe-container">
-    <iframe loading="lazy"  src="https://playcanv.as/p/TnUtDXWp/" title="Simple PlayCanvas App"></iframe>
+    <iframe  src="https://playcanv.as/p/TnUtDXWp/" title="Simple PlayCanvas App"></iframe>
 </div>
 
 *Use the arrow keys to move the red ball around.*

--- a/docs/user-manual/getting-started/your-first-app.md
+++ b/docs/user-manual/getting-started/your-first-app.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 Developing applications in PlayCanvas is easy and fun. Let's spend a few minutes learning the basics. We'll recreate the following simple 3D app:
 
 <div className="iframe-container">
-    <iframe  src="https://playcanv.as/p/TnUtDXWp/" title="Simple PlayCanvas App"></iframe>
+    <iframe  src="https://playcanv.as/p/TnUtDXWp/" title="Simple PlayCanvas App" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *Use the arrow keys to move the red ball around.*

--- a/docs/user-manual/graphics/gaussian-splatting.md
+++ b/docs/user-manual/graphics/gaussian-splatting.md
@@ -6,7 +6,7 @@ sidebar_position: 3.5
 3D Gaussian Splatting is a relatively new technique for capturing and rendering photorealistic volumetric point clouds. Since the technique relies on photogrammetry, it is very quick, cheap and easy to generate high-quality rendered scenes.
 
 <div className="iframe-container">
-    <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/Pe4Sx8t1Ud4" title="Templates Overview" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/Pe4Sx8t1Ud4" title="Templates Overview" allowfullscreen></iframe>
 </div>
 
 ## Working with Gaussian Splats

--- a/docs/user-manual/graphics/physical-rendering/physical-materials.md
+++ b/docs/user-manual/graphics/physical-rendering/physical-materials.md
@@ -36,7 +36,7 @@ The Diffuse Color is the base color of the material. This is an RGB color value.
 It can also be known as **albedo** or **base color**.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Q28EwTwQ/?color" title="Physical Materials - Diffuse"></iframe>
+    <iframe src="https://playcanv.as/p/Q28EwTwQ/?color" title="Physical Materials - Diffuse"></iframe>
 </div>
 
 You can often find the charts of recorded values for diffuse/albedo values on the internet.
@@ -62,7 +62,7 @@ The metalness value should almost always be 0 or 1. It is rare that you will nee
 You can also supply a metalness map which lets you define specific areas of your material as metal or non-metal.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Q28EwTwQ/?metal" title="Physical Materials - Metalness"></iframe>
+    <iframe src="https://playcanv.as/p/Q28EwTwQ/?metal" title="Physical Materials - Metalness"></iframe>
 </div>
 
 ### Glossiness
@@ -70,7 +70,7 @@ You can also supply a metalness map which lets you define specific areas of your
 Glossiness is used in both  **metalness** and **specular** workflows and it defines how smooth your material surface is. The glossiness will affect how blurry or sharp the reflections on the material are, or how broad or narrow the specular highlights are. Glossiness is provided as a single value between 0-100 or a glossiness map.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Q28EwTwQ/?gloss" title="Physical Materials - Glossiness"></iframe>
+    <iframe src="https://playcanv.as/p/Q28EwTwQ/?gloss" title="Physical Materials - Glossiness"></iframe>
 </div>
 
 Some PBR systems use **Roughness** instead of Glossiness. The roughness is the inverse of the glossiness. If you need to convert a roughness map to a glossiness map, simply invert it.
@@ -84,7 +84,7 @@ These three properties **diffuse**, **metalness** and **glossiness** are the cor
 There are many other additional properties to investigate that can be used to make great materials such as Ambient Occlusion, Emissive, Opacity, Normal and Height maps.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Q28EwTwQ/" title="Physical Materials - All"></iframe>
+    <iframe src="https://playcanv.as/p/Q28EwTwQ/" title="Physical Materials - All"></iframe>
 </div>
 
 [5]: https://marmoset.co/posts/pbr-texture-conversion/

--- a/docs/user-manual/graphics/physical-rendering/physical-materials.md
+++ b/docs/user-manual/graphics/physical-rendering/physical-materials.md
@@ -36,7 +36,7 @@ The Diffuse Color is the base color of the material. This is an RGB color value.
 It can also be known as **albedo** or **base color**.
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/Q28EwTwQ/?color" title="Physical Materials - Diffuse"></iframe>
+    <iframe src="https://playcanv.as/p/Q28EwTwQ/?color" title="Physical Materials - Diffuse" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 You can often find the charts of recorded values for diffuse/albedo values on the internet.
@@ -62,7 +62,7 @@ The metalness value should almost always be 0 or 1. It is rare that you will nee
 You can also supply a metalness map which lets you define specific areas of your material as metal or non-metal.
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/Q28EwTwQ/?metal" title="Physical Materials - Metalness"></iframe>
+    <iframe src="https://playcanv.as/p/Q28EwTwQ/?metal" title="Physical Materials - Metalness" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 ### Glossiness
@@ -70,7 +70,7 @@ You can also supply a metalness map which lets you define specific areas of your
 Glossiness is used in both  **metalness** and **specular** workflows and it defines how smooth your material surface is. The glossiness will affect how blurry or sharp the reflections on the material are, or how broad or narrow the specular highlights are. Glossiness is provided as a single value between 0-100 or a glossiness map.
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/Q28EwTwQ/?gloss" title="Physical Materials - Glossiness"></iframe>
+    <iframe src="https://playcanv.as/p/Q28EwTwQ/?gloss" title="Physical Materials - Glossiness" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 Some PBR systems use **Roughness** instead of Glossiness. The roughness is the inverse of the glossiness. If you need to convert a roughness map to a glossiness map, simply invert it.
@@ -84,7 +84,7 @@ These three properties **diffuse**, **metalness** and **glossiness** are the cor
 There are many other additional properties to investigate that can be used to make great materials such as Ambient Occlusion, Emissive, Opacity, Normal and Height maps.
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/Q28EwTwQ/" title="Physical Materials - All"></iframe>
+    <iframe src="https://playcanv.as/p/Q28EwTwQ/" title="Physical Materials - All" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 [5]: https://marmoset.co/posts/pbr-texture-conversion/

--- a/docs/user-manual/physics/compound-shapes.md
+++ b/docs/user-manual/physics/compound-shapes.md
@@ -8,7 +8,7 @@ Compound shapes are custom collision shapes created out of multiple primitive sh
 The main advantage is that you are able to have dynamic rigidbody collisions between compound shapes (shown below) which is not possible with mesh collision types.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/e/p/KXZ5Lsda/" title="Compound Physic Shapes"></iframe>
+    <iframe src="https://playcanv.as/e/p/KXZ5Lsda/" title="Compound Physic Shapes"></iframe>
 </div>
 
 [PlayCanvas project link][compound-shapes-project]

--- a/docs/user-manual/physics/compound-shapes.md
+++ b/docs/user-manual/physics/compound-shapes.md
@@ -8,7 +8,7 @@ Compound shapes are custom collision shapes created out of multiple primitive sh
 The main advantage is that you are able to have dynamic rigidbody collisions between compound shapes (shown below) which is not possible with mesh collision types.
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/e/p/KXZ5Lsda/" title="Compound Physic Shapes"></iframe>
+    <iframe src="https://playcanv.as/e/p/KXZ5Lsda/" title="Compound Physic Shapes" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 [PlayCanvas project link][compound-shapes-project]

--- a/docs/user-manual/publishing/playable-ads/fb-playable-ads.md
+++ b/docs/user-manual/publishing/playable-ads/fb-playable-ads.md
@@ -14,7 +14,7 @@ The tool can create both the single 2MB (uncompressed) HTML file and the 5MB (un
 The [Cube Jump project][5] is ready to be exported for the Facebook Playable Ad format and the expected [HTML output can be found here][6].
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/e/p/Hywjl9Bh/" title="Cube Jump Playable Ad"></iframe>
+    <iframe src="https://playcanv.as/e/p/Hywjl9Bh/" title="Cube Jump Playable Ad"></iframe>
 </div>
 
 ## File size tips

--- a/docs/user-manual/publishing/playable-ads/fb-playable-ads.md
+++ b/docs/user-manual/publishing/playable-ads/fb-playable-ads.md
@@ -14,7 +14,7 @@ The tool can create both the single 2MB (uncompressed) HTML file and the 5MB (un
 The [Cube Jump project][5] is ready to be exported for the Facebook Playable Ad format and the expected [HTML output can be found here][6].
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/e/p/Hywjl9Bh/" title="Cube Jump Playable Ad"></iframe>
+    <iframe src="https://playcanv.as/e/p/Hywjl9Bh/" title="Cube Jump Playable Ad" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 ## File size tips

--- a/docs/user-manual/publishing/playable-ads/snapchat-playable-ads.md
+++ b/docs/user-manual/publishing/playable-ads/snapchat-playable-ads.md
@@ -16,7 +16,7 @@ There are some limitations to be aware of with the tool which can be found in th
 The [Cube Jump project][5] is ready to be exported to the Snapchat Playable Ad format and the expected HTML output can be found [here][6].
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/e/p/X1nwbUGA/" title="Cube Jump Playable Ad"></iframe>
+    <iframe src="https://playcanv.as/e/p/X1nwbUGA/" title="Cube Jump Playable Ad"></iframe>
 </div>
 
 ## File size tips

--- a/docs/user-manual/publishing/playable-ads/snapchat-playable-ads.md
+++ b/docs/user-manual/publishing/playable-ads/snapchat-playable-ads.md
@@ -16,7 +16,7 @@ There are some limitations to be aware of with the tool which can be found in th
 The [Cube Jump project][5] is ready to be exported to the Snapchat Playable Ad format and the expected HTML output can be found [here][6].
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/e/p/X1nwbUGA/" title="Cube Jump Playable Ad"></iframe>
+    <iframe src="https://playcanv.as/e/p/X1nwbUGA/" title="Cube Jump Playable Ad" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 ## File size tips

--- a/docs/user-manual/publishing/web/communicating-webpage.md
+++ b/docs/user-manual/publishing/web/communicating-webpage.md
@@ -58,7 +58,7 @@ In your host page, use the iframeless URL for the iframe. The default publish li
 If you add `/e` after `https://playcanv.as` in the URL, this will give you a version of the build without the iframe and social sharing bar.
 
 ```html
-<iframe loading="lazy" id="app-frame" src="https://playcanv.as/e/p/example/">
+<iframe id="app-frame" src="https://playcanv.as/e/p/example/">
 <script>
 const iframe = document.getElementById("app-frame");
 iframe.contentWindow.postMessage({

--- a/docs/user-manual/publishing/web/self-hosting.md
+++ b/docs/user-manual/publishing/web/self-hosting.md
@@ -18,7 +18,7 @@ When you [publish to playcanvas.com][2], your application is assigned a URL. To 
         <title>My Great Game</title>
     </head>
     <body>
-        <iframe src="https://playcanv.as/p/PROJECT_ID/"></iframe>
+        <iframe src="https://playcanv.as/p/PROJECT_ID/" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
     </body>
 </html>
 ```

--- a/docs/user-manual/publishing/web/self-hosting.md
+++ b/docs/user-manual/publishing/web/self-hosting.md
@@ -18,7 +18,7 @@ When you [publish to playcanvas.com][2], your application is assigned a URL. To 
         <title>My Great Game</title>
     </head>
     <body>
-        <iframe loading="lazy" src="https://playcanv.as/p/PROJECT_ID/"></iframe>
+        <iframe src="https://playcanv.as/p/PROJECT_ID/"></iframe>
     </body>
 </html>
 ```

--- a/docs/user-manual/scenes/loading-scenes.md
+++ b/docs/user-manual/scenes/loading-scenes.md
@@ -14,7 +14,7 @@ This is the most common approach that developers take where each scene is a self
 [Here is an example][switch-scenes-completely-project] where the user can move to and from the title screen to other levels.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/e/p/Q1gKd1ek/"  title="Switching Scenes Completely"></iframe>
+    <iframe src="https://playcanv.as/e/p/Q1gKd1ek/"  title="Switching Scenes Completely"></iframe>
 </div>
 
 This is done by simply calling [`SceneRegistry.changeScene`][changescene-api] with the name of the scene.
@@ -57,7 +57,7 @@ Sometimes developers use this approach to ensure that certain code and entities 
 [Below is a simplified example][additively-loading-scenes-project] of additively loading scenes where the UI in the top left is the 'main' scene and different scene hierarchies are loaded/destroyed.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/e/p/cjBInud1/" title="Additively Loading Scenes"></iframe>
+    <iframe src="https://playcanv.as/e/p/cjBInud1/" title="Additively Loading Scenes"></iframe>
 </div>
 
 Please note that multiple instances of the scene hierarchy cannot be loaded at once. This is due to the entities having their unique GUIDs assigned in the Editor. When multiple instances of the same scene hierarchy are attempted to be loaded at once, there's a clash of GUIDs which are meant to be unique per entity.
@@ -193,7 +193,7 @@ More information about asset tags and asset loading can be found on [this page][
 The [example project][asset-load-for-scene-project] below loads the assets when loading the scene and unloads when returning the main menu.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/e/p/SBTfOAeM/" title="Loading scenes and assets"></iframe>
+    <iframe src="https://playcanv.as/e/p/SBTfOAeM/" title="Loading scenes and assets"></iframe>
 </div>
 
 [switch-scenes-completely-project]: https://playcanvas.com/project/924351/overview/switch-full-scene-example

--- a/docs/user-manual/scenes/loading-scenes.md
+++ b/docs/user-manual/scenes/loading-scenes.md
@@ -14,7 +14,7 @@ This is the most common approach that developers take where each scene is a self
 [Here is an example][switch-scenes-completely-project] where the user can move to and from the title screen to other levels.
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/e/p/Q1gKd1ek/"  title="Switching Scenes Completely"></iframe>
+    <iframe src="https://playcanv.as/e/p/Q1gKd1ek/"  title="Switching Scenes Completely" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 This is done by simply calling [`SceneRegistry.changeScene`][changescene-api] with the name of the scene.
@@ -57,7 +57,7 @@ Sometimes developers use this approach to ensure that certain code and entities 
 [Below is a simplified example][additively-loading-scenes-project] of additively loading scenes where the UI in the top left is the 'main' scene and different scene hierarchies are loaded/destroyed.
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/e/p/cjBInud1/" title="Additively Loading Scenes"></iframe>
+    <iframe src="https://playcanv.as/e/p/cjBInud1/" title="Additively Loading Scenes" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 Please note that multiple instances of the scene hierarchy cannot be loaded at once. This is due to the entities having their unique GUIDs assigned in the Editor. When multiple instances of the same scene hierarchy are attempted to be loaded at once, there's a clash of GUIDs which are meant to be unique per entity.
@@ -193,7 +193,7 @@ More information about asset tags and asset loading can be found on [this page][
 The [example project][asset-load-for-scene-project] below loads the assets when loading the scene and unloads when returning the main menu.
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/e/p/SBTfOAeM/" title="Loading scenes and assets"></iframe>
+    <iframe src="https://playcanv.as/e/p/SBTfOAeM/" title="Loading scenes and assets" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 [switch-scenes-completely-project]: https://playcanvas.com/project/924351/overview/switch-full-scene-example

--- a/docs/user-manual/templates/index.md
+++ b/docs/user-manual/templates/index.md
@@ -6,7 +6,7 @@ sidebar_position: 12
 Templates (or prefabs) allow you to speed up your development by creating Entities that are reusable. You can place multiple instances of a Template in your Scene and if you make any changes and apply them to the Template Asset, all instances of that Template will be updated.
 
 <div className="iframe-container">
-    <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/2HV8Ib6wYRc" title="Templates Overview" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/2HV8Ib6wYRc" title="Templates Overview" allowfullscreen></iframe>
 </div>
 
 ## Creating Templates {#creating-templates}

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/360-lookaround-camera.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/360-lookaround-camera.md
@@ -8,5 +8,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438
 Sample showing how to move the camera with mouse and touch to look around
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/TMrb4ucs/" title="360 lookaround camera" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/TMrb4ucs/" title="360 lookaround camera" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/Using-forces-on-rigid-bodies.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/Using-forces-on-rigid-bodies.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className='iframe-container'>
-    <iframe loading="lazy" src="https://playcanv.as/p/8LTSuf4F/" title="Forces and Impulses" />
+    <iframe src="https://playcanv.as/p/8LTSuf4F/" title="Forces and Impulses" />
 </div>
 
 *カーソルキーを使用してインパルスを適用し、WASDキーを使用してトルクを適用し、キューブを回転させることができます。Fキーを押し続けると、重力の影響をキャンセルするために一定の上向きの力が適用されます。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/additive-loading-scenes.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/additive-loading-scenes.md
@@ -7,7 +7,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/685
 シーンの読み込みに関する完全なドキュメントは、[ユーザーマニュアル][documentation-page]にあります。
 
 <div className='iframe-container'>
-    <iframe loading="lazy" src="https://playcanv.as/e/p/cjBInud1/" title="Additive Loading Scenes"></iframe>
+    <iframe src="https://playcanv.as/e/p/cjBInud1/" title="Additive Loading Scenes"></iframe>
 </div>
 
 [documentation-page]: /user-manual/scenes/loading-scenes/

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/additive-loading-scenes.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/additive-loading-scenes.md
@@ -7,7 +7,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/685
 シーンの読み込みに関する完全なドキュメントは、[ユーザーマニュアル][documentation-page]にあります。
 
 <div className='iframe-container'>
-    <iframe src="https://playcanv.as/e/p/cjBInud1/" title="Additive Loading Scenes"></iframe>
+    <iframe src="https://playcanv.as/e/p/cjBInud1/" title="Additive Loading Scenes" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 [documentation-page]: /user-manual/scenes/loading-scenes/

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/advance-loading-screen.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/advance-loading-screen.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/458
 Project sample showing how to use project image assets in the loading screen
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Di3Fb3fx/" title="Advance loading screen" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/Di3Fb3fx/" title="Advance loading screen" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/anim-blending.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/anim-blending.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className='iframe-container'>
-    <iframe loading="lazy" src="https://playcanv.as/p/HI8kniOx/" title="Anim State Graph Blending"></iframe>
+    <iframe src="https://playcanv.as/p/HI8kniOx/" title="Anim State Graph Blending"></iframe>
 </div>
 
 :::info

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/anim-blending.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/anim-blending.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className='iframe-container'>
-    <iframe src="https://playcanv.as/p/HI8kniOx/" title="Anim State Graph Blending"></iframe>
+    <iframe src="https://playcanv.as/p/HI8kniOx/" title="Anim State Graph Blending" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 :::info

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/animate-entities-with-curves.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/animate-entities-with-curves.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438
 Sample showing use of curves to do basic animation with curves.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/cp3OGFrJ/" title="Animate entities with curves" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/cp3OGFrJ/" title="Animate entities with curves" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/animated-textures.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/animated-textures.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className='iframe-container'>
-    <iframe loading="lazy" src="https://playcanv.as/p/BM93v05L/" title="Animated Textures"></iframe>
+    <iframe src="https://playcanv.as/p/BM93v05L/" title="Animated Textures"></iframe>
 </div>
 
 *[フルプロジェクト][1]を見てください*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/animated-textures.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/animated-textures.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className='iframe-container'>
-    <iframe src="https://playcanv.as/p/BM93v05L/" title="Animated Textures"></iframe>
+    <iframe src="https://playcanv.as/p/BM93v05L/" title="Animated Textures" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *[フルプロジェクト][1]を見てください*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/animation-blending.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/animation-blending.md
@@ -11,7 +11,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 :::
 
 <div className='iframe-container'>
-    <iframe src="https://playcanv.as/p/HI8kniOx/" title="Animation Blending"></iframe>
+    <iframe src="https://playcanv.as/p/HI8kniOx/" title="Animation Blending" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 :::info

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/animation-blending.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/animation-blending.md
@@ -11,7 +11,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 :::
 
 <div className='iframe-container'>
-    <iframe loading="lazy" src="https://playcanv.as/p/HI8kniOx/" title="Animation Blending"></iframe>
+    <iframe src="https://playcanv.as/p/HI8kniOx/" title="Animation Blending"></iframe>
 </div>
 
 :::info

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/animation-without-state-graph.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/animation-without-state-graph.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/841
 Example project on how to add and play animations without using a state graph
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/xrWromyG/" title="Animation without State Graph" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/xrWromyG/" title="Animation without State Graph" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/audio-effects.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/audio-effects.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/1nS6AnC9/" title="Audio Effects"></iframe>
+    <iframe src="https://playcanv.as/p/1nS6AnC9/" title="Audio Effects"></iframe>
 </div>
 
 *それぞれのボタンをクリックしてサウンドエフェクトを試してください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/audio-effects.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/audio-effects.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/1nS6AnC9/" title="Audio Effects"></iframe>
+    <iframe src="https://playcanv.as/p/1nS6AnC9/" title="Audio Effects" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *それぞれのボタンをクリックしてサウンドエフェクトを試してください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/basic-audio.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/basic-audio.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/XqMw92Zl/" title="Basic Audio"></iframe>
+    <iframe src="https://playcanv.as/p/XqMw92Zl/" title="Basic Audio"></iframe>
 </div>
 
 *タンクは、ロボットの周りを移動しています。ゲーム上の任意の場所をクリックして撃つことができます。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/basic-audio.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/basic-audio.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/XqMw92Zl/" title="Basic Audio"></iframe>
+    <iframe src="https://playcanv.as/p/XqMw92Zl/" title="Basic Audio" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *タンクは、ロボットの周りを移動しています。ゲーム上の任意の場所をクリックして撃つことができます。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/basic-touch-input.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/basic-touch-input.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438
 Tutorial demonstrating basic touch input in PlayCanvas. Touch the box and move it around the screen!
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/iEIZxwBC/" title="Basic touch input" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/iEIZxwBC/" title="Basic touch input" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/billboards.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/billboards.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/353
 Simple example of planes that always face the camera. i.e. billboards. Click on the box and fly around the scene with WASD
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/ZCD1bSXQ/" title="Billboards" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/ZCD1bSXQ/" title="Billboards" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/camera-following-a-path.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/camera-following-a-path.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438
 Sample of a camera following points on a spline path.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/LuNJjRCr/" title="Camera following a path" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/LuNJjRCr/" title="Camera following a path" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/camera-model-masking.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/camera-model-masking.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/436
 Sample showing to use render masking on the lights and models to enable lighting to only affect certain models and cameras to render certain models.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/D4ZYtQrG/" title="Camera model masking" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/D4ZYtQrG/" title="Camera model masking" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/capturing-a-screenshot.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/capturing-a-screenshot.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438
 A sample showing how capture a screenshot from a camera and download as a PNG
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Qlf6YvOV/" title="Capturing a screenshot" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0"/>
+    <iframe src="https://playcanv.as/p/Qlf6YvOV/" title="Capturing a screenshot" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0"/>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/changing-scenes.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/changing-scenes.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 シーンの読み込みに関する完全なドキュメントは、[ユーザーマニュアル][documentation-page]にあります。
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/e/p/IP7FtbDj/" title="Changing Scenes"></iframe>
+    <iframe src="https://playcanv.as/e/p/IP7FtbDj/" title="Changing Scenes"></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/437633/'>Open Project ↗</Link>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/changing-scenes.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/changing-scenes.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 シーンの読み込みに関する完全なドキュメントは、[ユーザーマニュアル][documentation-page]にあります。
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/e/p/IP7FtbDj/" title="Changing Scenes"></iframe>
+    <iframe src="https://playcanv.as/e/p/IP7FtbDj/" title="Changing Scenes" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/437633/'>Open Project ↗</Link>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/changing-textures-at-runtime.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/changing-textures-at-runtime.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/437
 A sample showing how to change a materials texture through a script
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Ivdxse42/" title="Changing textures at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/Ivdxse42/" title="Changing textures at runtime" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/collision-and-triggers.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/collision-and-triggers.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/1Hj5fX2I/" title="Collision and Triggers"></iframe>
+    <iframe src="https://playcanv.as/p/1Hj5fX2I/" title="Collision and Triggers"></iframe>
 </div>
 
 *RigidBodyが互いに衝突すると、衝突音が再生され、トリガーボリュームが形状をリセットします。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/collision-and-triggers.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/collision-and-triggers.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/1Hj5fX2I/" title="Collision and Triggers"></iframe>
+    <iframe src="https://playcanv.as/p/1Hj5fX2I/" title="Collision and Triggers" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *RigidBodyが互いに衝突すると、衝突音が再生され、トリガーボリュームが形状をリセットします。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/compound-physics-shapes.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/compound-physics-shapes.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 複合物理形状の作成の完全なドキュメントは、[ユーザーマニュアル][documentation-page]にあります。
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/KXZ5Lsda/" title="Compound Physics Shapes"></iframe>
+    <iframe src="https://playcanv.as/p/KXZ5Lsda/" title="Compound Physics Shapes"></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/688146/'>Open Project ↗</Link>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/compound-physics-shapes.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/compound-physics-shapes.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 複合物理形状の作成の完全なドキュメントは、[ユーザーマニュアル][documentation-page]にあります。
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/KXZ5Lsda/" title="Compound Physics Shapes"></iframe>
+    <iframe src="https://playcanv.as/p/KXZ5Lsda/" title="Compound Physics Shapes" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/688146/'>Open Project ↗</Link>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/controlling-lights.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/controlling-lights.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/tiKpka9M/" title="Controlling Lights"></iframe>
+    <iframe src="https://playcanv.as/p/tiKpka9M/" title="Controlling Lights"></iframe>
 </div>
 
 *1、2、3を押すとそれぞれスポットライト、ポイントライト、ディレクショナルライトのON/OFFが切り替わります。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/controlling-lights.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/controlling-lights.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/tiKpka9M/" title="Controlling Lights"></iframe>
+    <iframe src="https://playcanv.as/p/tiKpka9M/" title="Controlling Lights" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *1、2、3を押すとそれぞれスポットライト、ポイントライト、ディレクショナルライトのON/OFFが切り替わります。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/crash-course.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/crash-course.md
@@ -21,7 +21,7 @@ This was recorded for [JS GameDev Summit][js-gamedev-summit] and the video is ho
 Play below! Try to get as many food items as you can before the timer runs out! Use WASD for movement.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/dCoHvsRY/" title="Food Run - Full Project"></iframe>
+    <iframe src="https://playcanv.as/p/dCoHvsRY/" title="Food Run - Full Project"></iframe>
 </div>
 
 ## タイムスタンプ

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/crash-course.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/crash-course.md
@@ -21,7 +21,7 @@ This was recorded for [JS GameDev Summit][js-gamedev-summit] and the video is ho
 Play below! Try to get as many food items as you can before the timer runs out! Use WASD for movement.
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/dCoHvsRY/" title="Food Run - Full Project"></iframe>
+    <iframe src="https://playcanv.as/p/dCoHvsRY/" title="Food Run - Full Project" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 ## タイムスタンプ

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/create-qr-code-at-runtime.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/create-qr-code-at-runtime.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/102
 Create QR codes at runtime with https://github.com/davidshimjs/qrcodejs
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/O5MDA13T/" title="Create QR Code at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/O5MDA13T/" title="Create QR Code at runtime" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/creating-rigid-bodies-in-code.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/creating-rigid-bodies-in-code.md
@@ -5,5 +5,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/442
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/w8Hhxovk/" title="Creating Rigid Bodies in Code" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/w8Hhxovk/" title="Creating Rigid Bodies in Code" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/custom-posteffect.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/custom-posteffect.md
@@ -7,7 +7,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 In this tutorial, you'll learn how to create a custom watercolor post effect in PlayCanvas that applies a softening filter and a paper grain texture to your scene. By the end of this guide, you'll have a visually appealing watercolor effect that you can apply to any 3D scene.
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/3je0YP0q/" title="Custom Post Effects"></iframe>
+    <iframe src="https://playcanv.as/p/3je0YP0q/" title="Custom Post Effects" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 ## Step 1: Setting Up Your Shaders

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/custom-posteffect.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/custom-posteffect.md
@@ -7,7 +7,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 In this tutorial, you'll learn how to create a custom watercolor post effect in PlayCanvas that applies a softening filter and a paper grain texture to your scene. By the end of this guide, you'll have a visually appealing watercolor effect that you can apply to any 3D scene.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/3je0YP0q/" title="Custom Post Effects"></iframe>
+    <iframe src="https://playcanv.as/p/3je0YP0q/" title="Custom Post Effects"></iframe>
 </div>
 
 ## Step 1: Setting Up Your Shaders

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/custom-shaders.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/custom-shaders.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/zwvhLoS9/" title="Custom Shaders"></iframe>
+    <iframe src="https://playcanv.as/p/zwvhLoS9/" title="Custom Shaders" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 :::info

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/custom-shaders.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/custom-shaders.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/zwvhLoS9/" title="Custom Shaders"></iframe>
+    <iframe src="https://playcanv.as/p/zwvhLoS9/" title="Custom Shaders"></iframe>
 </div>
 
 :::info

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/detecting-a-double-click.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/detecting-a-double-click.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/436
 Double click on the screen to move the camera
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/BSSXwNAj/" title="Detecting a double click" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/BSSXwNAj/" title="Detecting a double click" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/detecting-a-double-tap.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/detecting-a-double-tap.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/436
 Sample showing how to detect a double tap on a touch screen.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/adm70VcR/" title="Detecting a double tap" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/adm70VcR/" title="Detecting a double tap" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/detecting-a-long-press.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/detecting-a-long-press.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438
 Sample showing how to detect a long press/touch to perform an action.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/kuSZj1KM/" title="Detecting a long press" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/kuSZj1KM/" title="Detecting a long press" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/dynamic-ui-scroll-view.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/dynamic-ui-scroll-view.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/734
 An example of adding and removing elements from the scroll view in the UI
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/XIarUWAW/" title="Dynamic UI Scroll View" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/XIarUWAW/" title="Dynamic UI Scroll View" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/entity-picking-using-physics.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/entity-picking-using-physics.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/410
 A sample showing how to use the physics raycast to pick entities
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/J02HZ0PC/" title="Entity picking using physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/J02HZ0PC/" title="Entity picking using physics" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/entity-picking-without-physics.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/entity-picking-without-physics.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/436
 Sample showing how to pick at objects without using the physics system (extra 1MB to published project) or the frame buffer.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Sd7PcPNL/" title="Entity picking without physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/Sd7PcPNL/" title="Entity picking without physics" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/entity-picking.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/entity-picking.md
@@ -7,7 +7,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 Collision Picking - クリックしてシェイプを選択する
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/b/Ps1tTzWn/" title="Collision Picking"></iframe>
+    <iframe src="https://playcanv.as/b/Ps1tTzWn/" title="Collision Picking" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 ---
@@ -15,7 +15,7 @@ Collision Picking - クリックしてシェイプを選択する
 Frame Buffer Picking - クリックしてグレーのシェイプを選択する。赤い形状はピックできないように設定されています。
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/b/ZQVQqgGU/" title="Frame Buffer Picking"></iframe>
+    <iframe src="https://playcanv.as/b/ZQVQqgGU/" title="Frame Buffer Picking" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 ---

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/entity-picking.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/entity-picking.md
@@ -7,7 +7,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 Collision Picking - クリックしてシェイプを選択する
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/b/Ps1tTzWn/" title="Collision Picking"></iframe>
+    <iframe src="https://playcanv.as/b/Ps1tTzWn/" title="Collision Picking"></iframe>
 </div>
 
 ---
@@ -15,7 +15,7 @@ Collision Picking - クリックしてシェイプを選択する
 Frame Buffer Picking - クリックしてグレーのシェイプを選択する。赤い形状はピックできないように設定されています。
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/b/ZQVQqgGU/" title="Frame Buffer Picking"></iframe>
+    <iframe src="https://playcanv.as/b/ZQVQqgGU/" title="Frame Buffer Picking"></iframe>
 </div>
 
 ---

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/explosion-particle-effect.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/explosion-particle-effect.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/439
 Sample project showing a multi layered particle effect with screen shake.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/0hjGM2Lh/" title="Explosion Particle Effect" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/0hjGM2Lh/" title="Explosion Particle Effect" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/facebook-api.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/facebook-api.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/StXUSCXN/" title="Facebook API"></iframe>
+    <iframe src="https://playcanv.as/p/StXUSCXN/" title="Facebook API"></iframe>
 </div>
 
 :::info

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/facebook-api.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/facebook-api.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/StXUSCXN/" title="Facebook API"></iframe>
+    <iframe src="https://playcanv.as/p/StXUSCXN/" title="Facebook API" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 :::info

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/fading-objects-in-and-out.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/fading-objects-in-and-out.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/436
 Sample showing how to fade a model in and out using on a per model basis.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/kvToWplO/" title="Fading objects in and out" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/kvToWplO/" title="Fading objects in and out" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/first-person-movement.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/first-person-movement.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/HzOzlZOC/" title="First Person Movement"></iframe>
+    <iframe src="https://playcanv.as/p/HzOzlZOC/" title="First Person Movement"></iframe>
 </div>
 
 このアプリケーションは、ファーストパーソンでのキャラクター移動を実装しています。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/first-person-movement.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/first-person-movement.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/HzOzlZOC/" title="First Person Movement"></iframe>
+    <iframe src="https://playcanv.as/p/HzOzlZOC/" title="First Person Movement" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 このアプリケーションは、ファーストパーソンでのキャラクター移動を実装しています。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/first-person-shooter-starter-kit.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/first-person-shooter-starter-kit.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/626
 Example project that extends the First Person Camera tutorial to move and jump around a 3D level
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/deRCEGms/" title="First Person Shooter Starter Kit" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/deRCEGms/" title="First Person Shooter Starter Kit" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/flaming-fireball.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/flaming-fireball.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/439
 Sample with a fireball that moves with the mouse
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/eavVneJi/" title="Flaming fireball" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/eavVneJi/" title="Flaming fireball" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/flappy-bird.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/flappy-bird.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/8/3753
 Flappy's Back! Guide Flappy Bird through as many pipes as you can. Made with @playcanvas
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/2OlkUaxF/" title="Flappy Bird" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/2OlkUaxF/" title="Flappy Bird" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/frames-per-sec-fps-counter.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/frames-per-sec-fps-counter.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/433
 Sample with self contained FPS counter that can be used in other projects.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/VRCXOsxi/" title="Frames Per Sec (FPS) counter" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/VRCXOsxi/" title="Frames Per Sec (FPS) counter" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/google-ads-for-games.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/google-ads-for-games.md
@@ -33,7 +33,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/889
 最終的には、以下のようになり、ボタンのクリックでインタースティシャル広告とリワード広告を呼び出し、リフレッシュボタンでリワード広告が表示されるかどうかを確認できます(後述)。
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/e/p/OkynewOO/" title="Finished Tutorial"></iframe>
+    <iframe src="https://playcanv.as/e/p/OkynewOO/" title="Finished Tutorial" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 ## 設定

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/google-ads-for-games.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/google-ads-for-games.md
@@ -33,7 +33,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/889
 最終的には、以下のようになり、ボタンのクリックでインタースティシャル広告とリワード広告を呼び出し、リフレッシュボタンでリワード広告が表示されるかどうかを確認できます(後述)。
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/e/p/OkynewOO/" title="Finished Tutorial"></iframe>
+    <iframe src="https://playcanv.as/e/p/OkynewOO/" title="Finished Tutorial"></iframe>
 </div>
 
 ## 設定

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/htmlcss---live-updates.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/htmlcss---live-updates.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/354
 Example of how to use live HTML and CSS editing.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/KqqOGvVi/" title="HTML/CSS - Live Updates" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/KqqOGvVi/" title="HTML/CSS - Live Updates" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/htmlcss-ui.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/htmlcss-ui.md
@@ -9,7 +9,7 @@ import Link from '@docusaurus/Link';
 Example of how to use HTML and CSS to create UI
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/B4W3iveA/" title="HTML/CSS UI" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/B4W3iveA/" title="HTML/CSS UI" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/443090/'>Open Project ↗</Link>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/importing-first-model-and-animation.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/importing-first-model-and-animation.md
@@ -5,7 +5,7 @@ thumb: /img/tutorials/importing-first-model-and-animation/thumbnail.jpg
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://www.youtube.com/embed/r0LYQw7laRA" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe src="https://www.youtube.com/embed/r0LYQw7laRA" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 ## 概要

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/information-hotspots.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/information-hotspots.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438
 Sample showing information hotspots on a scene.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/9yrH9xRZ/" title="Information hotspots" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/9yrH9xRZ/" title="Information hotspots" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-five.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-five.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 5"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 5"></iframe>
 </div>
 
 * [完成されたプロジェクトはこちら][9]です。先に[その1][1], [その2][2], [その3][3], [その4][4]を読んでください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-five.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-five.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 5"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 5" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 * [完成されたプロジェクトはこちら][9]です。先に[その1][1], [その2][2], [その3][3], [その4][4]を読んでください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-four.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-four.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 4"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 4"></iframe>
 </div>
 
 * [完成されたプロジェクトはこちら][6]です。先に[その1][1], [その2][2], [その3][3]を読んでください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-four.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-four.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 4"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 4" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 * [完成されたプロジェクトはこちら][6]です。先に[その1][1], [その2][2], [その3][3]を読んでください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-one.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-one.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 1"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 1" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *[完成されたプロジェクトはこちら][3]です*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-one.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-one.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 1"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 1"></iframe>
 </div>
 
 *[完成されたプロジェクトはこちら][3]です*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-six.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-six.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 6"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 6" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *[完成されたプロジェクトはこちら][11]です。先に[その1][1], [その2][2], [その3][3], [その4][4], [その5][5]を読んでください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-six.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-six.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 6"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 6"></iframe>
 </div>
 
 *[完成されたプロジェクトはこちら][11]です。先に[その1][1], [その2][2], [その3][3], [その4][4], [その5][5]を読んでください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-three.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-three.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 3"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 3" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *[完成されたプロジェクトはこちら][4]です。先に[その1][1]と[その2][2] を読んでください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-three.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-three.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 3"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 3"></iframe>
 </div>
 
 *[完成されたプロジェクトはこちら][4]です。先に[その1][1]と[その2][2] を読んでください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-two.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-two.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 2"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 2"></iframe>
 </div>
 
 *[完成されたプロジェクトはこちら][16]です。先に[その1][1]を読んでください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-two.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keepyup-part-two.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 2"></iframe>
+    <iframe src="https://playcanv.as/p/KH37bnOk/?overlay=false" title="Making a Simple Game - Part 2" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *[完成されたプロジェクトはこちら][16]です。先に[その1][1]を読んでください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keyboard-input.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keyboard-input.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/rFZGQWCi/?overlay=false" title="Basic Keyboard Input"></iframe>
+    <iframe src="https://playcanv.as/p/rFZGQWCi/?overlay=false" title="Basic Keyboard Input" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *フォーカスしてから`左矢印キー`、`右矢印キー`、`スペースバー`を押して立方体を回転させます。 'a' キーを押してリリースすると色が変わります。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keyboard-input.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/keyboard-input.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/rFZGQWCi/?overlay=false" title="Basic Keyboard Input"></iframe>
+    <iframe src="https://playcanv.as/p/rFZGQWCi/?overlay=false" title="Basic Keyboard Input"></iframe>
 </div>
 
 *フォーカスしてから`左矢印キー`、`右矢印キー`、`スペースバー`を押して立方体を回転させます。 'a' キーを押してリリースすると色が変わります。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/light-cookies.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/light-cookies.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/409
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/AGtssoOU/" title="Light Cookies"></iframe>
+    <iframe src="https://playcanv.as/p/AGtssoOU/" title="Light Cookies" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 [完成されたプロジェクト][1]をフォークして詳細をご確認ください。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/light-cookies.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/light-cookies.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/409
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/AGtssoOU/" title="Light Cookies"></iframe>
+    <iframe src="https://playcanv.as/p/AGtssoOU/" title="Light Cookies"></iframe>
 </div>
 
 [完成されたプロジェクト][1]をフォークして詳細をご確認ください。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/light-halos.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/light-halos.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/rnIUbXws/" title="Light Halos"></iframe>
+    <iframe src="https://playcanv.as/p/rnIUbXws/" title="Light Halos" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 [完成されたプロジェクト][4]をフォークして詳細をご確認ください。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/light-halos.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/light-halos.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/rnIUbXws/" title="Light Halos"></iframe>
+    <iframe src="https://playcanv.as/p/rnIUbXws/" title="Light Halos"></iframe>
 </div>
 
 [完成されたプロジェクト][4]をフォークして詳細をご確認ください。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/load-assets-with-a-progress-bar.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/load-assets-with-a-progress-bar.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/436
 Sample showing how to load multiple assets at runtime with a progress bar.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/MGKfj6jm/" title="Load assets with a progress bar" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/MGKfj6jm/" title="Load assets with a progress bar" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/load-multiple-assets-at-runtime.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/load-multiple-assets-at-runtime.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/439
 Sample showing how to load multiple assets at runtime.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/P7eFFj4u/" title="Load multiple assets at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/P7eFFj4u/" title="Load multiple assets at runtime" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/loading-an-asset-at-runtime.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/loading-an-asset-at-runtime.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/439
 Sample showing how to load an asset at runtime so you don't have to preload it at the start if it is not used.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/xIkPLoyX/" title="Loading an asset at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/xIkPLoyX/" title="Loading an asset at runtime" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/loading-circle-ui.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/loading-circle-ui.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/705
 An example of a radial loading circle
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/WVAhW4ft/" title="Loading Circle UI" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/WVAhW4ft/" title="Loading Circle UI" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/loading-draco-compressed-glbs.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/loading-draco-compressed-glbs.md
@@ -11,5 +11,5 @@ See https://google.github.io/draco/ for more information on Draco 3D Data Compre
 See https://github.com/CesiumGS/gltf-pipeline for the tool to compress glTF models.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/2uU2aYDh/" title="Loading Draco Compressed GLBs" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/2uU2aYDh/" title="Loading Draco Compressed GLBs" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/loading-gltf-glbs.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/loading-gltf-glbs.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/730
 How to load a GLB as a binary asset.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/RIN6pM0I/" title="Loading glTF GLBs" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/RIN6pM0I/" title="Loading glTF GLBs" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/loading-json.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/loading-json.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/cHnXIXoN/" title="Loading JSON Data"></iframe>
+    <iframe src="https://playcanv.as/p/cHnXIXoN/" title="Loading JSON Data" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 [このプロジェクト][1] で、JSON データを二つの方法で読み込む方法を紹介します。一つ目はプロジェクト内のアセットから直接、二つ目はリモートサーバーから HTTP で読み込みます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/loading-json.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/loading-json.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/cHnXIXoN/" title="Loading JSON Data"></iframe>
+    <iframe src="https://playcanv.as/p/cHnXIXoN/" title="Loading JSON Data"></iframe>
 </div>
 
 [このプロジェクト][1] で、JSON データを二つの方法で読み込む方法を紹介します。一つ目はプロジェクト内のアセットから直接、二つ目はリモートサーバーから HTTP で読み込みます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/locking-the-mouse.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/locking-the-mouse.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438
 A sample showing how to lock the mouse upon clicking.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/2Epvl0CT/" title="Locking the mouse" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/2Epvl0CT/" title="Locking the mouse" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/mobile-ui-safe-areas.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/mobile-ui-safe-areas.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/828
 Example project to handle safe areas on the UI - https://developer.playcanvas.com/user-manual/user-interface/safe-area/
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/z5pXervL/" title="Mobile UI Safe Areas" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/z5pXervL/" title="Mobile UI Safe Areas" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/more-cameras.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/more-cameras.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/5yUf1fvg/" title="More Cameras"></iframe>
+    <iframe src="https://playcanv.as/p/5yUf1fvg/" title="More Cameras" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *クリックしてフォーカスし、 `スペース` キーでズームインとズームアウトを行い、 `左矢印` キーと `右矢印` キーで左右のカメラに切り替えます*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/more-cameras.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/more-cameras.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/5yUf1fvg/" title="More Cameras"></iframe>
+    <iframe src="https://playcanv.as/p/5yUf1fvg/" title="More Cameras"></iframe>
 </div>
 
 *クリックしてフォーカスし、 `スペース` キーでズームインとズームアウトを行い、 `左矢印` キーと `右矢印` キーで左右のカメラに切り替えます*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/mouse-input.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/mouse-input.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/MHIdZgaj/?overlay=false" title="Basic Mouse Input"></iframe>
+    <iframe src="https://playcanv.as/p/MHIdZgaj/?overlay=false" title="Basic Mouse Input" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 :::info

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/mouse-input.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/mouse-input.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/MHIdZgaj/?overlay=false" title="Basic Mouse Input"></iframe>
+    <iframe src="https://playcanv.as/p/MHIdZgaj/?overlay=false" title="Basic Mouse Input"></iframe>
 </div>
 
 :::info

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/multiple-camera-layers.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/multiple-camera-layers.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/593
 Demonstration project that shows how to use multiple cameras and layers to render a mixed user interface of UI elements and world-space objects.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/h7V3tWZK/" title="Multiple Camera Layers" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/h7V3tWZK/" title="Multiple Camera Layers" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/multiple-viewport-rendering.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/multiple-viewport-rendering.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/443
 A sample showing how to render multiple viewports by modifying the viewport properties on the cameras
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/bkLdoYPQ/" title="Multiple Viewport Rendering" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/bkLdoYPQ/" title="Multiple Viewport Rendering" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/multitouch-input.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/multitouch-input.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/437
 Sample that draws lines between all the current touches on the screen.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/p56cF89z/" title="Multitouch input" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/p56cF89z/" title="Multitouch input" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/music-visualizer.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/music-visualizer.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/BqhCi6oy/" title="Creating a Music Visualizer"></iframe>
+    <iframe src="https://playcanv.as/p/BqhCi6oy/" title="Creating a Music Visualizer" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *[完成されたプロジェクト][1]をフォークして詳細をご確認ください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/music-visualizer.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/music-visualizer.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/BqhCi6oy/" title="Creating a Music Visualizer"></iframe>
+    <iframe src="https://playcanv.as/p/BqhCi6oy/" title="Creating a Music Visualizer"></iframe>
 </div>
 
 *[完成されたプロジェクト][1]をフォークして詳細をご確認ください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/orange-room.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/orange-room.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/345
 Interactive interior visualisation with dynamic reflections and HDR lightmaps.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/1ha5glKf/" title="Orange Room" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/1ha5glKf/" title="Orange Room" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/orbit-camera.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/orbit-camera.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438
 Sample with an orbit camera around an entity with both mouse and touch. Scroll wheel and 'pinch to zoom' is used to zoom in and out.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/fI6jSYjK/" title="Orbit camera" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/fI6jSYjK/" title="Orbit camera" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/pan-camera-to-target.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/pan-camera-to-target.md
@@ -9,5 +9,5 @@ An example shows how to focus a camera on target location
 Credit: https://playcanvas.com/user/lexxik
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/5SJsWtg3/" title="Pan Camera to Target" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/5SJsWtg3/" title="Pan Camera to Target" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/pauseplay-application.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/pauseplay-application.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/437
 A sample showing how to pause and resume an app by modifying the timeScale property. Click to pause/play the app
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/sNoeqOZL/" title="Pause/Play application" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/sNoeqOZL/" title="Pause/Play application" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/physics-raycasting-by-tag.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/physics-raycasting-by-tag.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/691
 Sample showing how to pick an entity by tag using raycastAll
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/j1aT7giL/" title="Physics raycasting by tag" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/j1aT7giL/" title="Physics raycasting by tag" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/physics-with-ccd.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/physics-with-ccd.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/447
 A sample with a script to setup and enable CCD for very fast moving physics objects
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/jBMFj7l2/" title="Physics with CCD" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/jBMFj7l2/" title="Physics with CCD" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/place-an-entity-with-physics.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/place-an-entity-with-physics.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/437
 A sample showing how to place objects in the world by using physics. Click on ground to place a box.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/JCW3CUKx/" title="Place an entity with physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/JCW3CUKx/" title="Place an entity with physics" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/place-entity-without-physics.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/place-entity-without-physics.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/437
 A sample showing how to place objects in the world without using physics. Click on the ground to place boxes.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Z2ieIwf8/" title="Place entity without physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/Z2ieIwf8/" title="Place entity without physics" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/planar-mirror-reflection.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/planar-mirror-reflection.md
@@ -9,5 +9,5 @@ Credit: https://playcanvas.com/user/lexxik
 Example of creating a planar reflection being used for a transparent mirror/water like surface.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/bQE35vbj/" title="Planar Mirror Reflection" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/bQE35vbj/" title="Planar Mirror Reflection" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/planet-earth.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/planet-earth.md
@@ -5,5 +5,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/419
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/kU1mx35y/" title="Planet Earth" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/kU1mx35y/" title="Planet Earth" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/point-and-click-movement.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/point-and-click-movement.md
@@ -7,6 +7,6 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/461
 Sample showing a simple point and click system to move an object where you user has clicked
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/RQAovNH6/" title="Point and click movement" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/RQAovNH6/" title="Point and click movement" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/procedural-gradient-texture.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/procedural-gradient-texture.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/708
 Example of creating a procedural texture with a gradient effect by LeXXik
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/5qggchI4/" title="Procedural Gradient Texture" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/5qggchI4/" title="Procedural Gradient Texture" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/procedural-levels.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/procedural-levels.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/smskdMrk/" title="Procedural Levels"></iframe>
+    <iframe src="https://playcanv.as/p/smskdMrk/" title="Procedural Levels"></iframe>
 </div>
 
 このプロジェクトでは、エディターで作成されたエンティティを元に、[clone()][1] 関数を使用してステージ（レベル）をランダムに生成しています。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/procedural-levels.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/procedural-levels.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/smskdMrk/" title="Procedural Levels"></iframe>
+    <iframe src="https://playcanv.as/p/smskdMrk/" title="Procedural Levels" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 このプロジェクトでは、エディターで作成されたエンティティを元に、[clone()][1] 関数を使用してステージ（レベル）をランダムに生成しています。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/programmatically-creating.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/programmatically-creating.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/1VjdIY7v/" title="Programmatically Creating Entities"></iframe>
+    <iframe src="https://playcanv.as/p/1VjdIY7v/" title="Programmatically Creating Entities" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 通常、PlayCanvas エディターを使用してエンティティを作成し、ゲームのさまざまなパーツを作成するためにコンポーネントやスクリプトのコレクションを作成することが多いです。しかし、スクリプトでエンティティを作成することもできます。このチュートリアルでは、その方法を説明します。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/programmatically-creating.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/programmatically-creating.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/1VjdIY7v/" title="Programmatically Creating Entities"></iframe>
+    <iframe src="https://playcanv.as/p/1VjdIY7v/" title="Programmatically Creating Entities"></iframe>
 </div>
 
 通常、PlayCanvas エディターを使用してエンティティを作成し、ゲームのさまざまなパーツを作成するためにコンポーネントやスクリプトのコレクションを作成することが多いです。しかし、スクリプトでエンティティを作成することもできます。このチュートリアルでは、その方法を説明します。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/rainbow-trail-with-mesh-api.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/rainbow-trail-with-mesh-api.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/733
 A rainbow trail using the pc.Mesh API
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/jGeaTg6B/" title="Rainbow Trail with Mesh API" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/jGeaTg6B/" title="Rainbow Trail with Mesh API" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/raycast-with-camera-viewports.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/raycast-with-camera-viewports.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/964
 Raycasting with multiple camera viewports. Click on the shapes in each view
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/dXvrDzH2/" title="Raycast with Camera Viewports" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/dXvrDzH2/" title="Raycast with Camera Viewports" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/real-time-multiplayer-colyseus.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/real-time-multiplayer-colyseus.md
@@ -5,7 +5,7 @@ thumb: "https://avatars.githubusercontent.com/u/28384334?s=300&v=4"
 ---
 
 <div className="iframe-container">
-  <iframe src="https://playcanv.as/p/1QoAsx7r/" title="Real-time Multiplayer with Colyseus"></iframe>
+  <iframe src="https://playcanv.as/p/1QoAsx7r/" title="Real-time Multiplayer with Colyseus" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 > *「create game」を選択し、新しいゲームを立ち上げます。床のいずれかをクリックしてオブジェクトを移動します。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/real-time-multiplayer-colyseus.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/real-time-multiplayer-colyseus.md
@@ -5,7 +5,7 @@ thumb: "https://avatars.githubusercontent.com/u/28384334?s=300&v=4"
 ---
 
 <div className="iframe-container">
-  <iframe loading="lazy" src="https://playcanv.as/p/1QoAsx7r/" title="Real-time Multiplayer with Colyseus"></iframe>
+  <iframe src="https://playcanv.as/p/1QoAsx7r/" title="Real-time Multiplayer with Colyseus"></iframe>
 </div>
 
 > *「create game」を選択し、新しいゲームを立ち上げます。床のいずれかをクリックしてオブジェクトを移動します。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/real-time-multiplayer-photon.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/real-time-multiplayer-photon.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/926
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/e/p/dvJYXs1Y/" title="Real-time Multiplayer with Photon - including matchmaking"></iframe>
+    <iframe src="https://playcanv.as/e/p/dvJYXs1Y/" title="Real-time Multiplayer with Photon - including matchmaking" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 :::info

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/real-time-multiplayer-photon.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/real-time-multiplayer-photon.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/926
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/e/p/dvJYXs1Y/" title="Real-time Multiplayer with Photon - including matchmaking"></iframe>
+    <iframe src="https://playcanv.as/e/p/dvJYXs1Y/" title="Real-time Multiplayer with Photon - including matchmaking"></iframe>
 </div>
 
 :::info

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/real-time-multiplayer.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/real-time-multiplayer.md
@@ -11,7 +11,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 :::
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/XFp1Ty3X/" title="Real Time Multiplayer"></iframe>
+    <iframe src="https://playcanv.as/p/XFp1Ty3X/" title="Real Time Multiplayer" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *WASD キーを使用してプレイヤーを移動します。カプセルが 1 つしか表示されない場合は、別のタブまたは別のコンピューターでこのページを開いてみてください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/real-time-multiplayer.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/real-time-multiplayer.md
@@ -11,7 +11,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 :::
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/XFp1Ty3X/" title="Real Time Multiplayer"></iframe>
+    <iframe src="https://playcanv.as/p/XFp1Ty3X/" title="Real Time Multiplayer"></iframe>
 </div>
 
 *WASD キーを使用してプレイヤーを移動します。カプセルが 1 つしか表示されない場合は、別のタブまたは別のコンピューターでこのページを開いてみてください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/render-3d-world-to-ui.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/render-3d-world-to-ui.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/855
 Render 3D objects as part of the UI
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/CQzD8zlM/" title="Render 3D World to UI" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/CQzD8zlM/" title="Render 3D World to UI" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/resolution-scaling.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/resolution-scaling.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/708
 Example project on rendering the world at different resolutions without the UI being affected
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/qx7PyE7q/" title="Resolution Scaling" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/qx7PyE7q/" title="Resolution Scaling" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/right-to-left-language-support.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/right-to-left-language-support.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/764
 Scripts to use for RTL language support such Arabic
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/k2TruV1u/" title="Right to left language support" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/k2TruV1u/" title="Right to left language support" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/rotating-objects-with-mouse.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/rotating-objects-with-mouse.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/442
 Sample showing how to rotate an object using the mouse in screen space
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/BgbpyC0Y/" title="Rotating Objects with Mouse" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/BgbpyC0Y/" title="Rotating Objects with Mouse" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/shockwave.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/shockwave.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/440
 Shockwave ripple post effect
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/c16yO94k/" title="Shockwave" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/c16yO94k/" title="Shockwave" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/simple-shape-raycasting.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/simple-shape-raycasting.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/457
 Sample showing how to pick at an entity
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/QGiL8OdM/" title="Simple shape raycasting" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/QGiL8OdM/" title="Simple shape raycasting" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/simple-water-surface.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/simple-water-surface.md
@@ -5,5 +5,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/438
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/NeYgvM9z/" title="Simple water surface" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/NeYgvM9z/" title="Simple water surface" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/smooth-camera-movement.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/smooth-camera-movement.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/437
 Sample with a smooth transition of a camera from one position and rotation to another using the Lerp and Slerp functions.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/T7VKMrs8/" title="Smooth camera movement" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/T7VKMrs8/" title="Smooth camera movement" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/sound-volume-control-using-curve.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/sound-volume-control-using-curve.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/436
 Sample showing how to control the volume of a sound slot using curve data. Click on the scene to start the audio.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/hmRciuNn/" title="Sound volume control using curve" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/hmRciuNn/" title="Sound volume control using curve" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/space-rocks.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/space-rocks.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/102
 Get started making your own space shooter game by forking this template Asteroids shooter! Aim with your mouse and fire with your left button. Survive as long as you can!
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/cAFbOEtL/" title="Space Rocks!" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/cAFbOEtL/" title="Space Rocks!" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/static-batching.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/static-batching.md
@@ -5,5 +5,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/520
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Qo7T1kqU/" title="Static Batching" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/Qo7T1kqU/" title="Static Batching" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/stencil-buffer---3d-magic-card.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/stencil-buffer---3d-magic-card.md
@@ -9,5 +9,5 @@ Example project that uses the stencil buffer to create a magic window like effec
 Credit: @ alexanderrdx for the original project
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/RAQhfemb/" title="Stencil Buffer - 3D Magic Card" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/RAQhfemb/" title="Stencil Buffer - 3D Magic Card" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/switch-full-scene.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/switch-full-scene.md
@@ -7,7 +7,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/691
 シーンの読み込みに関する完全なドキュメントは、[ユーザーマニュアル][documentation-page]にあります。
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/e/p/zsQcbehI/" title="Switch Full Scene"></iframe>
+    <iframe src="https://playcanv.as/e/p/zsQcbehI/" title="Switch Full Scene" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 [documentation-page]: /user-manual/scenes/loading-scenes/

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/switch-full-scene.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/switch-full-scene.md
@@ -7,7 +7,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/691
 シーンの読み込みに関する完全なドキュメントは、[ユーザーマニュアル][documentation-page]にあります。
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/e/p/zsQcbehI/" title="Switch Full Scene"></iframe>
+    <iframe src="https://playcanv.as/e/p/zsQcbehI/" title="Switch Full Scene"></iframe>
 </div>
 
 [documentation-page]: /user-manual/scenes/loading-scenes/

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/switching-materials-at-runtime.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/switching-materials-at-runtime.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/437
 Sample switching on a model materials at runtime.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/7EZvdnZd/" title="Switching materials at runtime" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/7EZvdnZd/" title="Switching materials at runtime" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/terrain-generation.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/terrain-generation.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/CmcIlmPb/" title="Terrain Generation from Heightmap"></iframe>
+    <iframe src="https://playcanv.as/p/CmcIlmPb/" title="Terrain Generation from Heightmap" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 このプロジェクトでは[`pc.Mesh`][1] API を使用して、ハイトマップ (Height) テクスチャから地形を手続き的に生成し、テクスチャを施しました。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/terrain-generation.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/terrain-generation.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/CmcIlmPb/" title="Terrain Generation from Heightmap"></iframe>
+    <iframe src="https://playcanv.as/p/CmcIlmPb/" title="Terrain Generation from Heightmap"></iframe>
 </div>
 
 このプロジェクトでは[`pc.Mesh`][1] API を使用して、ハイトマップ (Height) テクスチャから地形を手続き的に生成し、テクスチャを施しました。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/third-person-controller.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/third-person-controller.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/705
 A simple third person controller.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Q7CJA9Ku/" title="Third Person Controller" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/Q7CJA9Ku/" title="Third Person Controller" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/tic-tac-toe.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/tic-tac-toe.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/671
 The classic game Tic Tac Toe
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/i5csiIb9/" title="Tic Tac Toe" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/i5csiIb9/" title="Tic Tac Toe" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/timers.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/timers.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/691
 Example of extending the PlayCanvas engine to create one shot timers. Press P to pause time.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/WsI6QA7y/" title="Timers" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/WsI6QA7y/" title="Timers" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/touch-joypad.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/touch-joypad.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/100
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/kvE0iJWc/" title="Touchscreen Joypad Controls"></iframe>
+    <iframe src="https://playcanv.as/p/kvE0iJWc/" title="Touchscreen Joypad Controls" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 [プロジェクトのリンク][project-link]をクリックしてください。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/touch-joypad.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/touch-joypad.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/100
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/kvE0iJWc/" title="Touchscreen Joypad Controls"></iframe>
+    <iframe src="https://playcanv.as/p/kvE0iJWc/" title="Touchscreen Joypad Controls"></iframe>
 </div>
 
 [プロジェクトのリンク][project-link]をクリックしてください。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/tutorial-layout-groups.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/tutorial-layout-groups.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/553
 Use the Layout Group component to build a user interface.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/y4JwxWTI/" title="Tutorial: Layout Groups" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/y4JwxWTI/" title="Tutorial: Layout Groups" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/tutorial-normal-mapped-text.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/tutorial-normal-mapped-text.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/371
 Dynamically generate normal maps and parallax maps for text
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/MbMb81DM/" title="Tutorial: Normal Mapped Text" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/MbMb81DM/" title="Tutorial: Normal Mapped Text" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/tutorial-plasma-shader-chunk.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/tutorial-plasma-shader-chunk.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/453
 A demonstration of a GLSL effect from Shadertoy being used in a shader chunk on a PlayCanvas material
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/NLgp097Q/" title="Tutorial: Plasma Shader Chunk" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/NLgp097Q/" title="Tutorial: Plasma Shader Chunk" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/tutorial-shop-user-interface.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/tutorial-shop-user-interface.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/559
 Build a Shop User Interface screen using UI Elements, Layout Groups, Button components, Sprites and Texture Atlases
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/yN4CxzAs/" title="Tutorial: Shop User Interface" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/yN4CxzAs/" title="Tutorial: Shop User Interface" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/tweening.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/tweening.md
@@ -15,7 +15,7 @@ entity.tween(entity.getLocalPosition()).to({x: 10, y: 0, z: 0}, 1, pc.SineOut);
 ここでは、Entityのローカル位置をトゥイーンする方法の例が示されています。
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/b/wEftzstB/" title="Using the Tween library"></iframe>
+    <iframe src="https://playcanv.as/b/wEftzstB/" title="Using the Tween library"></iframe>
 </div>
 
 この例の[Project][2]と[Editor][3]へのリンクです。
@@ -34,7 +34,7 @@ this.entity
 エンティティのローカル回転をトゥイーンする方法の例です：
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/b/H8553dGa/" title="Tween Local Rotation"></iframe>
+    <iframe src="https://playcanv.as/b/H8553dGa/" title="Tween Local Rotation"></iframe>
 </div>
 
 この例の[プロジェクト][2]と[エディタ][4]へのリンクを貼ります。
@@ -53,7 +53,7 @@ this.entity
 次に、Entityのローカルスケールをトゥイーンする方法の例が示されています。
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/b/ndTiHCpD/" title="Tween Local Scale"></iframe>
+    <iframe src="https://playcanv.as/b/ndTiHCpD/" title="Tween Local Scale"></iframe>
 </div>
 
 この例の[Project][2]と[Editor][5]へのリンクです。
@@ -72,7 +72,7 @@ this.entity
 最後に、色をトゥイーンする方法です：
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/b/aoRYsYrc/" title="Tween Material Color"></iframe>
+    <iframe src="https://playcanv.as/b/aoRYsYrc/" title="Tween Material Color"></iframe>
 </div>
 
 この例の[プロジェクト][2]と[エディタ][6]へのリンクを貼ります。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/tweening.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/tweening.md
@@ -15,7 +15,7 @@ entity.tween(entity.getLocalPosition()).to({x: 10, y: 0, z: 0}, 1, pc.SineOut);
 ここでは、Entityのローカル位置をトゥイーンする方法の例が示されています。
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/b/wEftzstB/" title="Using the Tween library"></iframe>
+    <iframe src="https://playcanv.as/b/wEftzstB/" title="Using the Tween library" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 この例の[Project][2]と[Editor][3]へのリンクです。
@@ -34,7 +34,7 @@ this.entity
 エンティティのローカル回転をトゥイーンする方法の例です：
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/b/H8553dGa/" title="Tween Local Rotation"></iframe>
+    <iframe src="https://playcanv.as/b/H8553dGa/" title="Tween Local Rotation" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 この例の[プロジェクト][2]と[エディタ][4]へのリンクを貼ります。
@@ -53,7 +53,7 @@ this.entity
 次に、Entityのローカルスケールをトゥイーンする方法の例が示されています。
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/b/ndTiHCpD/" title="Tween Local Scale"></iframe>
+    <iframe src="https://playcanv.as/b/ndTiHCpD/" title="Tween Local Scale" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 この例の[Project][2]と[Editor][5]へのリンクです。
@@ -72,7 +72,7 @@ this.entity
 最後に、色をトゥイーンする方法です：
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/b/aoRYsYrc/" title="Tween Material Color"></iframe>
+    <iframe src="https://playcanv.as/b/aoRYsYrc/" title="Tween Material Color" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 この例の[プロジェクト][2]と[エディタ][6]へのリンクを貼ります。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-elements-buttons.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-elements-buttons.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/501
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/jpRiV53D/" title="User Interface - Buttons"></iframe>
+    <iframe src="https://playcanv.as/p/jpRiV53D/" title="User Interface - Buttons"></iframe>
 </div>
 
 *ElementとButtonコンポーネントを使用したシンプルなボタン。[完全なシーン][1]を参照してください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-elements-buttons.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-elements-buttons.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/501
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/jpRiV53D/" title="User Interface - Buttons"></iframe>
+    <iframe src="https://playcanv.as/p/jpRiV53D/" title="User Interface - Buttons" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *ElementとButtonコンポーネントを使用したシンプルなボタン。[完全なシーン][1]を参照してください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-elements-leaderboard.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-elements-leaderboard.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/501
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/nbMbtAGH/" title="User Interface - Leaderboard"></iframe>
+    <iframe src="https://playcanv.as/p/nbMbtAGH/" title="User Interface - Leaderboard"></iframe>
 </div>
 
 *Elementコンポーネントを使用しているリーダーボード。[フルシーン][1]を参照してください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-elements-leaderboard.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-elements-leaderboard.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/501
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/nbMbtAGH/" title="User Interface - Leaderboard"></iframe>
+    <iframe src="https://playcanv.as/p/nbMbtAGH/" title="User Interface - Leaderboard" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *Elementコンポーネントを使用しているリーダーボード。[フルシーン][1]を参照してください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-elements-progress.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-elements-progress.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/501
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/FlebHmLs/" title="User Interface - Progress Bar"></iframe>
+    <iframe src="https://playcanv.as/p/FlebHmLs/" title="User Interface - Progress Bar" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *Elementコンポーネントを使用するプログレスバー。[フルシーン][1]を参照してください*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-elements-progress.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-elements-progress.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/501
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/FlebHmLs/" title="User Interface - Progress Bar"></iframe>
+    <iframe src="https://playcanv.as/p/FlebHmLs/" title="User Interface - Progress Bar"></iframe>
 </div>
 
 *Elementコンポーネントを使用するプログレスバー。[フルシーン][1]を参照してください*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-elements-stats-counter.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-elements-stats-counter.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/501
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/XVLr9TWc/" title="User Interface - Stats Counter"></iframe>
+    <iframe src="https://playcanv.as/p/XVLr9TWc/" title="User Interface - Stats Counter" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *ボタンやプログレスバーの使い方と要素とインタラクトする方法。[フルシーン][1]を参照してください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-elements-stats-counter.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-elements-stats-counter.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/501
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/XVLr9TWc/" title="User Interface - Stats Counter"></iframe>
+    <iframe src="https://playcanv.as/p/XVLr9TWc/" title="User Interface - Stats Counter"></iframe>
 </div>
 
 *ボタンやプログレスバーの使い方と要素とインタラクトする方法。[フルシーン][1]を参照してください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-text-input.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-text-input.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/100
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/8ZQaDGf8/" title="User Interface - Text Input"></iframe>
+    <iframe src="https://playcanv.as/p/8ZQaDGf8/" title="User Interface - Text Input" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 [ここをクリックしてプロジェクトを見る][project-link].

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-text-input.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-text-input.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/100
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/8ZQaDGf8/" title="User Interface - Text Input"></iframe>
+    <iframe src="https://playcanv.as/p/8ZQaDGf8/" title="User Interface - Text Input"></iframe>
 </div>
 
 [ここをクリックしてプロジェクトを見る][project-link].

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/using-assets.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/using-assets.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/QwDM4qaF/" title="Using the Asset Registry"></iframe>
+    <iframe src="https://playcanv.as/p/QwDM4qaF/" title="Using the Asset Registry"></iframe>
 </div>
 
 :::info

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/using-assets.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/using-assets.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/406
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/QwDM4qaF/" title="Using the Asset Registry"></iframe>
+    <iframe src="https://playcanv.as/p/QwDM4qaF/" title="Using the Asset Registry" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 :::info

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/using-events-with-scripts.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/using-events-with-scripts.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/437
 Sample showing how to communicate between scripts using events.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/HXrtITkb/" title="Using events with scripts" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/HXrtITkb/" title="Using events with scripts" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/vehicle-physics.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/vehicle-physics.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/643
 An implementation of vehicle physics in PlayCanvas, using the RaycastVehicle API in ammo.js. Supports desktop, mobile and VR.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/CxgnAp22/" title="Vehicle Physics" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/CxgnAp22/" title="Vehicle Physics" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/vhscrt-post-effect.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/vhscrt-post-effect.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/373
 Basic fullscreen effect simulating a bad video screen like an old CRT.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/6hhSiHG3/" title="VHS/CRT Post Effect" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/6hhSiHG3/" title="VHS/CRT Post Effect" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/video-textures.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/video-textures.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/6wt5T87E/" title="Video Textures"></iframe>
+    <iframe src="https://playcanv.as/p/6wt5T87E/" title="Video Textures"></iframe>
 </div>
 
 [このチュートリアルのプロジェクト][1]をエディタから試すことができます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/video-textures.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/video-textures.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/405
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/6wt5T87E/" title="Video Textures"></iframe>
+    <iframe src="https://playcanv.as/p/6wt5T87E/" title="Video Textures" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 [このチュートリアルのプロジェクト][1]をエディタから試すことができます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/vignette-abberation.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/vignette-abberation.md
@@ -5,5 +5,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/440
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/UwEmhiJf/" title="Vignette Abberation" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/UwEmhiJf/" title="Vignette Abberation" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/warp-a-sprite-with-glsl.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/warp-a-sprite-with-glsl.md
@@ -5,5 +5,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/426
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/3NdgiVsp/" title="Warp a Sprite with GLSL" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/3NdgiVsp/" title="Warp a Sprite with GLSL" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-360-image.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-360-image.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/434
 360 Image with WebXR support | Image Credit: Bob Dass from https://www.flickr.com/photos/54144402@N03/
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/v6qoi4Yt/" title="WebXR 360 Image" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/v6qoi4Yt/" title="WebXR 360 Image" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-360-video.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-360-video.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/434
 360 Video with WebXR support
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/G0d8FneG/" title="WebXR 360 Video" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/G0d8FneG/" title="WebXR 360 Video" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-ar-dom-overlay.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-ar-dom-overlay.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/747
 Example of how to use DOM (HTML + CSS) with WebXR AR session.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/S01LYTIU/" title="WebXR AR: DOM Overlay" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/S01LYTIU/" title="WebXR AR: DOM Overlay" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-ar-hit-test.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-ar-hit-test.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/672
 Example of how to use WebXR Hit Test API. That allows to hit test real world geometry.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Kjol3uRS/" title="WebXR AR: Hit Test" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/Kjol3uRS/" title="WebXR AR: Hit Test" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-ar-image-tracking.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-ar-image-tracking.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/739
 Example of how to use WebXR Augmented Reality: Image Tracking API. That allows to *actively* track real world images based on provided sample.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/PCsSvN5h/" title="WebXR: AR Image Tracking" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/PCsSvN5h/" title="WebXR: AR Image Tracking" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-ar-raycasting-shapes.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-ar-raycasting-shapes.md
@@ -9,5 +9,5 @@ Example of how to raycast in the PlayCanvas scene when using WebXR AR.
 Tap the shapes to change their color!
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/qiLEOeL7/" title="WebXR AR Raycasting Shapes" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/qiLEOeL7/" title="WebXR AR Raycasting Shapes" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-controllerhand-models.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-controllerhand-models.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/706
 Sample application with WebXR controller/hand models loaded based on input source profile. Models sourced from: https://github.com/immersive-web/webxr-input-profiles
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/g7uSJhuo/" title="WebXR Controller/Hand Models" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/g7uSJhuo/" title="WebXR Controller/Hand Models" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-hands.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-hands.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/705
 Sample application with WebXR Hands Tracking.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/VmHVW3Wb/" title="WebXR Hands" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/VmHVW3Wb/" title="WebXR Hands" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-hello-world.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-hello-world.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/433
 Basic scene with support for VR camera
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/z7myUkHP/" title="WebXR Hello World" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/z7myUkHP/" title="WebXR Hello World" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-plane-detection.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-plane-detection.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/782
 Example of how to use WebXR Augmented Reality: Plane Detection API. That allows to *actively* track real world surface estimations.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/f2ESRGge/" title="WebXR: Plane Detection" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/f2ESRGge/" title="WebXR: Plane Detection" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-ray-input.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-ray-input.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/460
 ---
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/TAYVQgU2/" title="WebXR UI Interaction" allow="autoplay;xr-spatial-tracking"></iframe>
+    <iframe src="https://playcanv.as/p/TAYVQgU2/" title="WebXR UI Interaction" allow="autoplay;xr-spatial-tracking"></iframe>
 </div>
 
 *VR/AR対応のデバイスやヘッドセットがある場合は、VR/ARボタンをクリックしてください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-ray-input.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-ray-input.md
@@ -5,7 +5,7 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/460
 ---
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/TAYVQgU2/" title="WebXR UI Interaction" allow="autoplay;xr-spatial-tracking"></iframe>
+    <iframe src="https://playcanv.as/p/TAYVQgU2/" title="WebXR UI Interaction" allow="autoplay;xr-spatial-tracking" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *VR/AR対応のデバイスやヘッドセットがある場合は、VR/ARボタンをクリックしてください。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-realistic-hands.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-realistic-hands.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/771
 Realistic hands in VR!
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/pG6tosLX/" title="WebXR Realistic Hands" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/pG6tosLX/" title="WebXR Realistic Hands" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-tracked-controllers.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-tracked-controllers.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/457
 A sample application with boilerplate code for WebXR support with tracked controllers using PlayCanvas.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/TUBZkBEl/" title="WebXR Tracked Controllers" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/TUBZkBEl/" title="WebXR Tracked Controllers" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-vr-lab.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-vr-lab.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/446
 A living project built by the PlayCanvas team to help developers learn about creating scalable and responsive WebXR VR applications for all devices
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/sAsiDvtC/" title="WebXR VR Lab" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/sAsiDvtC/" title="WebXR VR Lab" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/world-space-ui-rendering-on-top.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/world-space-ui-rendering-on-top.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/691
 Learn how to render world space UI over the top of the world
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/0Ycgs0n7/" title="World space UI rendering on top" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/0Ycgs0n7/" title="World space UI rendering on top" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/world-to-ui-screen-space.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/world-to-ui-screen-space.md
@@ -7,5 +7,5 @@ thumb: "https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/679
 Sample in which a UI Element is positioned over a world space point.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/xU0TSSIY/" title="World to UI Screen space" webkitallowfullscreen="true" mozallowfullscreen="true" allow="autoplay" allowfullscreen="true" allowvr="" scrolling="no" frameborder="0" />
+    <iframe src="https://playcanv.as/p/xU0TSSIY/" title="World to UI Screen space" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/assets/types/cubemap.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/assets/types/cubemap.md
@@ -8,7 +8,7 @@ title: キューブマップ (Cubemap)
 2. キューブマップは、任意のマテリアルに反射を追加することができます。シーン内の光沢のあるクロムのボールベアリングを想像してみてください。そのボールは周囲のシーンを反射します。オープンな環境では、通常、シーンのスカイボックスキューブマップを反射オブジェクトのマテリアルのキューブマップとして設定します。
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/b/xp7v1oFB/" title="Cubemap"></iframe>
+    <iframe src="https://playcanv.as/b/xp7v1oFB/" title="Cubemap"></iframe>
 </div>
 
 ## キューブマップテクスチャのインポート

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/assets/types/cubemap.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/assets/types/cubemap.md
@@ -8,7 +8,7 @@ title: キューブマップ (Cubemap)
 2. キューブマップは、任意のマテリアルに反射を追加することができます。シーン内の光沢のあるクロムのボールベアリングを想像してみてください。そのボールは周囲のシーンを反射します。オープンな環境では、通常、シーンのスカイボックスキューブマップを反射オブジェクトのマテリアルのキューブマップとして設定します。
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/b/xp7v1oFB/" title="Cubemap"></iframe>
+    <iframe src="https://playcanv.as/b/xp7v1oFB/" title="Cubemap" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 ## キューブマップテクスチャのインポート

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/getting-started/index.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/getting-started/index.md
@@ -14,7 +14,7 @@ PlayCanvasは、インタラクティブなWebコンテンツのビジュアル�
 PlayCanvasエディターは、ビジュアルエディターです。シーン、アプリケーション、ゲームを素早く構築できます。エディターを使ってプロジェクトのアセットを管理し、インタラクティブ要素を追加し、チームとのコミュニケーションや作業を行います。エディターはリアルタイムで協同作業が可能で、これによりチームの作業による変更を即座に確認でき、アプリケーションをすべてのデバイスで即時に作成し、テストすることができます。
 
 <div className="iframe-container">
-    <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/PS4oMLPyYfI" title="PlayCanvas Editor Live Link" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/PS4oMLPyYfI" title="PlayCanvas Editor Live Link" allowfullscreen></iframe>
 </div>
 
 詳細は[editor][5]セクションでご確認ください。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/getting-started/made-with-playcanvas.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/getting-started/made-with-playcanvas.md
@@ -12,7 +12,7 @@ PlayCanvasのユーザーによって作成された素晴らしいゲームや�
 紹介されたコンテンツへのリンクは、[ブログ投稿][2022-blog-post]で見つけることができます。
 
 <div className="iframe-container">
-    <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/46f73gp1_TU" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/46f73gp1_TU" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 
@@ -21,7 +21,7 @@ PlayCanvasのユーザーによって作成された素晴らしいゲームや�
 Links to the content showcased can be found on the [blog post][2021-blog-post].
 
 <div className="iframe-container">
-    <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/FrUUrVRpbzg" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/FrUUrVRpbzg" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 [awesome-playcanvas]: https://github.com/playcanvas/awesome-playcanvas

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/getting-started/your-first-app.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/getting-started/your-first-app.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 PlayCanvasでのアプリケーション開発は簡単で楽しいものです。基本的なことを学ぶために次のシンプルな3Dアプリを作成しましょう。
 
 <div className="iframe-container">
-    <iframe loading="lazy"  src="https://playcanv.as/p/TnUtDXWp/" title="Simple PlayCanvas App"></iframe>
+    <iframe  src="https://playcanv.as/p/TnUtDXWp/" title="Simple PlayCanvas App"></iframe>
 </div>
 
 *矢印キーを使って赤いボールを動かします。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/getting-started/your-first-app.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/getting-started/your-first-app.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 PlayCanvasでのアプリケーション開発は簡単で楽しいものです。基本的なことを学ぶために次のシンプルな3Dアプリを作成しましょう。
 
 <div className="iframe-container">
-    <iframe  src="https://playcanv.as/p/TnUtDXWp/" title="Simple PlayCanvas App"></iframe>
+    <iframe  src="https://playcanv.as/p/TnUtDXWp/" title="Simple PlayCanvas App" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 *矢印キーを使って赤いボールを動かします。*

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/gaussian-splatting.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/gaussian-splatting.md
@@ -6,7 +6,7 @@ sidebar_position: 3.5
 3D Gaussian Splatting is a relatively new technique for capturing and rendering photorealistic volumetric point clouds. Since the technique relies on photogrammetry, it is very quick, cheap and easy to generate high-quality rendered scenes.
 
 <div className="iframe-container">
-    <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/Pe4Sx8t1Ud4" title="Templates Overview" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/Pe4Sx8t1Ud4" title="Templates Overview" allowfullscreen></iframe>
 </div>
 
 ## Working with Gaussian Splats

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/physical-rendering/physical-materials.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/physical-rendering/physical-materials.md
@@ -37,7 +37,7 @@ Diffuseカラーはマテリアルのベースとなるカラーです。これ�
 Diffuseカラーは **アルベド** や **ベースカラー** と呼ばれることもあります。
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Q28EwTwQ/?color" title="Physical Materials - Diffuse"></iframe>
+    <iframe src="https://playcanv.as/p/Q28EwTwQ/?color" title="Physical Materials - Diffuse"></iframe>
 </div>
 
 インターネット上を探すと、拡散色/アルベドの値と素材の対応表をすぐに見つけることができます。
@@ -63,7 +63,7 @@ Diffuseカラーは **アルベド** や **ベースカラー** と呼ばれる�
 また、金属質マップを使うと、マテリアルの特定の部分を金属に、特定の部分を非金属に設定することができます。
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Q28EwTwQ/?metal" title="Physical Materials - Metalness"></iframe>
+    <iframe src="https://playcanv.as/p/Q28EwTwQ/?metal" title="Physical Materials - Metalness"></iframe>
 </div>
 
 ### 光沢度 (Glossiness)
@@ -71,7 +71,7 @@ Diffuseカラーは **アルベド** や **ベースカラー** と呼ばれる�
 光沢度 (Glossiness) は **Metalness** と **Specular** を使う方法の両方で使われ、マテリアルの表面がどのくらいなめらかかを定義します。光沢度はマテリアルの表面で反射する光がぼやけるか鋭いか、あるいはSpecularハイライトが広いか狭いかに影響します。光沢度は0から100の間の値か、あるいはGlossinessマップとして与えることができます。
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Q28EwTwQ/?gloss" title="Physical Materials - Glossiness"></iframe>
+    <iframe src="https://playcanv.as/p/Q28EwTwQ/?gloss" title="Physical Materials - Glossiness"></iframe>
 </div>
 
 いくつかの物理ベースレンダリングシステムでは、光沢度という用語の代わりに**粗さ (Roughness)**という用語を使います。粗さは光沢度の反対の意味です。光沢度と粗さを変換する際には、単純にその値を反転してください。
@@ -85,7 +85,7 @@ Diffuseカラーは **アルベド** や **ベースカラー** と呼ばれる�
 マテリアルの見た目をさらに良くするために、アンビエントオクルージョン、発光、透明度、法線マップとハイトマップといった様々なプロパティを使うことができます。
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/p/Q28EwTwQ/" title="Physical Materials - All"></iframe>
+    <iframe src="https://playcanv.as/p/Q28EwTwQ/" title="Physical Materials - All"></iframe>
 </div>
 
 [5]: https://marmoset.co/posts/pbr-texture-conversion/

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/physical-rendering/physical-materials.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/physical-rendering/physical-materials.md
@@ -37,7 +37,7 @@ Diffuseカラーはマテリアルのベースとなるカラーです。これ�
 Diffuseカラーは **アルベド** や **ベースカラー** と呼ばれることもあります。
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/Q28EwTwQ/?color" title="Physical Materials - Diffuse"></iframe>
+    <iframe src="https://playcanv.as/p/Q28EwTwQ/?color" title="Physical Materials - Diffuse" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 インターネット上を探すと、拡散色/アルベドの値と素材の対応表をすぐに見つけることができます。
@@ -63,7 +63,7 @@ Diffuseカラーは **アルベド** や **ベースカラー** と呼ばれる�
 また、金属質マップを使うと、マテリアルの特定の部分を金属に、特定の部分を非金属に設定することができます。
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/Q28EwTwQ/?metal" title="Physical Materials - Metalness"></iframe>
+    <iframe src="https://playcanv.as/p/Q28EwTwQ/?metal" title="Physical Materials - Metalness" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 ### 光沢度 (Glossiness)
@@ -71,7 +71,7 @@ Diffuseカラーは **アルベド** や **ベースカラー** と呼ばれる�
 光沢度 (Glossiness) は **Metalness** と **Specular** を使う方法の両方で使われ、マテリアルの表面がどのくらいなめらかかを定義します。光沢度はマテリアルの表面で反射する光がぼやけるか鋭いか、あるいはSpecularハイライトが広いか狭いかに影響します。光沢度は0から100の間の値か、あるいはGlossinessマップとして与えることができます。
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/Q28EwTwQ/?gloss" title="Physical Materials - Glossiness"></iframe>
+    <iframe src="https://playcanv.as/p/Q28EwTwQ/?gloss" title="Physical Materials - Glossiness" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 いくつかの物理ベースレンダリングシステムでは、光沢度という用語の代わりに**粗さ (Roughness)**という用語を使います。粗さは光沢度の反対の意味です。光沢度と粗さを変換する際には、単純にその値を反転してください。
@@ -85,7 +85,7 @@ Diffuseカラーは **アルベド** や **ベースカラー** と呼ばれる�
 マテリアルの見た目をさらに良くするために、アンビエントオクルージョン、発光、透明度、法線マップとハイトマップといった様々なプロパティを使うことができます。
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/Q28EwTwQ/" title="Physical Materials - All"></iframe>
+    <iframe src="https://playcanv.as/p/Q28EwTwQ/" title="Physical Materials - All" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 [5]: https://marmoset.co/posts/pbr-texture-conversion/

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/physics/compound-shapes.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/physics/compound-shapes.md
@@ -8,7 +8,7 @@ sidebar_position: 4
 最大の利点は、メッシュコリジョン形状では不可能な動的なRigidBodyのコリジョンをコンパウンド間で行えることです(下記のように表示)。
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/e/p/KXZ5Lsda/" title="Compound Physic Shapes"></iframe>
+    <iframe src="https://playcanv.as/e/p/KXZ5Lsda/" title="Compound Physic Shapes"></iframe>
 </div>
 
 [PlayCanvas プロジェクトリンク][compound-shapes-project]

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/physics/compound-shapes.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/physics/compound-shapes.md
@@ -8,7 +8,7 @@ sidebar_position: 4
 最大の利点は、メッシュコリジョン形状では不可能な動的なRigidBodyのコリジョンをコンパウンド間で行えることです(下記のように表示)。
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/e/p/KXZ5Lsda/" title="Compound Physic Shapes"></iframe>
+    <iframe src="https://playcanv.as/e/p/KXZ5Lsda/" title="Compound Physic Shapes" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 [PlayCanvas プロジェクトリンク][compound-shapes-project]

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/publishing/playable-ads/fb-playable-ads.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/publishing/playable-ads/fb-playable-ads.md
@@ -14,7 +14,7 @@ PlayCanvasは、[公式の外部ツール][2]を通じて[Facebook Playable Ad][
 [Cube Jumpプロジェクト][5]は、Facebook Playable Adフォーマットにエクスポートする準備ができており、[HTML出力の期待される結果はこちら][6]にあります。
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/e/p/Hywjl9Bh/" title="Cube Jump Playable Ad"></iframe>
+    <iframe src="https://playcanv.as/e/p/Hywjl9Bh/" title="Cube Jump Playable Ad"></iframe>
 </div>
 
 ## ファイルサイズの補足

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/publishing/playable-ads/fb-playable-ads.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/publishing/playable-ads/fb-playable-ads.md
@@ -14,7 +14,7 @@ PlayCanvasは、[公式の外部ツール][2]を通じて[Facebook Playable Ad][
 [Cube Jumpプロジェクト][5]は、Facebook Playable Adフォーマットにエクスポートする準備ができており、[HTML出力の期待される結果はこちら][6]にあります。
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/e/p/Hywjl9Bh/" title="Cube Jump Playable Ad"></iframe>
+    <iframe src="https://playcanv.as/e/p/Hywjl9Bh/" title="Cube Jump Playable Ad" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 ## ファイルサイズの補足

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/publishing/playable-ads/snapchat-playable-ads.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/publishing/playable-ads/snapchat-playable-ads.md
@@ -16,7 +16,7 @@ SnapchatのPlayable Adでは、[MRAID 2.0 API][mraid-api]標準が使用され�
 [Cube Jumpプロジェクト][5]は、Snapchat Playable Adフォーマットにエクスポートできる状態になっており、期待されるHTML出力は[こちら][6]からダウンロードできます。
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/e/p/X1nwbUGA/" title="Cube Jump Playable Ad"></iframe>
+    <iframe src="https://playcanv.as/e/p/X1nwbUGA/" title="Cube Jump Playable Ad"></iframe>
 </div>
 
 ## ファイルサイズの補足

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/publishing/playable-ads/snapchat-playable-ads.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/publishing/playable-ads/snapchat-playable-ads.md
@@ -16,7 +16,7 @@ SnapchatのPlayable Adでは、[MRAID 2.0 API][mraid-api]標準が使用され�
 [Cube Jumpプロジェクト][5]は、Snapchat Playable Adフォーマットにエクスポートできる状態になっており、期待されるHTML出力は[こちら][6]からダウンロードできます。
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/e/p/X1nwbUGA/" title="Cube Jump Playable Ad"></iframe>
+    <iframe src="https://playcanv.as/e/p/X1nwbUGA/" title="Cube Jump Playable Ad" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 ## ファイルサイズの補足

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/publishing/web/communicating-webpage.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/publishing/web/communicating-webpage.md
@@ -58,7 +58,7 @@ PlayCanvasアプリケーションをiframeに埋め込むことは、すばや�
 iframeとソーシャル共有バーを含まないバージョンのビルドを取得するためには、URLの `https://playcanv.as` の後に`/e`を追加します。
 
 ```html
-<iframe loading="lazy" id="app-frame" src="https://playcanv.as/e/p/example/">
+<iframe id="app-frame" src="https://playcanv.as/e/p/example/">
 <script>
 const iframe = document.getElementById("app-frame");
 iframe.contentWindow.postMessage({

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/publishing/web/self-hosting.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/publishing/web/self-hosting.md
@@ -18,7 +18,7 @@ sidebar_position: 2
         <title>My Great Game</title>
     </head>
     <body>
-        <iframe loading="lazy" src="https://playcanv.as/p/PROJECT_ID/"></iframe>
+        <iframe src="https://playcanv.as/p/PROJECT_ID/"></iframe>
     </body>
 </html>
 ```

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/publishing/web/self-hosting.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/publishing/web/self-hosting.md
@@ -18,7 +18,7 @@ sidebar_position: 2
         <title>My Great Game</title>
     </head>
     <body>
-        <iframe src="https://playcanv.as/p/PROJECT_ID/"></iframe>
+        <iframe src="https://playcanv.as/p/PROJECT_ID/" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
     </body>
 </html>
 ```

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/loading-scenes.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/loading-scenes.md
@@ -14,7 +14,7 @@ sidebar_position: 4
 [ここに][switch-scenes-completely-project]ユーザーがタイトル画面から他のレベルに移動できる例があります。
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/e/p/Q1gKd1ek/"  title="Switching Scenes Completely"></iframe>
+    <iframe src="https://playcanv.as/e/p/Q1gKd1ek/"  title="Switching Scenes Completely"></iframe>
 </div>
 
 This is done by simply calling [`SceneRegistry.changeScene`][changescene-api] with the name of the scene.
@@ -57,7 +57,7 @@ Sometimes developers use this approach to ensure that certain code and entities 
 [Below is a simplified example][additively-loading-scenes-project] of additively loading scenes where the UI in the top left is the 'main' scene and different scene hierarchies are loaded/destroyed.
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/e/p/cjBInud1/" title="Additively Loading Scenes"></iframe>
+    <iframe src="https://playcanv.as/e/p/cjBInud1/" title="Additively Loading Scenes"></iframe>
 </div>
 
 シーンヒエラルキーの複数のインスタンスを同時にロードすることはできません。これは、エンティティがエディタでユニークなGUIDが割り当てられているためです。同じシーンヒエラルキーの複数のインスタンスを同時にロードしようとすると、エンティティごとにユニークである必要があるGUIDが衝突するため、エラーが発生します。
@@ -193,7 +193,7 @@ this.app.scenes.loadSceneHierarchy(sceneItem, function (err, loadedSceneRootEnti
 下記の[サンプルプロジェクト][asset-load-for-scene-project]は、シーンのロード時にアセットをロードし、メインメニューに戻る際にアンロードするものです。
 
 <div className="iframe-container">
-    <iframe loading="lazy" src="https://playcanv.as/e/p/SBTfOAeM/" title="Loading scenes and assets"></iframe>
+    <iframe src="https://playcanv.as/e/p/SBTfOAeM/" title="Loading scenes and assets"></iframe>
 </div>
 
 [switch-scenes-completely-project]: https://playcanvas.com/project/924351/overview/switch-full-scene-example

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/loading-scenes.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/loading-scenes.md
@@ -14,7 +14,7 @@ sidebar_position: 4
 [ここに][switch-scenes-completely-project]ユーザーがタイトル画面から他のレベルに移動できる例があります。
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/e/p/Q1gKd1ek/"  title="Switching Scenes Completely"></iframe>
+    <iframe src="https://playcanv.as/e/p/Q1gKd1ek/"  title="Switching Scenes Completely" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 This is done by simply calling [`SceneRegistry.changeScene`][changescene-api] with the name of the scene.
@@ -57,7 +57,7 @@ Sometimes developers use this approach to ensure that certain code and entities 
 [Below is a simplified example][additively-loading-scenes-project] of additively loading scenes where the UI in the top left is the 'main' scene and different scene hierarchies are loaded/destroyed.
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/e/p/cjBInud1/" title="Additively Loading Scenes"></iframe>
+    <iframe src="https://playcanv.as/e/p/cjBInud1/" title="Additively Loading Scenes" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 シーンヒエラルキーの複数のインスタンスを同時にロードすることはできません。これは、エンティティがエディタでユニークなGUIDが割り当てられているためです。同じシーンヒエラルキーの複数のインスタンスを同時にロードしようとすると、エンティティごとにユニークである必要があるGUIDが衝突するため、エラーが発生します。
@@ -193,7 +193,7 @@ this.app.scenes.loadSceneHierarchy(sceneItem, function (err, loadedSceneRootEnti
 下記の[サンプルプロジェクト][asset-load-for-scene-project]は、シーンのロード時にアセットをロードし、メインメニューに戻る際にアンロードするものです。
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/e/p/SBTfOAeM/" title="Loading scenes and assets"></iframe>
+    <iframe src="https://playcanv.as/e/p/SBTfOAeM/" title="Loading scenes and assets" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 [switch-scenes-completely-project]: https://playcanvas.com/project/924351/overview/switch-full-scene-example

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/templates/index.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/templates/index.md
@@ -6,7 +6,7 @@ sidebar_position: 12
 テンプレート(またはプレハブ)は再利用可能なエンティティを作成することにより、開発を迅速化することができます。シーン内に複数のテンプレートのインスタンスを配置することができ、Templateアセットに変更を加えてそれを適用すると、そのテンプレートのすべてのインスタンスが更新されます。
 
 <div className="iframe-container">
-    <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/2HV8Ib6wYRc" title="Templates Overview" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/2HV8Ib6wYRc" title="Templates Overview" allowfullscreen></iframe>
 </div>
 
 ## テンプレートの作成 {#creating-templates}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -15,7 +15,7 @@ function HomepageHeader() {
     <header className={clsx('hero hero--primary shadow-lg', styles.heroBanner)}>
       <div className="container">
         
-        <iframe src="https://ghbtns.com/github-btn.html?user=playcanvas&repo=engine&type=star&count=true&size=large" frameBorder="0" scrolling="0" width="170" height="30" title="PlayCanvas"></iframe>
+        <iframe src="https://ghbtns.com/github-btn.html?user=playcanvas&repo=engine&type=star&count=true&size=large" frameBorder="0" scrolling="0" width="170" height="30" title="PlayCanvas" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
         <Heading as="h1" className={clsx('hero__title', styles.heroTitle)}>
           <Translate id="homepage.title" description="The homepage title">
             {siteConfig.title}


### PR DESCRIPTION
This was preventing this iframed examle from entering AR:

https://developer.playcanvas.com/tutorials/webxr-ray-input/

I've also removed the `loading="lazy"` attribute too because 99.9% of iframes are at the top of the page.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/main/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
