### PR TITLE
Update Python self-hosting command to Python 3

### DIFF
--- a/docs/user-manual/publishing/web/self-hosting.md
+++ b/docs/user-manual/publishing/web/self-hosting.md
@@ -59,7 +59,7 @@ You cannot load your application by opening the `index.html` file in a browser o
 
 There are many options for running a web server. Here are a few:
 
-* *Easy:* Install [Python][6] and run the command *python -m SimpleHTTPServer* from the same folder as your application's index.html. Then point your browser to `http://localhost:8000`.
+* *Easy:* Install [Python][6] and run the command *python -m http.server* from the same folder as your application's index.html. Then point your browser to `http://localhost:8000`.
 * *Intermediate:* Install [NPM][10] and [http-server][11] globally. Run the command *http-server -p 8000 --cors -c-1* from the same folder as your application's index.html. Then point your browser to `http://localhost:8000`.
 * *Intermediate:* Install [XAMPP][7]. Although this is a full PHP development environment, it includes an easy to configure Apache server.
 * *Advanced:* Install [Apache][8] or [nginx][9] as a standalone service.


### PR DESCRIPTION
The SimpleHTTPServer module has been merged into http.server in Python 3.0. Although PR #466 allegedly fixed this issue, due to a merge commit, the fix was overwritten. Therefore, this PR updates Python's self-hosting command to comply with Python 3.

Fixes #464 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/main/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
