### PR TITLE
Add PCUI Graph docs

### DIFF
--- a/docs/user-manual/pcui/api-reference.md
+++ b/docs/user-manual/pcui/api-reference.md
@@ -1,8 +1,0 @@
----
-title: API Reference
-sidebar_position: 2
----
-
-The API reference is a list of all of PCUI's class components and their properties. It is automatically generated from the source code.
-
-[Click here](https://api.playcanvas.com/modules/PCUI.html) to view the API reference.

--- a/docs/user-manual/pcui/data-binding/index.md
+++ b/docs/user-manual/pcui/data-binding/index.md
@@ -1,6 +1,6 @@
 ---
 title: Data Binding
-sidebar_position: 4
+sidebar_position: 3
 ---
 
 The PCUI library offers a data binding layer that can be used to synchronize data across multiple components. It offers two-way binding to a given observer object, so updates made in a component are reflected in the observer's data and distributed out to all other subscribed components.

--- a/docs/user-manual/pcui/examples/index.md
+++ b/docs/user-manual/pcui/examples/index.md
@@ -1,6 +1,6 @@
 ---
 title: Examples
-sidebar_position: 5
+sidebar_position: 4
 ---
 
 Here are some simple examples demonstrating the various PCUI elements:
@@ -8,3 +8,5 @@ Here are some simple examples demonstrating the various PCUI elements:
 <div className='iframe-container'>
     <iframe src="https://playcanvas.github.io/pcui/examples/"></iframe>
 </div>
+
+The source code for these examples can be found in the [PCUI GitHub repository](https://github.com/playcanvas/pcui/tree/main/examples).

--- a/docs/user-manual/pcui/getting-started.md
+++ b/docs/user-manual/pcui/getting-started.md
@@ -3,10 +3,14 @@ title: Getting Started
 sidebar_position: 1
 ---
 
-To add PCUI to your `package.json`, run the following in the project's directory:
+Before you begin, make sure you have [Node.js](https://nodejs.org/) 18 or later installed.
+
+## Installing from NPM
+
+PCUI is available as a package on [NPM](https://www.npmjs.com/package/@playcanvas/pcui). You can install it as follows:
 
 ```bash
-npm install --save-dev @playcanvas/pcui
+npm install @playcanvas/pcui --save-dev
 ```
 
 This will include the entire PCUI library in your project. The various parts of the library will be available to import from that package at the following locations:
@@ -15,7 +19,7 @@ This will include the entire PCUI library in your project. The various parts of 
 - ES Module Components: `@playcanvas/pcui`
 - React Components: `@playcanvas/pcui/react`
 
-You can then import the ES Module components into your own `.js` files and use them as follows:
+You can import the ES Module components into your own `.js` files and use them as follows:
 
 ```javascript
 import { Button } from '@playcanvas/pcui';
@@ -33,3 +37,7 @@ This will result in your first component being appended to your document body!
 <div className='iframe-container'>
     <iframe src="https://playcanvas.github.io/pcui/storybook/iframe?id=components-button--text&viewMode=story"></iframe>
 </div>
+
+## API Reference
+
+The [API reference](https://api.playcanvas.com/modules/PCUI.html) is a list of all of PCUI's class components and their properties. It is automatically generated from the source code.

--- a/docs/user-manual/pcui/index.md
+++ b/docs/user-manual/pcui/index.md
@@ -5,4 +5,11 @@ sidebar_position: 20.5
 
 ![PCUI splash](/img/user-manual/pcui/pcui-banner.jpg)
 
-This library enables the creation of reliable and visually pleasing user interfaces by providing fully styled components that you can use directly on your site. The components are useful in a wide range of use cases, from creating simple forms to building graphical user interfaces for complex web tools.
+PCUI stands for _PlayCanvas User Interface_. It is the front-end framework on which all PlayCanvas tools are built:
+
+* [PlayCanvas Editor](https://playcanvas.com/products/editor)
+* [SuperSplat](https://superspl.at/editor)
+* [Model Viewer](https://playcanvas.com/viewer)
+* [Texture Tool](https://playcanvas.com/texture-tool)
+
+PCUI is open source and available on [GitHub](https://github.com/playcanvas/pcui). As such, you can use it in your own projects. This guide shows you how!

--- a/docs/user-manual/pcui/pcui-graph/context-menus.md
+++ b/docs/user-manual/pcui/pcui-graph/context-menus.md
@@ -1,0 +1,67 @@
+---
+title: Context Menus
+sidebar_position: 2
+---
+
+It is possible to create context menus on your graph which display when right clicking various graph items. There are three types of context menus; background, node and edge. You can define a set of actions which will display in each of these menus and each action item in the menu will fire an action event when selected.
+
+The background context menu appears when you right click on any blank space in the canvas. This context menu is used to add new nodes to the graph. It can be created by adding a `contextMenuItems` array to the options object passed to the graph constructor:
+
+```javascript
+const graph = new Graph(schema, {
+    contextMenuItems: [
+        {
+            {
+                text: 'Add a hello node',
+                action: GRAPH.GRAPH_ACTIONS.ADD_NODE,
+                nodeType: NODE_KEYS.HELLO,
+                attributes: {
+                    name: 'New hello'
+                    'Editable boolean': true
+                }
+            },
+            {
+                text: 'Add a world node',
+                action: GRAPH.GRAPH_ACTIONS.ADD_NODE,
+                nodeType: NODE_KEYS.WORLD,
+                attributes: {
+                    name: 'New world'
+                    'Editable boolean': true
+                }
+            }
+        }
+    ]
+})
+```
+
+The text property defines the display text of the context menu item. The action property tells the graph that this context menu item should fire an `ADD_NODE` action when it is selected. The other properties define the type of node that will be created when this item is selected. The node type references one of the node keys defined in the graphs schema. The attributes object defines the initial values of any editable attributes that exist in that nodes schema. The name attribute will also show up in the header for the node.
+
+Context menus can also be added to nodes and edges by including contextMenu properties in their schemas as follows:
+
+```javascript
+const schema = {
+    edges: {
+        0: {
+            contextMenuItems: [
+                {
+                    text: 'Delete edge', // name of the context menu item
+                    action: Graph.GRAPH_ACTIONS.DELETE_EDGE // action to carry out when item is selected
+                }
+            ]
+        }
+    }
+};
+```
+
+Currently node context menus support two actions:
+
+``` javascript
+Graph.GRAPH_ACTIONS.DELTE_NODE // Delete the node associated with this context menu.
+Graph.GRAPH_ACTIONS.ADD_EDGE // Add an edge that starts from the node associated with this context menu, selecting another node will complete the edge connection. Selecting the background canvas will cancel adding an edge.
+```
+
+While edges support their own deletion by adding this action in their context menu:
+
+``` javascript
+Graph.GRAPH_ACTIONS.DELETE_EDGE // Delete the edge associated with this context menu.
+```

--- a/docs/user-manual/pcui/pcui-graph/events.md
+++ b/docs/user-manual/pcui/pcui-graph/events.md
@@ -1,0 +1,89 @@
+---
+title: Events
+sidebar_position: 3
+---
+
+After creating a graph, you can register a callback for various events. This is achieved using the graphs [on function](https://api.playcanvas.com/classes/PCUIGraph.Graph.html#on). The following events are supported:
+
+```javascript
+import Graph from '@playcanvas/pcui-graph';
+
+const schema = { ... };
+const graph = new Graph(schema);
+
+/*
+ * @event
+ * @param {object} args.node - The node that was added
+ */
+graph.on(Graph.GRAPH_ACTIONS.ADD_NODE, ({ node }) => { ... });
+
+/*
+ * @event
+ * @param {object} args.node - The node that was deleted
+ * @param {object} args.edgeData - The edges contained in the graph
+ * @param {object} args.edges - The edges that were removed when deleting this node
+ */
+graph.on(Graph.GRAPH_ACTIONS.DELETE_NODE, ({ node, edgeData, edges }) => { ... });
+
+/*
+ * @event
+ * @param {object} args.node - The node that was selected
+ * @param {object} args.prevItem - The previously selected item, either a node or an edge
+ */
+graph.on(Graph.GRAPH_ACTIONS.SELECT_NODE, ({ node, prevItem }) => { ... });
+
+/*
+ * @event
+ * @param {object} args.node - The node that was updated
+ * @param {object} args.nodeId - The node id of the node that was updated
+ */
+graph.on(Graph.GRAPH_ACTIONS.UPDATE_NODE_POSITION, ({ node, nodeId }) => { ... });
+
+/*
+ * @event
+ * @param {object} args.node - The node that was updated
+ * @param {object} args.attribute - The name of the attribute that was updated
+ * @param {object} args.attributeKey - The key of the attribute that was updated
+ */
+graph.on(Graph.GRAPH_ACTIONS.UPDATE_NODE_ATTRIBUTE, ({ node, attribute, attributeKey }) => { ... });
+
+/*
+ * @event
+ * @param {object} args.edge - The edge that was updated
+ * @param {object} args.edgeId - The id of the edge that was updated
+ */
+graph.on(Graph.GRAPH_ACTIONS.ADD_EDGE, ({ edge, edgeId }) => { ... });
+
+/*
+ * @event
+ * @param {object} args.edge - The edge that was updated
+ * @param {object} args.edgeId - The id of the edge that was updated
+ */
+graph.on(Graph.GRAPH_ACTIONS.DELETE_EDGE, ({ edge, edgeId }) => { ... });
+
+/*
+ * @event
+ * @param {object} args.edge - The edge that was selected
+ * @param {object} args.prevItem - The previously selected item, either a node or an edge
+ */
+graph.on(Graph.GRAPH_ACTIONS.SELECT_EDGE, ({ edge, prevItem }) => { ... });
+
+/*
+ * @event
+ * @param {object} args.prevItem - The previously selected item, either a node or an edge
+ */
+graph.on(Graph.GRAPH_ACTIONS.DESELECT_ITEM, ({ prevItem }) => { ... });
+
+/*
+ * @event
+ * @param {number} args.pos.x - The x position of the viewport in relation to the graph
+ * @param {number} args.pos.y - The y position of the viewport in relation to the graph
+ */
+graph.on(Graph.GRAPH_ACTIONS.UPDATE_TRANSLATE, ({ pos }) => { ... });
+
+/*
+ * @event
+ * param {number} args.scale - The current scale of the graph
+ */
+graph.on(Graph.GRAPH_ACTIONS.UPDATE_SCALE, ({ scale }) => { ... });
+```

--- a/docs/user-manual/pcui/pcui-graph/getting-started.md
+++ b/docs/user-manual/pcui/pcui-graph/getting-started.md
@@ -1,0 +1,43 @@
+---
+title: Getting Started
+sidebar_position: 1
+---
+
+## Installing from NPM
+
+PCUI Graph is available as a package on [NPM](https://www.npmjs.com/package/@playcanvas/pcui-graph). You can install it as follows:
+
+```bash
+npm install @playcanvas/pcui-graph --save-dev
+```
+
+:::note
+
+It is assumed you already have the `@playcanvas/pcui` package installed in your project.
+
+:::
+
+## Importing the Graph Component
+
+You can import the `Graph` component as follows:
+
+```javascript
+import { Graph } from '@playcanvas/pcui-graph';
+```
+
+## Creating a Graph
+
+Options can be passed to the `Graph` constructor as a JSON object which change the default behavior of the graph. You can do so as follows:
+
+```javascript
+const graph = new Graph(schema, {
+    readOnly: true,
+    initialData: { ... }
+});
+```
+
+You can see a full list of options [here](https://api.playcanvas.com/classes/PCUIGraph.Graph.html#constructor).
+
+## Examples
+
+Examples of PCUI Graph usage can be found in this [Storybook](https://playcanvas.github.io/pcui-graph/storybook/index.html).

--- a/docs/user-manual/pcui/pcui-graph/index.md
+++ b/docs/user-manual/pcui/pcui-graph/index.md
@@ -1,6 +1,6 @@
 ---
 title: PCUI Graph
-sidebar_position: 7
+sidebar_position: 5
 ---
 
 PCUI Graph is a graph visualization framework designed to help you build applications that can create and view node-based graphs in the browser. It was built as an extension of the PCUI library but now lives in its own repository.

--- a/docs/user-manual/pcui/pcui-graph/schema.md
+++ b/docs/user-manual/pcui/pcui-graph/schema.md
@@ -1,0 +1,131 @@
+---
+title: Schema
+sidebar_position: 4
+---
+
+The schema object is used to define what type of graph you will be initializing. More specifically, it defines which node your graph can contain and how those nodes can be connected together with edges.
+
+It should contain a set of nodes and edges which can be created in the graph. Each node and edge that is defined will need a unique number key which is used to reference that particular part of the schema. In the above example the single edge type defined references the two nodes contained in the schema when defining which node types it can connect. When creating large schemas, it can be useful to define these keys before creating the schema, so they can be easily referenced:
+
+```javascript
+const NODE_KEYS = {
+    HELLO: 0,
+    WORLD: 1
+};
+const EDGE_KEYS = {
+    HELLO_TO_WORLD: 0
+};
+
+const schema = {
+    nodes: {
+        [NODE_KEYS.HELLO]: {
+            name: 'Hello',
+            fill: 'red'
+        },
+        [NODE_KEYS.WORLD]: {
+            name: 'World',
+            fill: 'green'
+        }
+    },
+    edges: {
+        [EDGE_KEYS.HELLO_TO_WORLD]: {
+            from: [NODE_KEYS.HELLO], // this edge can connect nodes of type NODE_KEYS.HELLO
+            to: [NODE_KEYS.WORLD] // to nodes of type NODE_KEYS.WORLD,
+            stroke: 'blue'
+        }
+    }
+};
+```
+
+The schemas above are used to created directed graphs, as they define edges which contain `from` and `to` attributes. These attributes tell an edge which nodes they can connect, creating a directed edge from one node to another.
+
+When creating visual programming graphs, nodes are not connected directly. Instead, they contain input and output ports which can be connected together. This will need to be expressed in the schema you create. To achieve this, you can add `inPorts` and `outPorts` attributes to your nodes in the schema. These will define a set of ports which will be created on a given node, specifying which edges can connect those ports.
+
+The schema defined above can be reworked to support port connections as follows:
+
+```javascript
+const NODE_KEYS = {
+    HELLO: 0,
+    WORLD: 1
+};
+const EDGE_KEYS = {
+    HELLO_TO_WORLD: 0
+};
+
+const schema = {
+    nodes: {
+        [NODE_KEYS.HELLO]: {
+            name: 'Hello',
+            fill: 'red',
+            outPorts: [
+                {
+                    name: 'output',
+                    type: EDGE_KEYS.HELLO_TO_WORLD
+                }
+            ]
+        },
+        [NODE_KEYS.WORLD]: {
+            name: 'World',
+            fill: 'green',
+            inPorts: [
+                {
+                    name: 'input',
+                    type: EDGE_KEYS.HELLO_TO_WORLD
+                }
+            ]
+        }
+    },
+    edges: {
+        [EDGE_KEYS.HELLO_TO_WORLD]: {
+            stroke: 'blue'
+        }
+    }
+};
+```
+
+You can see that created ports have a type which defines the edge type each port accepts. Only input and output ports of the same type can be connected together in the graph. Ports also contain a name which will appear next to the port in the graph.
+
+Nodes can also contain editable attributes, which will show up as input fields within them. These attributes can be set in a node as follows:
+
+```javascript
+const schema = {
+    nodes: {
+        0: {
+            name: 'Foobar',
+            attributes: [
+                {
+                    name: 'Editable boolean',
+                    type: 'BOOLEAN_INPUT'
+                },
+                {
+                    name: 'Editable text',
+                    type: 'TEXT_INPUT'
+                },
+                {
+                    name: 'Editable number',
+                    type: 'NUMERIC_INPUT'
+                },
+                {
+                    name: 'Editable 2D vector',
+                    type: 'VEC2_INPUT'
+                },
+                {
+                    name: 'Editable 3D vector',
+                    type: 'VEC3_INPUT'
+                },
+                {
+                    name: 'Editable 4D vector',
+                    type: 'VEC4_INPUT'
+                }
+            ]
+        }
+    }
+};
+```
+
+Editable attributes for a given node type must have unique names as they are stored in the graph data in a dictionary. When a node with an editable attribute is created, it can be accessed via the graph data as follows:
+
+```javascript
+const selectedItemId = graph.selectedItem.id;
+const currentBooleanValue = graph.data.nodes[selectedItemId].attributes['Editable boolean'].value;
+```

--- a/docs/user-manual/pcui/pcui-graph/styling.md
+++ b/docs/user-manual/pcui/pcui-graph/styling.md
@@ -1,0 +1,42 @@
+---
+title: Styling
+sidebar_position: 5
+---
+
+You can style your graph by overriding it's default style properties. This can be achieved by modifying the defaultStyles passed in as part of an options object to the graph constructor.
+
+```javascript
+const graph = new Graph(schema, {
+    defaultStyles: {
+        background: {
+            color: 'black'
+        }
+    }
+})
+```
+
+The defaultStyles object contains styling options for the graphs background as well as node and edge styles. A full list of these overridable properties can be see [here](https://github.com/playcanvas/pcui-graph/blob/main/src/constants.js).
+
+If you'd like to update the styling of particular node / edge types, you can override any of the node or edge properties given in the defaultStyles object by defining them in the schema for a particular node or edge as follows:
+
+```javascript
+const schema = {
+    nodes: {
+        0: {
+            name: 'standard node'
+        },
+        1: {
+            name: 'red node'
+            fill: 'red' // Update the background color of any nodes of this type to red
+        },
+    }
+};
+
+const graph = new Graph(schema, {
+    defaultStyles: {
+        node: {
+            fill: 'grey' // All other node types will have a grey background
+        }
+    }
+})
+```

--- a/docs/user-manual/pcui/react.md
+++ b/docs/user-manual/pcui/react.md
@@ -1,9 +1,9 @@
 ---
 title: React
-sidebar_position: 3
+sidebar_position: 2
 ---
 
-If you are more familiar with React, you can import React elements into your own `.jsx` files and use them as follows:
+PCUI components can be used directly in React applications. Import the components from the React package and use them in your `.jsx` files as follows:
 
 ```jsx
 import * as React from 'react';
@@ -17,10 +17,19 @@ ReactDOM.render(
 );
 ```
 
-This will render a single text input to the document's body element. You can see the result of this rendered component below:
+This example renders a basic text input component. You can see it in action below:
 
 <div className='iframe-container'>
     <iframe src="https://playcanvas.github.io/pcui/storybook/iframe?id=components-textinput--main&viewMode=story"></iframe>
 </div>
 
-For more extensive examples, see the [examples](../examples) section.
+For more complex implementations, check out the [examples](../examples) section.
+
+## Storybook
+
+The [PCUI Storybook](https://playcanvas.github.io/pcui/storybook/) provides an interactive showcase of all available components. You can:
+
+- Explore each component's properties and behavior
+- Test different configurations in real-time
+- View component documentation
+- Copy example code

--- a/docs/user-manual/pcui/storybook.md
+++ b/docs/user-manual/pcui/storybook.md
@@ -1,8 +1,0 @@
----
-title: Storybook
-sidebar_position: 6
----
-
-The storybook showcases all of PCUI's components in a single app. Each component can be adjusted using its documented properties. Their behavior can then be tested each components canvas.
-
-[Click here](https://playcanvas.github.io/pcui/storybook/) to view the storybook.


### PR DESCRIPTION
Move PCUI Graph docs from its own GitHub Pages site to the Developer Site.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/main/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
