### PR TITLE
Update asset types documentation to include additional asset types

### DIFF
--- a/docs/user-manual/assets/types/index.md
+++ b/docs/user-manual/assets/types/index.md
@@ -9,7 +9,7 @@ The [Assets Panel](/user-manual/editor/interface/assets) manages the assets in y
 | -------------------------------- | -------------------------------- | -------------------------------- | ---------------------------------- |
 | [`animation`](animation)         | `.glb`, `.fbx`                   | `.glb`                           | Animation keyframe data            |
 | [`audio`](audio)                 | `.mp3`, `.wav`, `.ogg`           | `.mp3`, `.wav`, `.ogg`           | Sound data                         |
-| `binary`                         | `.bin`, `.gltf`                  | `.bin`, `.gltf`                  | Binary data                        |
+| `binary`                         | `.bin`                           | `.bin`                           | Binary data                        |
 | `bundle`                         | `.tar`                           | `.tar`                           | Bundled assets                     |
 | [`css`](css)                     | `.css`                           | `.css`                           | Stylesheets for HTML               |
 | [`cubemap`](cubemap)             | `.png`, `.jpg`, `.webp`, `.avif` | `.png`, `.jpg`, `.webp`, `.avif` | Environment lighting data          |

--- a/docs/user-manual/assets/types/index.md
+++ b/docs/user-manual/assets/types/index.md
@@ -7,8 +7,10 @@ The [Assets Panel](/user-manual/editor/interface/assets) manages the assets in y
 
 | Type                             | Imported From                    | Resource Extensions              | Description                        |
 | -------------------------------- | -------------------------------- | -------------------------------- | ---------------------------------- |
-| [`animation`](animation)         | `.glb`, `.fbx`                   | `.glb`                           | Animation keyframe data            |
+| [`animation`](animation)         | `.glb`, `.fbx`, `.json`          | `.glb`, `.json`                  | Animation keyframe data            |
 | [`audio`](audio)                 | `.mp3`, `.wav`, `.ogg`           | `.mp3`, `.wav`, `.ogg`           | Sound data                         |
+| `binary`                         | `.bin`, `.gltf`                  | `.bin`, `.gltf`                  | Binary data                        |
+| `bundle`                         | `.tar`                           | `.tar`                           | Bundled assets                     |
 | [`css`](css)                     | `.css`                           | `.css`                           | Stylesheets for HTML               |
 | [`cubemap`](cubemap)             | `.png`, `.jpg`, `.webp`, `.avif` | `.png`, `.jpg`, `.webp`, `.avif` | Environment lighting data          |
 | [`font`](font)                   | `.ttf`, `.woff`                  | `.json`, `.png`                  | Font data for rendering text       |
@@ -17,6 +19,7 @@ The [Assets Panel](/user-manual/editor/interface/assets) manages the assets in y
 | [`json`](json)                   | `.json`                          | `.json`                          | JSON documents                     |
 | [`material`](material)           | `.glb`, `.fbx`                   | None                             | Material definitions for 3D models |
 | [`render`](render)               | `.glb`, `.fbx`                   | `.glb`                           | 3D mesh data                       |
+| `script`                         | `.js`, `.mjs`, `.ts`             | `.js`, `.mjs`, `.ts`             | Scripts                            |
 | [`shader`](shader)               | `.glsl`, `.vert`, `.frag`        | `.glsl`, `.vert`, `.frag`        | Custom shaders for rendering       |
 | [`sprite`](sprite)               | Created in the Editor            | None                             | 2D images for UIs or textures      |
 | [`template`](template)           | `.glb`                           | None                             | Templates for entity hierarchy     |

--- a/docs/user-manual/assets/types/index.md
+++ b/docs/user-manual/assets/types/index.md
@@ -19,7 +19,7 @@ The [Assets Panel](/user-manual/editor/interface/assets) manages the assets in y
 | [`json`](json)                   | `.json`                          | `.json`                          | JSON documents                     |
 | [`material`](material)           | `.glb`, `.fbx`                   | None                             | Material definitions for 3D models |
 | [`render`](render)               | `.glb`, `.fbx`                   | `.glb`                           | 3D mesh data                       |
-| `script`                         | `.js`, `.mjs`, `.ts`             | `.js`, `.mjs`, `.ts`             | Scripts                            |
+| [`script`](../../scripting/index.md) | `.js`, `.mjs`, `.ts`         | `.js`, `.mjs`, `.ts`             | Scripts                            |
 | [`shader`](shader)               | `.glsl`, `.vert`, `.frag`        | `.glsl`, `.vert`, `.frag`        | Custom shaders for rendering       |
 | [`sprite`](sprite)               | Created in the Editor            | None                             | 2D images for UIs or textures      |
 | [`template`](template)           | `.glb`                           | None                             | Templates for entity hierarchy     |

