### PR TITLE
Add docs for pc-model tag

### DIFF
--- a/docs/user-manual/engine/web-components/tags/pc-entity.md
+++ b/docs/user-manual/engine/web-components/tags/pc-entity.md
@@ -21,6 +21,18 @@ The `<pc-entity>` tag is used to define an entity.
 | `scale` | The scale of the entity. Specified as a space-separated list of X, Y, and Z values. If not specified, `1 1 1` is used. |
 | `tags` | A space-separated list of tags for the entity. |
 
+## Events
+
+Listen to these events using [`addEventListener()`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) or by assigning an event listener to the `oneventname` property of this interface.
+
+| Event | Description |
+| --- | --- |
+| `pointerdown` | Fired when a pointer is pressed down on the entity. |
+| `pointerenter` | Fired when a pointer enters the entity. |
+| `pointerleave` | Fired when a pointer leaves the entity. |
+| `pointermove` | Fired when a pointer is moved over the entity. |
+| `pointerup` | Fired when a pointer is released from the entity. |
+
 ## Example
 
 ```html

--- a/docs/user-manual/engine/web-components/tags/pc-model.md
+++ b/docs/user-manual/engine/web-components/tags/pc-model.md
@@ -1,0 +1,32 @@
+---
+title: <pc-model>
+---
+
+The `<pc-model>` tag is used to define an entity that instantiates a 3D model from a GLB file. It inherits from [`<pc-entity>`](../pc-entity).
+
+:::note
+
+* It must be a direct child of a [`<pc-scene>`](../pc-scene) or another [`<pc-entity>`](../pc-entity).
+
+:::
+
+## Attributes
+
+All attributes of [`<pc-entity>`](../pc-entity) are also available.
+
+| Attribute | Description |
+| --- | --- |
+| `asset` | A string that should match the `id` of a [`<pc-asset>`](../pc-asset) tag that has a type of `container`. |
+
+## Example
+
+```html
+<pc-asset id="car" src="assets/car.glb" preload></pc-asset>
+<pc-scene>
+    <pc-model asset="car"></pc-model>
+</pc-scene>
+```
+
+## JavaScript Interface
+
+You can programmatically create and manipulate `<pc-model>` elements using the [ModelElement API](https://api.playcanvas.com/classes/EngineWebComponents.ModelElement.html).

--- a/docs/user-manual/engine/web-components/xr.md
+++ b/docs/user-manual/engine/web-components/xr.md
@@ -22,7 +22,7 @@ Specify the following scripts using [`<pc-asset>`](../tags/pc-asset) elements:
 <pc-asset id="xr-navigation" src="/node_modules/playcanvas/scripts/esm/xr-navigation.mjs" preload></pc-asset>
 ```
 
-* [`xr-controllers.mjs`](https://github.com/playcanvas/engine/blob/main/scripts/esm/xr-controllers.mjs) - Dynamically downloads XR controller models (GLBs) for any detected XR controllers (including hands).
+* [`xr-controllers.mjs`](https://github.com/playcanvas/engine/blob/main/scripts/esm/xr-controllers.mjs) - Dynamically downloads and renders XR controller models (GLBs) for any detected XR controllers (including hands).
 * [`xr-navigation.mjs`](https://github.com/playcanvas/engine/blob/main/scripts/esm/xr-navigation.mjs) - Implements basic teleportation navigation (via point and select actions).
 
 ### Camera Setup


### PR DESCRIPTION
* Documents the `pc-model` tag.
* Documents `pc-entity` events.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/main/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
