### PR TITLE
Fixed link to WebXR AR: DOM Overlay tutorial project

### DIFF
--- a/docs/tutorials/webxr-ar-dom-overlay.md
+++ b/docs/tutorials/webxr-ar-dom-overlay.md
@@ -12,4 +12,4 @@ Example of how to use DOM (HTML + CSS) with WebXR AR session.
     <iframe src="https://playcanv.as/p/S01LYTIU/" title="WebXR AR: DOM Overlay" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
-<Link to='https://playcanvas.com/project/691979/'>Open Project ↗</Link>
+<Link to='https://playcanvas.com/project/747233/'>Open Project ↗</Link>


### PR DESCRIPTION
Fixes the project link to WebXR AR: DOM Overlay tutorial project

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/main/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
