### PR TITLE
New page for engine v1 to v2 migration

### DIFF
--- a/docs/user-manual/engine/migrations.md
+++ b/docs/user-manual/engine/migrations.md
@@ -1,3 +1,8 @@
+---
+title: Engine Migrations
+sidebar_position: 4
+---
+
 # Engine Migrations
 
 The PlayCanvas Engine is continually evolving, and its updates occasionally introduce breaking changes that require users to adapt their scripts.

--- a/docs/user-manual/engine/migrations.md
+++ b/docs/user-manual/engine/migrations.md
@@ -43,13 +43,12 @@ The engine previously executed multiple callbacks per frame for camera and layer
 
 #### StandardMaterial tint flags
 
-The tint options for StandardMaterial have been confusing and inconsistent, so we've removed the flags for Ambient, Diffuse, Specular and Emissive tint. Previously, these flags only affected certain cases, such as when a texture was applied. With this update, tint colors are now always applied. To disable tinting, set the color to a neutral value (the default tint colors used when creating a new material):
+The tint options for StandardMaterial have been confusing and inconsistent, so we've removed the flags for Ambient, Diffuse and Emissive tint. Previously, these flags only affected certain cases, such as when a texture was applied. With this update, tint colors are now always applied. To disable tinting, set the color to a neutral value (the default tint colors used when creating a new material):
 
 Here is the list of default colors per tint type:
 
 * **Ambient**: `new Color(1, 1, 1)` (white)
 * **Diffuse**: `new Color(1, 1, 1)` (white)
-* **Specular**: `new Color(0, 0, 0)` (black)
 * **Emissive**: `new Color(0, 0, 0)` (black)
 
 There is one somewhat confusing behavior to note. By default, the emissive tint is set to black to ensure the material doesn't emit any color. When you assign an emissive texture, it's important to set the emissive color to white; otherwise, the black tint will override the emissive contribution from the texture, resulting in no visible emission.

