### PR TITLE
docs: Improve documentation on API routes

### DIFF
--- a/docs/user-manual/api/app-download.md
+++ b/docs/user-manual/api/app-download.md
@@ -22,20 +22,20 @@ curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json
 
 ## Parameters
 
-| Name                    | Type       | Required | Default   | Description                                                                                                                                                           |
-| ----------------------- | ---------- | :------: | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `project_id`            | `number`   | ✔️        | —                | The id of the project.                                                                                                                                                |
-| `name`                  | `string`   | ✔️        | —                | The name of the app. Must be less than 1000 characters.                                                                                                               |
-| `scenes`                | `number[]` | ✔️        | —                | A list of scene ids to be included in the app. When you specify scenes then the first scene in the list will be used as the initial scene of the application.         |
-| `branch_id`             | `string`   |           | main             | The id of the branch. If no id is specified the main branch will be used.                                                                                             |
-| `description`           | `string`   |           | —                | The description of the app. Must be less than 10,000 characters.                                                                                                      |
-| `version`               | `string`   |           | —                | The version of the app. Can be a string up to 20 characters.                                                                                                          |
-| `release_notes`         | `string`   |           | —                | Release notes for the app. Can be a string up to 10,000 characters.                                                                                                   |
-| `scripts_concatenate`   | `boolean`  |           | false            | Set it to true if you want scripts to be concatenated.                                                                                                                |
-| `scripts_minify`        | `boolean`  |           | true             | Set it to true if you want scripts to be minified. Defaults to true.                                                                                                  |
-| `scripts_sourcemaps`    | `boolean`  |           | false            | Set it to true if you want script sourcemaps to be generated. Defaults to false.                                                                                      |
-| `optimize_scene_format` | `boolean`  |           | false            | Set it to true if you want scenes to be in an optimized format (see [Optimize Scene Format](/user-manual/optimization/optimizing-scene-format) for more information). |
-| `engine_version`        | `string`   |           | v1.x.x (Current) | Set it to a Engine version string ([full list of releases](https://github.com/playcanvas/engine/releases)) if a specific version is needed for the app. If you're using engine v2, you must override this value.              |
+| Name                    | Type       | Required | Default          | Description                                                                                                                                                           |
+| ----------------------- | ---------- | :------: | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `project_id`            | `number`   | ✔️       | —                | The id of the project.                                                                                                                                                |
+| `name`                  | `string`   | ✔️       | —                | The name of the app. Must be less than 1000 characters.                                                                                                               |
+| `scenes`                | `number[]` | ✔️       | —                | A list of scene ids to be included in the app. When you specify scenes then the first scene in the list will be used as the initial scene of the application.         |
+| `branch_id`             | `string`   |          | main             | The id of the branch. If no id is specified the main branch will be used.                                                                                             |
+| `description`           | `string`   |          | —                | The description of the app. Must be less than 10,000 characters.                                                                                                      |
+| `version`               | `string`   |          | —                | The version of the app. Can be a string up to 20 characters.                                                                                                          |
+| `release_notes`         | `string`   |          | —                | Release notes for the app. Can be a string up to 10,000 characters.                                                                                                   |
+| `scripts_concatenate`   | `boolean`  |          | false            | Set it to true if you want scripts to be concatenated.                                                                                                                |
+| `scripts_minify`        | `boolean`  |          | true             | Set it to true if you want scripts to be minified.                                                                                                                    |
+| `scripts_sourcemaps`    | `boolean`  |          | false            | Set it to true if you want script sourcemaps to be generated.                                                                                                         |
+| `optimize_scene_format` | `boolean`  |          | false            | Set it to true if you want scenes to be in an optimized format (see [Optimize Scene Format](/user-manual/optimization/optimizing-scene-format) for more information). |
+| `engine_version`        | `string`   |          | v1.x.x (Current) | Set it to a Engine version string ([full list of releases](https://github.com/playcanvas/engine/releases)) if a specific version is needed for the app. If you're using engine v2, you must override this value.              |
 
 ## Response Schema
 

--- a/docs/user-manual/api/app-download.md
+++ b/docs/user-manual/api/app-download.md
@@ -10,7 +10,9 @@ POST https://playcanvas.com/api/apps/download
 
 ## Description
 
-This will allow you to download an app which you can self host on your own server. The request will start an export job and the job details will be returned in the response. You can [poll the job by id][2] until its status is either 'complete' or 'error'. When the job is done, its data will contain a URL to download the exported app.
+This will allow you to download an app which you can self host on your own server. The request will start an export job and the job details will be returned in the response. You can [poll the job by id][2] until its status is either 'complete' or 'error'.
+
+When the job is complete, the data on ["Get job"][2] will contain a `data.download_url` string property to download the exported app.
 
 ## Example
 
@@ -20,20 +22,20 @@ curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json
 
 ## Parameters
 
-| Name                    | Type       | Required | Description                                                                                                                                                           |
-| ----------------------- | ---------- | :------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `project_id`            | `number`   | ✔️      | The id of the project.                                                                                                                                                |
-| `name`                  | `string`   | ✔️      | The name of the app. Must be less than 1000 characters.                                                                                                               |
-| `scenes`                | `number[]` | ✔️      | A list of scene ids to be included in the app. When you specify scenes then the first scene in the list will be used as the initial scene of the application.         |
-| `branch_id`             | `string`   |          | The id of the branch. If no id is specified the main branch will be used.                                                                                             |
-| `description`           | `string`   |          | The description of the app. Must be less than 10,000 characters.                                                                                                      |
-| `version`               | `string`   |          | The version of the app. Can be a string up to 20 characters.                                                                                                          |
-| `release_notes`         | `string`   |          | Release notes for the app. Can be a string up to 10,000 characters.                                                                                                   |
-| `scripts_concatenate`   | `boolean`  |          | Set it to true if you want scripts to be concatenated.                                                                                                                |
-| `scripts_minify`        | `boolean`  |          | Set it to true if you want scripts to be minified. Defaults to true.                                                                                                  |
-| `scripts_sourcemaps`    | `boolean`  |          | Set it to true if you want script sourcemaps to be generated. Defaults to false.                                                                                      |
-| `optimize_scene_format` | `boolean`  |          | Set it to true if you want scenes to be in an optimized format (see [Optimize Scene Format](/user-manual/optimization/optimizing-scene-format) for more information). |
-| `engine_version`        | `string`   |          | Set it to a Engine version string ([full list of releases](https://github.com/playcanvas/engine/releases)) if a specific version is needed for the app.               |
+| Name                    | Type       | Required | Default   | Description                                                                                                                                                           |
+| ----------------------- | ---------- | :------: | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ```project_id```            | ```number```   | ✔️        | —                | The id of the project.                                                                                                                                                |
+| ```name```                  | ```string```   | ✔️        | —                | The name of the app. Must be less than 1000 characters.                                                                                                               |
+| ```scenes```                | ```number[]``` | ✔️        | —                | A list of scene ids to be included in the app. When you specify scenes then the first scene in the list will be used as the initial scene of the application.         |
+| ```branch_id```             | ```string```   |           | main             | The id of the branch. If no id is specified the main branch will be used.                                                                                             |
+| ```description```           | ```string```   |           | —                | The description of the app. Must be less than 10,000 characters.                                                                                                      |
+| ```version```               | ```string```   |           | —                | The version of the app. Can be a string up to 20 characters.                                                                                                          |
+| ```release_notes```         | ```string```   |           | —                | Release notes for the app. Can be a string up to 10,000 characters.                                                                                                   |
+| ```scripts_concatenate```   | ```boolean```  |           | false            | Set it to true if you want scripts to be concatenated.                                                                                                                |
+| ```scripts_minify```        | ```boolean```  |           | true             | Set it to true if you want scripts to be minified. Defaults to true.                                                                                                  |
+| ```scripts_sourcemaps```    | ```boolean```  |           | false            | Set it to true if you want script sourcemaps to be generated. Defaults to false.                                                                                      |
+| ```optimize_scene_format``` | ```boolean```  |           | false            | Set it to true if you want scenes to be in an optimized format (see [Optimize Scene Format](/user-manual/optimization/optimizing-scene-format) for more information). |
+| ```engine_version```        | ```string```   |           | v1.x.x (Current) | Set it to a Engine version string ([full list of releases](https://github.com/playcanvas/engine/releases)) if a specific version is needed for the app.               |
 
 ## Response Schema
 

--- a/docs/user-manual/api/app-download.md
+++ b/docs/user-manual/api/app-download.md
@@ -35,7 +35,7 @@ curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json
 | ```scripts_minify```        | ```boolean```  |           | true             | Set it to true if you want scripts to be minified. Defaults to true.                                                                                                  |
 | ```scripts_sourcemaps```    | ```boolean```  |           | false            | Set it to true if you want script sourcemaps to be generated. Defaults to false.                                                                                      |
 | ```optimize_scene_format``` | ```boolean```  |           | false            | Set it to true if you want scenes to be in an optimized format (see [Optimize Scene Format](/user-manual/optimization/optimizing-scene-format) for more information). |
-| ```engine_version```        | ```string```   |           | v1.x.x (Current) | Set it to a Engine version string ([full list of releases](https://github.com/playcanvas/engine/releases)) if a specific version is needed for the app.               |
+| ```engine_version```        | ```string```   |           | v1.x.x (Current) | Set it to a Engine version string ([full list of releases](https://github.com/playcanvas/engine/releases)) if a specific version is needed for the app. If you're using engine v2, you must override this value.              |
 
 ## Response Schema
 

--- a/docs/user-manual/api/app-download.md
+++ b/docs/user-manual/api/app-download.md
@@ -22,20 +22,20 @@ curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json
 
 ## Parameters
 
-| Name                    | Type       | Required | Default          | Description                                                                                                                                                           |
-| ----------------------- | ---------- | :------: | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `project_id`            | `number`   | ✔️       | —                | The id of the project.                                                                                                                                                |
-| `name`                  | `string`   | ✔️       | —                | The name of the app. Must be less than 1000 characters.                                                                                                               |
-| `scenes`                | `number[]` | ✔️       | —                | A list of scene ids to be included in the app. When you specify scenes then the first scene in the list will be used as the initial scene of the application.         |
-| `branch_id`             | `string`   |          | main             | The id of the branch. If no id is specified the main branch will be used.                                                                                             |
-| `description`           | `string`   |          | —                | The description of the app. Must be less than 10,000 characters.                                                                                                      |
-| `version`               | `string`   |          | —                | The version of the app. Can be a string up to 20 characters.                                                                                                          |
-| `release_notes`         | `string`   |          | —                | Release notes for the app. Can be a string up to 10,000 characters.                                                                                                   |
-| `scripts_concatenate`   | `boolean`  |          | false            | Set it to true if you want scripts to be concatenated.                                                                                                                |
-| `scripts_minify`        | `boolean`  |          | true             | Set it to true if you want scripts to be minified.                                                                                                                    |
-| `scripts_sourcemaps`    | `boolean`  |          | false            | Set it to true if you want script sourcemaps to be generated.                                                                                                         |
-| `optimize_scene_format` | `boolean`  |          | false            | Set it to true if you want scenes to be in an optimized format (see [Optimize Scene Format](/user-manual/optimization/optimizing-scene-format) for more information). |
-| `engine_version`        | `string`   |          | v1.x.x (Current) | Set it to a Engine version string ([full list of releases](https://github.com/playcanvas/engine/releases)) if a specific version is needed for the app. If you're using engine v2, you must override this value.              |
+| Name                    | Type       | Required | Default           | Description                                                                                                                                                           |
+| ----------------------- | ---------- | :------: | :---------------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `project_id`            | `number`   | ✔️       | —                 | The id of the project.                                                                                                                                                |
+| `name`                  | `string`   | ✔️       | —                 | The name of the app. Must be less than 1000 characters.                                                                                                               |
+| `scenes`                | `number[]` | ✔️       | —                 | A list of scene ids to be included in the app. When you specify scenes then the first scene in the list will be used as the initial scene of the application.         |
+| `branch_id`             | `string`   |          | id of main branch | The id of the branch.                                                                                                                                                 |
+| `description`           | `string`   |          | —                 | The description of the app. Must be less than 10,000 characters.                                                                                                      |
+| `version`               | `string`   |          | —                 | The version of the app. Can be a string up to 20 characters.                                                                                                          |
+| `release_notes`         | `string`   |          | —                 | Release notes for the app. Can be a string up to 10,000 characters.                                                                                                   |
+| `scripts_concatenate`   | `boolean`  |          | `false`           | Set it to true if you want scripts to be concatenated.                                                                                                                |
+| `scripts_minify`        | `boolean`  |          | `true`            | Set it to true if you want scripts to be minified.                                                                                                                    |
+| `scripts_sourcemaps`    | `boolean`  |          | `false`           | Set it to true if you want script sourcemaps to be generated.                                                                                                         |
+| `optimize_scene_format` | `boolean`  |          | `false`           | Set it to true if you want scenes to be in an optimized format (see [Optimize Scene Format](/user-manual/optimization/optimizing-scene-format) for more information). |
+| `engine_version`        | `string`   |          | v1.x.x (Current)  | Set it to a Engine version string ([full list of releases](https://github.com/playcanvas/engine/releases)) if a specific version is needed for the app. If you're using engine v2, you must override this value.              |
 
 ## Response Schema
 

--- a/docs/user-manual/api/app-download.md
+++ b/docs/user-manual/api/app-download.md
@@ -16,7 +16,7 @@ When the job is complete, the data on ["Get job"][2] will contain a `data.downlo
 
 ## Example
 
-```none
+```bash
 curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json" -X POST -d '{"project_id": 9999999, "scenes": [9999999], "name": "My App"}' "https://playcanvas.com/api/apps/download"
 ```
 
@@ -24,18 +24,18 @@ curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json
 
 | Name                    | Type       | Required | Default   | Description                                                                                                                                                           |
 | ----------------------- | ---------- | :------: | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ```project_id```            | ```number```   | ✔️        | —                | The id of the project.                                                                                                                                                |
-| ```name```                  | ```string```   | ✔️        | —                | The name of the app. Must be less than 1000 characters.                                                                                                               |
-| ```scenes```                | ```number[]``` | ✔️        | —                | A list of scene ids to be included in the app. When you specify scenes then the first scene in the list will be used as the initial scene of the application.         |
-| ```branch_id```             | ```string```   |           | main             | The id of the branch. If no id is specified the main branch will be used.                                                                                             |
-| ```description```           | ```string```   |           | —                | The description of the app. Must be less than 10,000 characters.                                                                                                      |
-| ```version```               | ```string```   |           | —                | The version of the app. Can be a string up to 20 characters.                                                                                                          |
-| ```release_notes```         | ```string```   |           | —                | Release notes for the app. Can be a string up to 10,000 characters.                                                                                                   |
-| ```scripts_concatenate```   | ```boolean```  |           | false            | Set it to true if you want scripts to be concatenated.                                                                                                                |
-| ```scripts_minify```        | ```boolean```  |           | true             | Set it to true if you want scripts to be minified. Defaults to true.                                                                                                  |
-| ```scripts_sourcemaps```    | ```boolean```  |           | false            | Set it to true if you want script sourcemaps to be generated. Defaults to false.                                                                                      |
-| ```optimize_scene_format``` | ```boolean```  |           | false            | Set it to true if you want scenes to be in an optimized format (see [Optimize Scene Format](/user-manual/optimization/optimizing-scene-format) for more information). |
-| ```engine_version```        | ```string```   |           | v1.x.x (Current) | Set it to a Engine version string ([full list of releases](https://github.com/playcanvas/engine/releases)) if a specific version is needed for the app. If you're using engine v2, you must override this value.              |
+| `project_id`            | `number`   | ✔️        | —                | The id of the project.                                                                                                                                                |
+| `name`                  | `string`   | ✔️        | —                | The name of the app. Must be less than 1000 characters.                                                                                                               |
+| `scenes`                | `number[]` | ✔️        | —                | A list of scene ids to be included in the app. When you specify scenes then the first scene in the list will be used as the initial scene of the application.         |
+| `branch_id`             | `string`   |           | main             | The id of the branch. If no id is specified the main branch will be used.                                                                                             |
+| `description`           | `string`   |           | —                | The description of the app. Must be less than 10,000 characters.                                                                                                      |
+| `version`               | `string`   |           | —                | The version of the app. Can be a string up to 20 characters.                                                                                                          |
+| `release_notes`         | `string`   |           | —                | Release notes for the app. Can be a string up to 10,000 characters.                                                                                                   |
+| `scripts_concatenate`   | `boolean`  |           | false            | Set it to true if you want scripts to be concatenated.                                                                                                                |
+| `scripts_minify`        | `boolean`  |           | true             | Set it to true if you want scripts to be minified. Defaults to true.                                                                                                  |
+| `scripts_sourcemaps`    | `boolean`  |           | false            | Set it to true if you want script sourcemaps to be generated. Defaults to false.                                                                                      |
+| `optimize_scene_format` | `boolean`  |           | false            | Set it to true if you want scenes to be in an optimized format (see [Optimize Scene Format](/user-manual/optimization/optimizing-scene-format) for more information). |
+| `engine_version`        | `string`   |           | v1.x.x (Current) | Set it to a Engine version string ([full list of releases](https://github.com/playcanvas/engine/releases)) if a specific version is needed for the app. If you're using engine v2, you must override this value.              |
 
 ## Response Schema
 

--- a/docs/user-manual/api/app-get-primary.md
+++ b/docs/user-manual/api/app-get-primary.md
@@ -21,8 +21,8 @@ curl -H "Authorization: Bearer {accessToken}" https://playcanvas.com/api/project
 ## Parameters
 
 | Name        | Type       | Required | Default | Description            |
-| ----------- | ---------- | :------: | ------- | ---------------------- |
-| `projectId` | `number`   |   ✔️     |   —     | The id of the project. |
+| ----------- | ---------- | :------: | :-----: | ---------------------- |
+| `projectId` | `number`   | ✔️       | —       | The id of the project. |
 
 ## Response Schema
 

--- a/docs/user-manual/api/app-get-primary.md
+++ b/docs/user-manual/api/app-get-primary.md
@@ -14,15 +14,15 @@ Gets the Primary App of a Project.
 
 ## Example
 
-```none
+```bash
 curl -H "Authorization: Bearer {accessToken}" https://playcanvas.com/api/projects/{projectId}/app
 ```
 
 ## Parameters
 
-| Name        | Type     | Description            |
-| ----------- | -------- | ---------------------- |
-| `projectId` | `number` | The id of the project. |
+| Name        | Type       | Required | Default | Description            |
+| ----------- | ---------- | :------: | ------- | ---------------------- |
+| `projectId` | `number`   |   ✔️     |   —     | The id of the project. |
 
 ## Response Schema
 

--- a/docs/user-manual/api/app-get-project.md
+++ b/docs/user-manual/api/app-get-project.md
@@ -21,8 +21,8 @@ curl -H "Authorization: Bearer {accessToken}" https://playcanvas.com/api/project
 ## Parameters
 
 | Name        | Type       | Required | Default | Description            |
-| ----------- | ---------- | :------: | ------- | ---------------------- |
-| `projectId` | `number`   |   ✔️     |   —     | The id of the project. |
+| ----------- | ---------- | :------: | :-----: | ---------------------- |
+| `projectId` | `number`   | ✔️       | —       | The id of the project. |
 
 ## Response Schema
 

--- a/docs/user-manual/api/app-get-project.md
+++ b/docs/user-manual/api/app-get-project.md
@@ -14,15 +14,15 @@ Lists all the published Apps of a Project.
 
 ## Example
 
-```none
+```bash
 curl -H "Authorization: Bearer {accessToken}" https://playcanvas.com/api/projects/{projectId}/apps
 ```
 
 ## Parameters
 
-| Name        | Type     | Description            |
-| ----------- | -------- | ---------------------- |
-| `projectId` | `number` | The id of the project. |
+| Name        | Type       | Required | Default | Description            |
+| ----------- | ---------- | :------: | ------- | ---------------------- |
+| `projectId` | `number`   |   ✔️     |   —     | The id of the project. |
 
 ## Response Schema
 

--- a/docs/user-manual/api/app-get.md
+++ b/docs/user-manual/api/app-get.md
@@ -21,8 +21,8 @@ curl -H "Authorization: Bearer {accessToken}" https://playcanvas.com/api/apps/{i
 ## Parameters
 
 | Name   | Type       | Required | Default | Description        |
-| ------ | ---------- | :------: | ------- | ------------------ |
-| `id`   | `number`   |   ✔️     |   —     | The id of the app. |
+| ------ | ---------- | :------: | :-----: | ------------------ |
+| `id`   | `number`   | ✔️       | —       | The id of the app. |
 
 ## Response Schema
 

--- a/docs/user-manual/api/app-get.md
+++ b/docs/user-manual/api/app-get.md
@@ -14,15 +14,15 @@ Gets a published App by id.
 
 ## Example
 
-```none
+```bash
 curl -H "Authorization: Bearer {accessToken}" https://playcanvas.com/api/apps/{id}
 ```
 
 ## Parameters
 
-| Name | Type     | Description        |
-| ---- | -------- | ------------------ |
-| `id` | `number` | The id of the app. |
+| Name   | Type       | Required | Default | Description        |
+| ------ | ---------- | :------: | ------- | ------------------ |
+| `id`   | `number`   |   ✔️     |   —     | The id of the app. |
 
 ## Response Schema
 

--- a/docs/user-manual/api/asset-create.md
+++ b/docs/user-manual/api/asset-create.md
@@ -22,7 +22,7 @@ This endpoint currently only supports creating `script`, `html`, `css`, `text`, 
 
 ## Example
 
-```none
+```bash
 curl -H "Authorization: Bearer {accessToken}" -X POST -F 'name={name}' -F 'projectId={projectId}' -F 'parent={parent}' -F 'preload={preload}' -F 'pow2={pow2}' -F 'file=@./script.js' "https://playcanvas.com/api/assets"
 ```
 
@@ -59,15 +59,15 @@ Content-Type: application/javascript
 
 ## Parameters
 
-| Name        | Type      | Required | Description                                                                                                 |
-| ----------- | --------- | :------: | ----------------------------------------------------------------------------------------------------------- |
-| `name`      | `string`  | ✔️      | The name of the asset.                                                                                      |
-| `projectId` | `number`  | ✔️      | The id of the project.                                                                                      |
-| `branchId`  | `string`  | ✔️      | The id of the branch.                                                                                       |
-| `parent`    | `number`  |          | Parent asset's id.                                                                                          |
-| `preload`   | `boolean` |          | Preload the asset (true / false).                                                                           |
-| `file`      | `file`    |          | Data to store as the asset file.                                                                            |
-| `pow2`      | `boolean` |          | Only used for textures and defaults to false. Resize the texture to power of two dimensions (true / false). |
+| Name        | Type      | Required | Default | Description                                                                                                 |
+| ----------- | --------- | :------: | ------- | ----------------------------------------------------------------------------------------------------------- |
+| `name`      | `string`  |   ✔️     |   —     | The name of the asset.                                                                                      |
+| `projectId` | `number`  |   ✔️     |   —     | The id of the project.                                                                                      |
+| `branchId`  | `string`  |   ✔️     |   —     | The id of the branch.                                                                                       |
+| `parent`    | `number`  |          |   —     | Parent asset's id.                                                                                          |
+| `preload`   | `boolean` |          |   —     | Preload the asset (true / false).                                                                           |
+| `file`      | `file`    |          |   —     | Data to store as the asset file.                                                                            |
+| `pow2`      | `boolean` |          | false   | Only used for textures. Resize the texture to power of two dimensions (true / false).                       |
 
 ## Response Schema
 

--- a/docs/user-manual/api/asset-create.md
+++ b/docs/user-manual/api/asset-create.md
@@ -60,14 +60,14 @@ Content-Type: application/javascript
 ## Parameters
 
 | Name        | Type      | Required | Default | Description                                                                                                 |
-| ----------- | --------- | :------: | ------- | ----------------------------------------------------------------------------------------------------------- |
-| `name`      | `string`  |   ✔️     |   —     | The name of the asset.                                                                                      |
-| `projectId` | `number`  |   ✔️     |   —     | The id of the project.                                                                                      |
-| `branchId`  | `string`  |   ✔️     |   —     | The id of the branch.                                                                                       |
-| `parent`    | `number`  |          |   —     | Parent asset's id.                                                                                          |
-| `preload`   | `boolean` |          |   —     | Preload the asset (true / false).                                                                           |
-| `file`      | `file`    |          |   —     | Data to store as the asset file.                                                                            |
-| `pow2`      | `boolean` |          | false   | Only used for textures. Resize the texture to power of two dimensions (true / false).                       |
+| ----------- | --------- | :------: | :-----: | ----------------------------------------------------------------------------------------------------------- |
+| `name`      | `string`  | ✔️       | —       | The name of the asset.                                                                                      |
+| `projectId` | `number`  | ✔️       | —       | The id of the project.                                                                                      |
+| `branchId`  | `string`  | ✔️       | —       | The id of the branch.                                                                                       |
+| `parent`    | `number`  |          | —       | Parent asset's id.                                                                                          |
+| `preload`   | `boolean` |          | —       | Preload the asset (true / false).                                                                           |
+| `file`      | `file`    |          | —       | Data to store as the asset file.                                                                            |
+| `pow2`      | `boolean` |          | `false` | Only used for textures. Resize the texture to power of two dimensions (true / false).                       |
 
 ## Response Schema
 

--- a/docs/user-manual/api/asset-delete.md
+++ b/docs/user-manual/api/asset-delete.md
@@ -34,9 +34,9 @@ Authorization: Bearer {accessToken}
 ## Parameters
 
 | Name       | Type       | Required | Default | Description                                    |
-| ---------- | ---------- | :------: | ------- | ---------------------------------------------- |
-| `assetId`  | `number`   |   ✔️     |   —     | The id of the asset to delete.                 |
-| `branchId` | `string`   |   ✔️     |   —     | The id of the branch to delete the asset from. |
+| ---------- | ---------- | :------: | :-----: | ---------------------------------------------- |
+| `assetId`  | `number`   | ✔️       | —       | The id of the asset to delete.                 |
+| `branchId` | `string`   | ✔️       | —       | The id of the branch to delete the asset from. |
 
 ## Response Schema
 

--- a/docs/user-manual/api/asset-delete.md
+++ b/docs/user-manual/api/asset-delete.md
@@ -20,7 +20,7 @@ Deleting an asset is permanent and unrecoverable unless you have taken a checkpo
 
 ## Example
 
-```none
+```bash
 curl -H "Authorization: Bearer {accessToken}" -X DELETE "https://playcanvas.com/api/assets/{assetId}?branchId={branchId}"
 ```
 
@@ -33,10 +33,10 @@ Authorization: Bearer {accessToken}
 
 ## Parameters
 
-| Name       | Type     | Required | Description                                    |
-| ---------- | -------- | :------: | ---------------------------------------------- |
-| `assetId`  | `number` | ✔️      | The id of the asset to delete.                 |
-| `branchId` | `string` | ✔️      | The id of the branch to delete the asset from. |
+| Name       | Type       | Required | Default | Description                                    |
+| ---------- | ---------- | :------: | ------- | ---------------------------------------------- |
+| `assetId`  | `number`   |   ✔️     |   —     | The id of the asset to delete.                 |
+| `branchId` | `string`   |   ✔️     |   —     | The id of the branch to delete the asset from. |
 
 ## Response Schema
 

--- a/docs/user-manual/api/asset-file.md
+++ b/docs/user-manual/api/asset-file.md
@@ -28,10 +28,10 @@ Authorization: Bearer {accessToken}
 ## Parameters
 
 | Name        | Type       | Required | Default | Description                |
-| ----------- | ---------- | :------: | ------- | -------------------------- |
-| `assetId`   | `number`   |   ✔️     |   —     | The id of the asset.       |
-| `branchId`  | `string`   |   ✔️     |   —     | The id of the branch.      |
-| `filename`  | `string`   |   ✔️     |   —     | The filename of the asset. |
+| ----------- | ---------- | :------: | :-----: | -------------------------- |
+| `assetId`   | `number`   | ✔️       | —       | The id of the asset.       |
+| `branchId`  | `string`   | ✔️       | —       | The id of the branch.      |
+| `filename`  | `string`   | ✔️       | —       | The filename of the asset. |
 
 ## Response Schema
 

--- a/docs/user-manual/api/asset-file.md
+++ b/docs/user-manual/api/asset-file.md
@@ -14,7 +14,7 @@ Get the details of a single asset
 
 ## Example
 
-```none
+```bash
 curl -H "Authorization: Bearer {accessToken}" "https://playcanvas.com/api/assets/{assetId}/file/{filename}?branchId={branchId}"
 ```
 
@@ -27,11 +27,11 @@ Authorization: Bearer {accessToken}
 
 ## Parameters
 
-| Name       | Type     | Required | Description                |
-| ---------- | -------- | :------: | -------------------------- |
-| `assetId`  | `number` | ✔️      | The id of the asset.       |
-| `branchId` | `string` | ✔️      | The id of the branch.      |
-| `filename` | `string` | ✔️      | The filename of the asset. |
+| Name        | Type       | Required | Default | Description                |
+| ----------- | ---------- | :------: | ------- | -------------------------- |
+| `assetId`   | `number`   |   ✔️     |   —     | The id of the asset.       |
+| `branchId`  | `string`   |   ✔️     |   —     | The id of the branch.      |
+| `filename`  | `string`   |   ✔️     |   —     | The filename of the asset. |
 
 ## Response Schema
 

--- a/docs/user-manual/api/asset-get.md
+++ b/docs/user-manual/api/asset-get.md
@@ -14,7 +14,7 @@ Get the details of a single asset
 
 ## Example
 
-```none
+```bash
 curl -H "Authorization: Bearer {accessToken}" https://playcanvas.com/api/assets/{assetId}?branchId={branchId}
 ```
 
@@ -27,10 +27,10 @@ Authorization: Bearer {accessToken}
 
 ## Parameters
 
-| Name       | Type     | Required | Description           |
-| ---------- | -------- | :------: | --------------------- |
-| `assetId`  | `number` | ✔️      | The id of the asset.  |
-| `branchId` | `string` | ✔️      | The id of the branch. |
+| Name        | Type       | Required | Default | Description           |
+| ----------- | ---------- | :------: | ------- | --------------------- |
+| `assetId`   | `number`   |   ✔️     |   —     | The id of the asset.  |
+| `branchId`  | `string`   |   ✔️     |   —     | The id of the branch. |
 
 ## Response Schema
 

--- a/docs/user-manual/api/asset-get.md
+++ b/docs/user-manual/api/asset-get.md
@@ -28,9 +28,9 @@ Authorization: Bearer {accessToken}
 ## Parameters
 
 | Name        | Type       | Required | Default | Description           |
-| ----------- | ---------- | :------: | ------- | --------------------- |
-| `assetId`   | `number`   |   ✔️     |   —     | The id of the asset.  |
-| `branchId`  | `string`   |   ✔️     |   —     | The id of the branch. |
+| ----------- | ---------- | :------: | :-----: | --------------------- |
+| `assetId`   | `number`   | ✔️       | —       | The id of the asset.  |
+| `branchId`  | `string`   | ✔️       | —       | The id of the branch. |
 
 ## Response Schema
 

--- a/docs/user-manual/api/asset-list.md
+++ b/docs/user-manual/api/asset-list.md
@@ -14,7 +14,7 @@ Get the details of all assets in a project for a specific branch
 
 ## Example
 
-```none
+```bash
 curl -H "Authorization: Bearer {accessToken}" "https://playcanvas.com/api/projects/{projectId}/assets?branchId={branchId}&skip={number}&limit={number}"
 ```
 
@@ -27,12 +27,12 @@ Authorization: Bearer {accessToken}
 
 ## Parameters
 
-| Name        | Type       | Required | Description                                                                  |
-| ----------- | ---------- | :------: | ---------------------------------------------------------------------------- |
-| `projectId` | `number`   | ✔️      | The id of the project.                                                       |
-| `branchId`  | `string`   | ✔️      | The id of the branch.                                                        |
-| `skip`      | `number`   |          | Number of assets to skip before listing. Used for pagination. Defaults to 0. |
-| `limit`     | `number`   |          | Maximum number of assets to list. Defaults to 16. Maximum 100000.            |
+| Name        | Type       | Required | Default | Description                                                                  |
+| ----------- | ---------- | :------: | ------- | ---------------------------------------------------------------------------- |
+| `projectId` | `number`   |   ✔️     |   —     | The id of the project.                                                       |
+| `branchId`  | `string`   |   ✔️     |   —     | The id of the branch.                                                        |
+| `skip`      | `number`   |          |   0     | Number of assets to skip before listing. Used for pagination.                |
+| `limit`     | `number`   |          |  16     | Maximum number of assets to list. Maximum 100000.                            |
 
 ## Response Schema
 

--- a/docs/user-manual/api/asset-list.md
+++ b/docs/user-manual/api/asset-list.md
@@ -28,11 +28,11 @@ Authorization: Bearer {accessToken}
 ## Parameters
 
 | Name        | Type       | Required | Default | Description                                                                  |
-| ----------- | ---------- | :------: | ------- | ---------------------------------------------------------------------------- |
-| `projectId` | `number`   |   ✔️     |   —     | The id of the project.                                                       |
-| `branchId`  | `string`   |   ✔️     |   —     | The id of the branch.                                                        |
-| `skip`      | `number`   |          |   0     | Number of assets to skip before listing. Used for pagination.                |
-| `limit`     | `number`   |          |  16     | Maximum number of assets to list. Maximum 100000.                            |
+| ----------- | ---------- | :------: | :-----: | ---------------------------------------------------------------------------- |
+| `projectId` | `number`   | ✔️       | —       | The id of the project.                                                       |
+| `branchId`  | `string`   | ✔️       | —       | The id of the branch.                                                        |
+| `skip`      | `number`   |          | `0`     | Number of assets to skip before listing. Used for pagination.                |
+| `limit`     | `number`   |          | `16`    | Maximum number of assets to list. Maximum 100000.                            |
 
 ## Response Schema
 

--- a/docs/user-manual/api/asset-update.md
+++ b/docs/user-manual/api/asset-update.md
@@ -29,10 +29,10 @@ curl -H "Authorization: Bearer {accessToken}" -X PUT -F 'pow2={pow2}' -F 'file=@
 ## Parameters
 
 | Name        | Type       | Required | Default | Description                                                                                                 |
-| ----------- | ---------- | :------: | ------- | ----------------------------------------------------------------------------------------------------------- |
-| `assetId`  | `number`   |   ✔️     |   —      | The id of the asset.                                                                                        |
-| `file`     | `file`     |   ✔️     |   —      | Data to update asset file with.                                                                             |
-| `pow2`     | `boolean`  |          | false    | Only used for textures. Resize the texture to power of two dimensions (true / false).                       |
+| ----------- | ---------- | :------: | :-----: | ----------------------------------------------------------------------------------------------------------- |
+| `assetId`   | `number`   | ✔️       | —       | The id of the asset.                                                                                        |
+| `file`      | `file`     | ✔️       | —       | Data to update asset file with.                                                                             |
+| `pow2`      | `boolean`  |          | `false` | Only used for textures. Resize the texture to power of two dimensions (true / false).                       |
 
 ## Response Schema
 

--- a/docs/user-manual/api/asset-update.md
+++ b/docs/user-manual/api/asset-update.md
@@ -22,17 +22,17 @@ This endpoint currently only supports updating `script`, `html`, `css`, `text`, 
 
 ## Example
 
-```none
+```bash
 curl -H "Authorization: Bearer {accessToken}" -X PUT -F 'pow2={pow2}' -F 'file=@./script.js' "https://playcanvas.com/api/assets/{assetId}"
 ```
 
 ## Parameters
 
-| Name       | Type      | Required | Description                                                                                                 |
-| ---------- | --------- | :------: | ----------------------------------------------------------------------------------------------------------- |
-| `assetId`  | `number`  | ✔️      | The id of the asset.                                                                                        |
-| `file`     | `file`    | ✔️      | Data to update asset file with.                                                                             |
-| `pow2`     | `boolean` |          | Only used for textures and defaults to false. Resize the texture to power of two dimensions (true / false). |
+| Name        | Type       | Required | Default | Description                                                                                                 |
+| ----------- | ---------- | :------: | ------- | ----------------------------------------------------------------------------------------------------------- |
+| `assetId`  | `number`   |   ✔️     |   —      | The id of the asset.                                                                                        |
+| `file`     | `file`     |   ✔️     |   —      | Data to update asset file with.                                                                             |
+| `pow2`     | `boolean`  |          | false    | Only used for textures. Resize the texture to power of two dimensions (true / false).                       |
 
 ## Response Schema
 

--- a/docs/user-manual/api/branch-list.md
+++ b/docs/user-manual/api/branch-list.md
@@ -14,7 +14,7 @@ Get a list of all open branches for a project
 
 ## Example
 
-```none
+```bash
 curl -H "Authorization: Bearer {accessToken}" "https://playcanvas.com/api/projects/{projectId}/branches"
 ```
 
@@ -27,9 +27,9 @@ Authorization: Bearer {accessToken}
 
 ## Parameters
 
-| Name        | Type     | Description            |
-| ----------- | -------- | ---------------------- |
-| `projectId` | `number` | The id of the project. |
+| Name        | Type       | Required | Default | Description            |
+| ----------- | ---------- | :------: | ------- | ---------------------- |
+| `projectId` | `number`   |   ✔️     |   —     | The id of the project. |
 
 ## Response Schema
 

--- a/docs/user-manual/api/branch-list.md
+++ b/docs/user-manual/api/branch-list.md
@@ -28,8 +28,8 @@ Authorization: Bearer {accessToken}
 ## Parameters
 
 | Name        | Type       | Required | Default | Description            |
-| ----------- | ---------- | :------: | ------- | ---------------------- |
-| `projectId` | `number`   |   ✔️     |   —     | The id of the project. |
+| ----------- | ---------- | :------: | :-----: | ---------------------- |
+| `projectId` | `number`   | ✔️       | —       | The id of the project. |
 
 ## Response Schema
 

--- a/docs/user-manual/api/job-get.md
+++ b/docs/user-manual/api/job-get.md
@@ -14,15 +14,15 @@ Gets a Job by id.
 
 ## Example
 
-```none
+```bash
 curl -H "Authorization: Bearer {accessToken}" "https://playcanvas.com/api/jobs/{id}"
 ```
 
 ## Parameters
 
-| Name | Type     | Description        |
-| ---- | -------- | ------------------ |
-| `id` | `number` | The id of the job. |
+| Name   | Type       | Required | Default | Description        |
+| ------ | ---------- | :------: | ------- | ------------------ |
+| `id`   | `number`   |   ✔️     |   —     | The id of the job. |
 
 ## Response Schema
 

--- a/docs/user-manual/api/job-get.md
+++ b/docs/user-manual/api/job-get.md
@@ -21,8 +21,8 @@ curl -H "Authorization: Bearer {accessToken}" "https://playcanvas.com/api/jobs/{
 ## Parameters
 
 | Name   | Type       | Required | Default | Description        |
-| ------ | ---------- | :------: | ------- | ------------------ |
-| `id`   | `number`   |   ✔️     |   —     | The id of the job. |
+| ------ | ---------- | :------: | :-----: | ------------------ |
+| `id`   | `number`   | ✔️       | —       | The id of the job. |
 
 ## Response Schema
 

--- a/docs/user-manual/api/project-archive.md
+++ b/docs/user-manual/api/project-archive.md
@@ -22,10 +22,10 @@ curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json
 
 ## Parameters
 
-| Name         | Type       | Required | Default | Description                                                                |
-| ------------ | ---------- | :------: | ------- | -------------------------------------------------------------------------- |
-| `projectId`  | `number`   |   ✔️     |   —     | The id of the project.                                                     |
-| `branch_id`  | `string`   |          | main    | The id of the branch.                                                      |
+| Name         | Type       | Required | Default           | Description                                                                |
+| ------------ | ---------- | :------: | :---------------: | -------------------------------------------------------------------------- |
+| `projectId`  | `number`   | ✔️       | —                 | The id of the project.                                                     |
+| `branch_id`  | `string`   |          | id of main branch | The id of the branch.                                                      |
 
 ## Response Schema
 

--- a/docs/user-manual/api/project-archive.md
+++ b/docs/user-manual/api/project-archive.md
@@ -16,16 +16,16 @@ The request will start an archive job and the job details will be returned in th
 
 ## Example
 
-```none
+```bash
 curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json" -X POST -d '{"branch_id": "99999999-9999-9999-9999-999999999999"}' "https://playcanvas.com/api/projects/{projectId}/export"
 ```
 
 ## Parameters
 
-| Name        | Type     | Required | Description                                                                |
-| ----------- | -------- | :------: | -------------------------------------------------------------------------- |
-| `projectId` | `number` | ✔️      | The id of the project.                                                     |
-| `branch_id` | `string` |          | The id of the branch. If no id is specified, the main branch will be used. |
+| Name         | Type       | Required | Default | Description                                                                |
+| ------------ | ---------- | :------: | ------- | -------------------------------------------------------------------------- |
+| `projectId`  | `number`   |   ✔️     |   —     | The id of the project.                                                     |
+| `branch_id`  | `string`   |          | main    | The id of the branch.                                                      |
 
 ## Response Schema
 

--- a/docs/user-manual/api/scene-list.md
+++ b/docs/user-manual/api/scene-list.md
@@ -14,7 +14,7 @@ Get a list of all scenes for a project
 
 ## Example
 
-```none
+```bash
 curl -H "Authorization: Bearer {accessToken}" "https://playcanvas.com/api/projects/{projectId}/scenes?branchId={branchId}"
 ```
 
@@ -27,10 +27,10 @@ Authorization: Bearer {accessToken}
 
 ## Parameters
 
-| Name        | Type     | Required | Description                                                                |
-| ----------- | -------- | :------: | -------------------------------------------------------------------------- |
-| `projectId` | `number` | ✔️      | The id of the project.                                                     |
-| `branchId`  | `string` |          | The id of the branch. If no id is specified, the main branch will be used. |
+| Name         | Type       | Required | Default | Description                                                                |
+| ------------ | ---------- | :------: | ------- | -------------------------------------------------------------------------- |
+| `projectId`  | `number`   |   ✔️     |   —     | The id of the project.                                                     |
+| `branchId`   | `string`   |          | main    | The id of the branch.                                                      |
 
 ## Response Schema
 

--- a/docs/user-manual/api/scene-list.md
+++ b/docs/user-manual/api/scene-list.md
@@ -27,10 +27,10 @@ Authorization: Bearer {accessToken}
 
 ## Parameters
 
-| Name         | Type       | Required | Default | Description                                                                |
-| ------------ | ---------- | :------: | ------- | -------------------------------------------------------------------------- |
-| `projectId`  | `number`   |   ✔️     |   —     | The id of the project.                                                     |
-| `branchId`   | `string`   |          | main    | The id of the branch.                                                      |
+| Name         | Type       | Required | Default           | Description                                                                |
+| ------------ | ---------- | :------: | :---------------: | -------------------------------------------------------------------------- |
+| `projectId`  | `number`   | ✔️       | —                 | The id of the project.                                                     |
+| `branchId`   | `string`   |          | id of main branch | The id of the branch.                                                      |
 
 ## Response Schema
 


### PR DESCRIPTION
## Description

This PR addresses some difficulties I had working with the ["Download app"](https://developer.playcanvas.com/user-manual/api/app-download/) API:

- Default values of the API arguments wasn't always documented.
- The default value of "engine_version" is engine v1. This is confusing for anyone exporting from the editor on a v2 project where v2 is the default.
- The `download_url` property wasn't documented explicitly, this means you must test the API to learn what property name you need to get the download URL.

To address these challenges, the following was changed:

- A "Default" column was added to the table.
- `engine_version` both notes in the default column that it uses engine v1 and the description notes that engine v2 users must override the default.
- Added a note in the description to say what `data` property is needed to get the download path.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/main/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).

### Update

The other API route docs have been updated as well:

- Added a "default" column to all param tables
  - Descriptions were modified in places where stating the default value was redundant.
  - Inline code blocks were used to differentiate from explicit default values like `false` vs ones like "id of main branch" that cannot state the exact default value.
- Not all tables had a "required" column, so that was added on tables that didn't have one. 
  - This is needed because it's confusing to have have a "default" column without a "required" column.