### PR TITLE
Add API documentation for 'Get project' and 'List projects' endpoints

### DIFF
--- a/docs/user-manual/api/project-get.md
+++ b/docs/user-manual/api/project-get.md
@@ -1,0 +1,86 @@
+---
+title: Projects - Get project
+---
+
+## Route URL
+
+```none
+GET https://playcanvas.com/api/projects/:projectId
+```
+
+## Description
+
+Get the details of a single project.
+
+## Example
+
+```bash
+curl -H "Authorization: Bearer {accessToken}" https://playcanvas.com/api/projects/{projectId}
+```
+
+## Parameters
+
+| Name        | Type     | Required | Default | Description            |
+| ----------- | -------- | :------: | :-----: | ---------------------- |
+| `projectId` | `number` |   ✔️     |   —     | The id of the project. |
+
+## Response Schema
+
+```none
+Status: 200
+```
+
+```json
+{
+  "id": int,
+  "name": string,
+  "description": string,
+  "created": date,
+  "modified": date,
+  "owner": string,
+  "owner_id": int,
+  "access_level": string,
+  "fork_count": int,
+  "locked": bool,
+  "new_owner": string|null,
+  "permissions": {
+    "admin": [string],
+    "write": [string],
+    "read": [string]
+  },
+  "plays": int,
+  "primary_app": int,
+  "primary_app_url": string,
+  "private": bool,
+  "size": {
+    "total": int,
+    "code": int,
+    "apps": int,
+    "assets": int,
+    "checkpoints": int
+  },
+  "starred": int,
+  "thumbnails": {
+    "s": string,
+    "m": string,
+    "l": string,
+    "xl": string
+  },
+  "views": int
+}
+```
+
+## Errors
+
+| Code | Description       |
+| ---- | ----------------- |
+| 401  | Unauthorized      |
+| 403  | Forbidden         |
+| 404  | Project not found |
+| 429  | Too many requests |
+
+## Rate Limiting
+
+This route uses a [normal][1] rate limit.
+
+[1]: /user-manual/api#rate-limiting

--- a/docs/user-manual/api/project-list.md
+++ b/docs/user-manual/api/project-list.md
@@ -1,0 +1,91 @@
+---
+title: Projects - List projects
+---
+
+## Route URL
+
+```none
+GET https://playcanvas.com/api/users/:userId/projects
+```
+
+## Description
+
+Lists all projects owned by a user.
+
+## Example
+
+```bash
+curl -H "Authorization: Bearer {accessToken}" https://playcanvas.com/api/users/{userId}/projects
+```
+
+## Parameters
+
+| Name      | Type     | Required | Default | Description             |
+| --------- | -------- | :------: | :-----: | ----------------------- |
+| `userId`  | `number` |   ✔️     |   —     | The id of the user.     |
+
+## Response Schema
+
+```none
+Status: 200
+```
+
+```json
+{
+  "result": [
+    {
+      "id": int,
+      "name": string,
+      "description": string,
+      "created": date,
+      "modified": date,
+      "owner": string,
+      "owner_id": int,
+      "access_level": string,
+      "fork_count": int,
+      "locked": bool,
+      "new_owner": string|null,
+      "permissions": {
+        "admin": [string],
+        "write": [string],
+        "read": [string]
+      },
+      "plays": int,
+      "primary_app": int,
+      "primary_app_url": string,
+      "private": bool,
+      "size": {
+        "total": int,
+        "code": int,
+        "apps": int,
+        "assets": int,
+        "checkpoints": int
+      },
+      "starred": int,
+      "thumbnails": {
+        "s": string,
+        "m": string,
+        "l": string,
+        "xl": string
+      },
+      "views": int
+    }
+    // ...more projects...
+  ]
+}
+```
+
+## Errors
+
+| Code | Description       |
+| ---- | ----------------- |
+| 401  | Unauthorized      |
+| 403  | Forbidden         |
+| 404  | User not found    |
+| 429  | Too many requests |
+
+## Rate Limiting
+
+This route uses a [normal][1] rate limit.
+
+[1]: /user-manual/api#rate-limiting

--- a/docs/user-manual/api/project-list.md
+++ b/docs/user-manual/api/project-list.md
@@ -10,7 +10,7 @@ GET https://playcanvas.com/api/users/:userId/projects
 
 ## Description
 
-Lists all projects owned by a user.
+Lists all projects that a user has access to.
 
 ## Example
 

--- a/docs/user-manual/api/project-list.md
+++ b/docs/user-manual/api/project-list.md
@@ -10,7 +10,7 @@ GET https://playcanvas.com/api/users/:userId/projects
 
 ## Description
 
-Lists all projects that a user has access to.
+Retrieve all projects to which the specified user has explicit access. Use it to enumerate every project where that user has either read, write or admin rights.
 
 ## Example
 


### PR DESCRIPTION
## Description

Adds REST API doc pages for "Get Project" and "List projects".

This is based off code that references these APIs in the `playcanvas/vscode-extension` project:

- Get project - https://github.com/playcanvas/vscode-extension/blob/d7b667d54b0399e0a52c770e31c0b41dbae9f906/src/api.js#L120-L124
- List projects - https://github.com/playcanvas/vscode-extension/blob/d7b667d54b0399e0a52c770e31c0b41dbae9f906/src/api.js#L114-L118

## Note to reviewer

One thing I'm not 100% sure about is what query params are available. I'm only aware of how it was used in the vscode-extension.

The errors and rate limiting sections are best guesses as well.

## Fixes

Fixes #736

## Misc

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/main/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).

_This code was written with the help of the following ai tools: Copilot_