--- a/docs/user-manual/assets/types/index.md
+++ b/docs/user-manual/assets/types/index.md
@@ -19,7 +19,7 @@ The [Assets Panel](/user-manual/editor/interface/assets) manages the assets in y
 | [`json`](json)                   | `.json`                          | `.json`                          | JSON documents                     |
 | [`material`](material)           | `.glb`, `.fbx`                   | None                             | Material definitions for 3D models |
 | [`render`](render)               | `.glb`, `.fbx`                   | `.glb`                           | 3D mesh data                       |
-| [`script`](../../scripting/index.md) | `.js`, `.mjs`, `.ts`         | `.js`, `.mjs`, `.ts`             | Scripts                            |
+| [`script`](../../scripting/index.md) | `.js`, `.mjs`                | `.js`, `.mjs`                    | Scripts                            |
 | [`shader`](shader)               | `.glsl`, `.vert`, `.frag`        | `.glsl`, `.vert`, `.frag`        | Custom shaders for rendering       |
 | [`sprite`](sprite)               | Created in the Editor            | None                             | 2D images for UIs or textures      |
 | [`template`](template)           | `.glb`                           | None                             | Templates for entity hierarchy     |

--- a/docs/user-manual/assets/types/index.md
+++ b/docs/user-manual/assets/types/index.md
@@ -10,7 +10,7 @@ The [Assets Panel](/user-manual/editor/interface/assets) manages the assets in y
 | [`animation`](animation)         | `.glb`, `.fbx`                   | `.glb`                           | Animation keyframe data            |
 | [`audio`](audio)                 | `.mp3`, `.wav`, `.ogg`           | `.mp3`, `.wav`, `.ogg`           | Sound data                         |
 | `binary`                         | `.bin`                           | `.bin`                           | Binary data                        |
-| `bundle`                         | `.tar`                           | `.tar`                           | Bundled assets                     |
+| `bundle`                         | Created in the Editor            | `.tar`                           | Bundled assets                     |
 | [`css`](css)                     | `.css`                           | `.css`                           | Stylesheets for HTML               |
 | [`cubemap`](cubemap)             | `.png`, `.jpg`, `.webp`, `.avif` | `.png`, `.jpg`, `.webp`, `.avif` | Environment lighting data          |
 | [`font`](font)                   | `.ttf`, `.woff`                  | `.json`, `.png`                  | Font data for rendering text       |

--- a/docs/user-manual/assets/types/index.md
+++ b/docs/user-manual/assets/types/index.md
@@ -7,7 +7,7 @@ The [Assets Panel](/user-manual/editor/interface/assets) manages the assets in y
 
 | Type                             | Imported From                    | Resource Extensions              | Description                        |
 | -------------------------------- | -------------------------------- | -------------------------------- | ---------------------------------- |
-| [`animation`](animation)         | `.glb`, `.fbx`, `.json`          | `.glb`, `.json`                  | Animation keyframe data            |
+| [`animation`](animation)         | `.glb`, `.fbx`                   | `.glb`                           | Animation keyframe data            |
 | [`audio`](audio)                 | `.mp3`, `.wav`, `.ogg`           | `.mp3`, `.wav`, `.ogg`           | Sound data                         |
 | `binary`                         | `.bin`, `.gltf`                  | `.bin`, `.gltf`                  | Binary data                        |
 | `bundle`                         | `.tar`                           | `.tar`                           | Bundled assets                     |


### PR DESCRIPTION
## Description

The following asset types are undocumented:

- binary
- bundle
- script
- model
- container

I'm going off the list of assets documented here: https://api.playcanvas.com/engine/classes/Asset.html#constructor

This PR adds `binary`, `bundle`, and `script` to the "Asset Types" table.

I did not include `model` and `container`. My understanding is `model` is replaced by `render`. I'm not super familiar with how `container` works and if it would be worth including.

### binary

Can be useful including binary as some users try to import `.gltf` and [are confused that it's imported as a binary](https://forum.playcanvas.com/t/trying-to-import-gltf-models-but-they-import-as-binary-files/30087/4).

### bundle

This is a new feature that [landed in 2024](https://github.com/playcanvas/engine/pull/5675).

### script

I was kind of surprised this wasn't mentioned.

## Misc

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/main/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
