### PR TITLE
Updated chunk migration for engine 2.6

### DIFF
--- a/docs/user-manual/graphics/shader-chunk-migrations.md
+++ b/docs/user-manual/graphics/shader-chunk-migrations.md
@@ -30,6 +30,8 @@ The following tables break down the chunk changes by Engine release.
 
 ### *Engine v2.6*
 
+#### Internal engine chunks
+
 The following vertex shader chunks were removed and replaced by a single `litMainVS` chunk:
 
 - `endVS`
@@ -47,6 +49,17 @@ The following vertex shader chunks were removed and replaced by a single `litMai
 `outputAlphaOpaquePS` and `outputAlphaPremulPS` chunks were merged into `outputAlphaPS` chunk.
 
 `cubeMapProjectBoxPS` and `cubeMapProjectNonePS` chunks were merged into `cubeMapProjectPS` chunk.
+
+`envMultiplyPS` and `envConstPS` were merged into `envProcPS` chunk.
+
+`aoSpecOccSimplePS`, `aoSpecOccConstSimplePS`, `aoSpecOccPS` and `aoSpecOccConstPS` chunks were merged into `aoSpecOccPS` chunk.
+
+The following reflection related chunks had a slight change in how the texture decode function is provided. `$DECODE` is now `{reflectionDecode}` and `$DECODE_CUBEMAP` is now `{reflectionCubemapDecode}`. These chunks were affected:
+
+- `reflectionEnvPS`
+- `reflectionEnvHQPS`
+- `reflectionCubePS`
+- `reflectionSpherePS`
 
 ### *Engine v2.5*
 


### PR DESCRIPTION
<img width="1208" alt="Screenshot 2025-03-04 at 14 33 45" src="https://github.com/user-attachments/assets/1958cf87-48c9-4e1e-8da6-e7f06c0ade03" />