--- a/docs/user-manual/engine/migrations.md
+++ b/docs/user-manual/engine/migrations.md
@@ -1,0 +1,98 @@
+# Engine Migrations
+
+
+# Introduction
+
+The PlayCanvas Engine is continually evolving, and its updates occasionally introduce breaking changes that require users to adapt their scripts.
+
+This guide provides an overview of all major breaking changes across releases, offering users a helpful resource for migrating their code to newer versions.
+
+
+# Migration from 1.75.0 to 2.3.0
+
+The migration from major version 1 to major version 2 is a substantial update, introducing numerous breaking changes.
+
+
+## Breaking changes
+
+
+### WebGL 1
+
+Support for WebGL1 has been discontinued; the engine now exclusively supports WebGL2 and WebGPU (in beta). If your application relies on WebGL1, you will need to continue using version 1 of the engine.
+
+
+### AudioSourceComponent
+
+The AudioSourceComponent, which was replaced by the SoundComponent some time ago, has now been completely removed.
+
+
+### Legacy Scripts
+
+The legacy scripting system, deprecated since 2016 and maintained in a read-only state for several years, is now being removed entirely.
+
+
+### Deprecated functions
+
+Numerous deprecated functions that provided backward compatibility have been removed. If your application displays deprecation warnings when using the debug version of Engine 1, these issues should be resolved before migrating to Engine 2. In Engine 2, deprecated warnings are no longer displayed, and the backward compatibility code has been eliminated.
+
+
+### Basic Material
+
+The BasicMaterial has been removed. To achieve equivalent functionality, you can use a StandardMaterial with the emissive color or emissive map set as a replacement.
+
+
+### Rendering to a texture
+
+When rendering to a texture, the deprecated method of configuring the RenderTarget on the Layer has been fully removed. The RenderTarget must now be set directly on the camera instead.
+
+
+### Engine rendering callbacks
+
+The engine previously executed multiple callbacks per frame for camera and layer rendering. These have been replaced with an event-driven system that supports multiple subscribers. The new events are now emitted by the Scene class. For more details, refer to[ this pull request](https://github.com/playcanvas/engine/pull/7156).
+
+
+### StandardMaterial tint flags
+
+The tint options for StandardMaterial have been confusing and inconsistent, so we've removed the flags for Ambient, Diffuse, Specular and Emissive tint. Previously, these flags only affected certain cases, such as when a texture was applied. With this update, tint colors are now always applied. To disable tinting, set the color to a neutral value (the default tint colors used when creating a new material):
+
+Here is the list of default colors per tint type:
+
+
+
+* **Ambient**: `new Color(1, 1, 1)` (white)
+* **Diffuse**: `new Color(1, 1, 1)` (white)
+* **Specular**: `new Color(0, 0, 0)` (black)
+* **Emissive**: `new Color(0, 0, 0)` (black)
+
+There is one somewhat confusing behavior to note. By default, the emissive tint is set to black to ensure the material doesn't emit any color. When you assign an emissive texture, it's important to set the emissive color to white; otherwise, the black tint will override the emissive contribution from the texture, resulting in no visible emission.
+
+
+### Gamma-correction, tone-mapping and fog settings
+
+Previously, the `gammaCorrection` and `toneMapping` settings were applied globally on the `Scene` and affected all cameras' rendering. Now, these settings are available directly on each camera, allowing for unique configurations and rendering for each individual camera.
+
+Previously, fog settings were accessed directly on the `Scene`, such as `Scene.fog`, `Scene.fogColor`, and `Scene.fogEnd`. These settings have now been moved under the `Scene.fog` property, and can be set using `Scene.fog.type`, `Scene.fog.color`, `Scene.fog.end`, and similar properties.
+
+For more details, refer to[ this pull request](https://github.com/playcanvas/engine/pull/7101).
+
+
+### Gamma space textures
+
+Textures that represent colors, such as Diffuse, Emissive, Specular, and Sheen, are typically stored in sRGB space to maintain color range and reduce banding. When used by the engine, these textures are converted from sRGB to linear space for accurate lighting calculations. Previously, this conversion was handled by shader math, which impacted performance. With the removal of WebGL1 support, we can now leverage hardware to perform this conversion efficiently at no extra cost. The only requirement is that the texture must be created using sRGB format:
+
+
+
+* When loading a Texture asset that represents colors in sRGB space, it's important to specify an sRGB encoding. For details, see[ this pull request](https://github.com/playcanvas/engine/pull/6739).
+* When creating a Texture instance that represents color in sRGB space, it is essential to use an sRGB pixel format, such as `PIXELFORMAT_SRGBA8`.
+
+
+## Other changes
+
+For detailed information on the changes, refer to the release notes for each individual engine version:
+
+
+
+* [2.0.0](https://github.com/playcanvas/engine/releases/tag/v2.0.0)
+* [2.1.0](https://github.com/playcanvas/engine/releases/tag/v2.1.0)
+* [2.2.0](https://github.com/playcanvas/engine/releases/tag/v2.2.0)
+* [2.3.0](https://github.com/playcanvas/engine/releases/tag/v2.3.0)

--- a/docs/user-manual/engine/migrations.md
+++ b/docs/user-manual/engine/migrations.md
@@ -3,8 +3,6 @@ title: Engine Migrations
 sidebar_position: 4
 ---
 
-# Engine Migrations
-
 The PlayCanvas Engine is continually evolving, and its updates occasionally introduce breaking changes that require users to adapt their scripts.
 
 This guide provides an overview of all major breaking changes across releases, offering users a helpful resource for migrating their code to newer versions.

--- a/docs/user-manual/engine/migrations.md
+++ b/docs/user-manual/engine/migrations.md
@@ -1,63 +1,48 @@
 # Engine Migrations
 
-
-# Introduction
-
 The PlayCanvas Engine is continually evolving, and its updates occasionally introduce breaking changes that require users to adapt their scripts.
 
 This guide provides an overview of all major breaking changes across releases, offering users a helpful resource for migrating their code to newer versions.
 
-
-# Migration from 1.75.0 to 2.3.0
+## Migration from 1.75.0 to 2.3.0
 
 The migration from major version 1 to major version 2 is a substantial update, introducing numerous breaking changes.
 
+### Breaking changes
 
-## Breaking changes
-
-
-### WebGL 1
+#### WebGL 1
 
 Support for WebGL1 has been discontinued; the engine now exclusively supports WebGL2 and WebGPU (in beta). If your application relies on WebGL1, you will need to continue using version 1 of the engine.
 
-
-### AudioSourceComponent
+#### AudioSourceComponent
 
 The AudioSourceComponent, which was replaced by the SoundComponent some time ago, has now been completely removed.
 
-
-### Legacy Scripts
+#### Legacy Scripts
 
 The legacy scripting system, deprecated since 2016 and maintained in a read-only state for several years, is now being removed entirely.
 
-
-### Deprecated functions
+#### Deprecated functions
 
 Numerous deprecated functions that provided backward compatibility have been removed. If your application displays deprecation warnings when using the debug version of Engine 1, these issues should be resolved before migrating to Engine 2. In Engine 2, deprecated warnings are no longer displayed, and the backward compatibility code has been eliminated.
 
-
-### Basic Material
+#### Basic Material
 
 The BasicMaterial has been removed. To achieve equivalent functionality, you can use a StandardMaterial with the emissive color or emissive map set as a replacement.
 
-
-### Rendering to a texture
+#### Rendering to a texture
 
 When rendering to a texture, the deprecated method of configuring the RenderTarget on the Layer has been fully removed. The RenderTarget must now be set directly on the camera instead.
 
+#### Engine rendering callbacks
 
-### Engine rendering callbacks
+The engine previously executed multiple callbacks per frame for camera and layer rendering. These have been replaced with an event-driven system that supports multiple subscribers. The new events are now emitted by the Scene class. For more details, refer to [this pull request](https://github.com/playcanvas/engine/pull/7156).
 
-The engine previously executed multiple callbacks per frame for camera and layer rendering. These have been replaced with an event-driven system that supports multiple subscribers. The new events are now emitted by the Scene class. For more details, refer to[ this pull request](https://github.com/playcanvas/engine/pull/7156).
-
-
-### StandardMaterial tint flags
+#### StandardMaterial tint flags
 
 The tint options for StandardMaterial have been confusing and inconsistent, so we've removed the flags for Ambient, Diffuse, Specular and Emissive tint. Previously, these flags only affected certain cases, such as when a texture was applied. With this update, tint colors are now always applied. To disable tinting, set the color to a neutral value (the default tint colors used when creating a new material):
 
 Here is the list of default colors per tint type:
-
-
 
 * **Ambient**: `new Color(1, 1, 1)` (white)
 * **Diffuse**: `new Color(1, 1, 1)` (white)
@@ -66,31 +51,24 @@ Here is the list of default colors per tint type:
 
 There is one somewhat confusing behavior to note. By default, the emissive tint is set to black to ensure the material doesn't emit any color. When you assign an emissive texture, it's important to set the emissive color to white; otherwise, the black tint will override the emissive contribution from the texture, resulting in no visible emission.
 
-
-### Gamma-correction, tone-mapping and fog settings
+#### Gamma-correction, tone-mapping and fog settings
 
 Previously, the `gammaCorrection` and `toneMapping` settings were applied globally on the `Scene` and affected all cameras' rendering. Now, these settings are available directly on each camera, allowing for unique configurations and rendering for each individual camera.
 
 Previously, fog settings were accessed directly on the `Scene`, such as `Scene.fog`, `Scene.fogColor`, and `Scene.fogEnd`. These settings have now been moved under the `Scene.fog` property, and can be set using `Scene.fog.type`, `Scene.fog.color`, `Scene.fog.end`, and similar properties.
 
-For more details, refer to[ this pull request](https://github.com/playcanvas/engine/pull/7101).
+For more details, refer to [this pull request](https://github.com/playcanvas/engine/pull/7101).
 
-
-### Gamma space textures
+#### Gamma space textures
 
 Textures that represent colors, such as Diffuse, Emissive, Specular, and Sheen, are typically stored in sRGB space to maintain color range and reduce banding. When used by the engine, these textures are converted from sRGB to linear space for accurate lighting calculations. Previously, this conversion was handled by shader math, which impacted performance. With the removal of WebGL1 support, we can now leverage hardware to perform this conversion efficiently at no extra cost. The only requirement is that the texture must be created using sRGB format:
 
-
-
-* When loading a Texture asset that represents colors in sRGB space, it's important to specify an sRGB encoding. For details, see[ this pull request](https://github.com/playcanvas/engine/pull/6739).
+* When loading a Texture asset that represents colors in sRGB space, it's important to specify an sRGB encoding. For details, see [this pull request](https://github.com/playcanvas/engine/pull/6739).
 * When creating a Texture instance that represents color in sRGB space, it is essential to use an sRGB pixel format, such as `PIXELFORMAT_SRGBA8`.
 
-
-## Other changes
+### Other changes
 
 For detailed information on the changes, refer to the release notes for each individual engine version:
-
-
 
 * [2.0.0](https://github.com/playcanvas/engine/releases/tag/v2.0.0)
 * [2.1.0](https://github.com/playcanvas/engine/releases/tag/v2.1.0)

--- a/docs/user-manual/engine/migrations.md
+++ b/docs/user-manual/engine/migrations.md
@@ -4,7 +4,7 @@ The PlayCanvas Engine is continually evolving, and its updates occasionally intr
 
 This guide provides an overview of all major breaking changes across releases, offering users a helpful resource for migrating their code to newer versions.
 
-## Migration from 1.75.0 to 2.3.0
+## Migration from 1.75.0 to 2.4.0
 
 The migration from major version 1 to major version 2 is a substantial update, introducing numerous breaking changes.
 
@@ -74,3 +74,4 @@ For detailed information on the changes, refer to the release notes for each ind
 * [2.1.0](https://github.com/playcanvas/engine/releases/tag/v2.1.0)
 * [2.2.0](https://github.com/playcanvas/engine/releases/tag/v2.2.0)
 * [2.3.0](https://github.com/playcanvas/engine/releases/tag/v2.3.0)
+* [2.4.0](https://github.com/playcanvas/engine/releases/tag/v2.4.0)


### PR DESCRIPTION

<img width="277" alt="Screenshot 2025-01-14 at 16 54 13" src="https://github.com/user-attachments/assets/4c5d55f3-76a1-4a0c-8c49-32f170aeb342" />


<img width="972" alt="Screenshot 2025-01-14 at 16 40 26" src="https://github.com/user-attachments/assets/7c89bf89-1bad-4ab4-8edc-49ac9abda28f" />
<img width="981" alt="Screenshot 2025-01-14 at 16 40 37" src="https://github.com/user-attachments/assets/fc805918-49ee-4118-9f8f-f342cb357add" />
<img width="975" alt="Screenshot 2025-01-14 at 16 40 47" src="https://github.com/user-attachments/assets/2fd1a2cc-940c-4c45-9c70-8f27664124f0" />
