### PR TITLE
Update Engine API links to the correct form

### DIFF
--- a/docs/shader-editor/window-layout/inspector-pane/material-inspector.md
+++ b/docs/shader-editor/window-layout/inspector-pane/material-inspector.md
@@ -32,4 +32,4 @@ There are three sections: Basic, Render States and Parameters.
 The parameters section lists the parameter nodes placed on the graph. The names and types are taken from the graph nodes themselves.
 
 [2]: /shader-editor/window-layout/assets-pane
-[3]: https://api.playcanvas.com/classes/Engine.Material.html#blendType
+[3]: https://api.playcanvas.com/engine/classes/Material.html#blendType

--- a/docs/tutorials/Using-forces-on-rigid-bodies.md
+++ b/docs/tutorials/Using-forces-on-rigid-bodies.md
@@ -184,12 +184,12 @@ DynamicBody.prototype.reset = function () {
 };
 ```
 
-[1]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html#applyForce
-[2]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html#applyImpulse
-[3]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html#applyTorque
-[4]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html#applyTorqueImpulse
-[5]: https://api.playcanvas.com/classes/Engine.Vec3.html
-[6]: https://api.playcanvas.com/classes/Engine.CollisionComponent.html
+[1]: https://api.playcanvas.com/engine/classes/RigidBodyComponent.html#applyForce
+[2]: https://api.playcanvas.com/engine/classes/RigidBodyComponent.html#applyImpulse
+[3]: https://api.playcanvas.com/engine/classes/RigidBodyComponent.html#applyTorque
+[4]: https://api.playcanvas.com/engine/classes/RigidBodyComponent.html#applyTorqueImpulse
+[5]: https://api.playcanvas.com/engine/classes/Vec3.html
+[6]: https://api.playcanvas.com/engine/classes/CollisionComponent.html
 [7]: https://api.playcanvas.com/modules/Engine.html
 [8]: /tutorials/first-person-movement/
 [9]: /tutorials/collision-and-triggers/

--- a/docs/tutorials/audio-effects.md
+++ b/docs/tutorials/audio-effects.md
@@ -68,4 +68,4 @@ You can find out more about the Sound Component API [here][8].
 [5]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API
 [6]: https://developer.mozilla.org/en-US/docs/Web/API/ConvolverNode
 [7]: https://developer.mozilla.org/en-US/docs/Web/API/ConvolverNode/buffer
-[8]: https://api.playcanvas.com/classes/Engine.Sound.html
+[8]: https://api.playcanvas.com/engine/classes/Sound.html

--- a/docs/tutorials/collision-and-triggers.md
+++ b/docs/tutorials/collision-and-triggers.md
@@ -135,4 +135,4 @@ And that's all there is to handling Collisions and Triggers in PlayCanvas.
 
 [1]: https://playcanvas.com/project/405871
 [5]: /user-manual/scenes/components/rigidbody/
-[8]: https://api.playcanvas.com/classes/Engine.Entity.html
+[8]: https://api.playcanvas.com/engine/classes/Entity.html

--- a/docs/tutorials/controlling-lights.md
+++ b/docs/tutorials/controlling-lights.md
@@ -125,5 +125,5 @@ LightHandler.prototype.pivot = function () {
 };
 ```
 
-[1]: https://api.playcanvas.com/classes/Engine.LightComponent.html
+[1]: https://api.playcanvas.com/engine/classes/LightComponent.html
 [2]: https://playcanvas.com/project/405812/overview/tutorial-controlling-lights

--- a/docs/tutorials/custom-shaders.md
+++ b/docs/tutorials/custom-shaders.md
@@ -287,7 +287,7 @@ CustomShader.prototype.update = function(dt) {
 
 Here is the complete script. Remember you'll need to create vertex shader and fragment shader assets in order for it to work.
 
-[1]: https://api.playcanvas.com/classes/Engine.Shader.html
+[1]: https://api.playcanvas.com/engine/classes/Shader.html
 [2]: /user-manual/scripting/script-attributes/
 [3]: /user-manual/graphics/physical-rendering/physical-materials/
 [project]: https://playcanvas.com/project/406044/overview/tutorial-custom-shaders

--- a/docs/tutorials/entity-picking.md
+++ b/docs/tutorials/entity-picking.md
@@ -146,5 +146,5 @@ PickerFramebuffer.prototype.onSelect = function (event) {
 ```
 
 [1]: https://playcanvas.com/project/405856
-[2]: https://api.playcanvas.com/classes/Engine.RigidBodyComponentSystem.html#raycastFirst
-[3]: https://api.playcanvas.com/classes/Engine.Picker.html
+[2]: https://api.playcanvas.com/engine/classes/RigidBodyComponentSystem.html#raycastFirst
+[3]: https://api.playcanvas.com/engine/classes/Picker.html

--- a/docs/tutorials/first-person-movement.md
+++ b/docs/tutorials/first-person-movement.md
@@ -145,4 +145,4 @@ FirstPersonMovement.prototype._createCamera = function () {
 ```
 
 [1]: https://playcanvas.com/project/405842
-[3]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html#applyForce
+[3]: https://api.playcanvas.com/engine/classes/RigidBodyComponent.html#applyForce

--- a/docs/tutorials/light-halos.md
+++ b/docs/tutorials/light-halos.md
@@ -126,4 +126,4 @@ Halo.prototype.update = function(dt) {
 That's it. A simple but pretty effect to add to your scene. Take a look at the [project][4] for more information.
 
 [4]: https://playcanvas.com/project/406040
-[5]: https://api.playcanvas.com/classes/Engine.MeshInstance.html
+[5]: https://api.playcanvas.com/engine/classes/MeshInstance.html

--- a/docs/tutorials/music-visualizer.md
+++ b/docs/tutorials/music-visualizer.md
@@ -137,4 +137,4 @@ This is just a taster of how you can visualize your music. Why not try scaling 3
 [1]: https://playcanvas.com/project/405891
 [2]: https://developer.mozilla.org/en/docs/Web/API/AudioContext
 [3]: https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode
-[4]: https://api.playcanvas.com/classes/Engine.Application.html#renderLines
+[4]: https://api.playcanvas.com/engine/classes/Application.html#renderLines

--- a/docs/tutorials/procedural-levels.md
+++ b/docs/tutorials/procedural-levels.md
@@ -57,5 +57,5 @@ Generate.prototype.initialize = function() {
 };
 ```
 
-[1]: https://api.playcanvas.com/classes/Engine.Entity.html#clone
+[1]: https://api.playcanvas.com/engine/classes/Entity.html#clone
 [2]: https://playcanvas.com/project/405864

--- a/docs/tutorials/terrain-generation.md
+++ b/docs/tutorials/terrain-generation.md
@@ -164,5 +164,5 @@ Terrain.prototype.createTerrainFromHeightMap = function (img, subdivisions) {
 };
 ```
 
-[1]: https://api.playcanvas.com/classes/Engine.Mesh.html
+[1]: https://api.playcanvas.com/engine/classes/Mesh.html
 [2]: https://playcanvas.com/project/406046

--- a/docs/tutorials/touch-joypad.md
+++ b/docs/tutorials/touch-joypad.md
@@ -134,8 +134,8 @@ console.log('Was pressed: ' + buttons.wasPressed('button0'));
 [project-link]: https://playcanvas.com/project/1007506/overview/touchscreen-joypad-controls
 [playcanvas-ui]: /user-manual/user-interface/
 [add-template-docs]: /user-manual/editor/templates/#adding-templates-in-your-scene
-[pc-app-mouse-api]: https://api.playcanvas.com/classes/Engine.Mouse.html
-[pc-app-touch-api]: https://api.playcanvas.com/classes/Engine.Touch.html
+[pc-app-mouse-api]: https://api.playcanvas.com/engine/classes/Mouse.html
+[pc-app-touch-api]: https://api.playcanvas.com/engine/classes/Touch.html
 [elements-manual]: /user-manual/user-interface/elements/
 [orbit-camera-joypad-input-script]: https://playcanvas.com/editor/code/1007506?tabs=111433673
 [player-controller-script]: https://playcanvas.com/editor/code/1007506?tabs=111432679

--- a/docs/tutorials/ui-elements-buttons.md
+++ b/docs/tutorials/ui-elements-buttons.md
@@ -147,4 +147,4 @@ These events will only fire if Use Input is enabled on the Element component so 
 [1]: https://playcanvas.com/editor/scene/547900
 [2]: /user-manual/user-interface/elements/
 [3]: /user-manual/user-interface/screens/
-[click-event-api]: https://api.playcanvas.com/classes/Engine.ButtonComponent.html#event:click
+[click-event-api]: https://api.playcanvas.com/engine/classes/ButtonComponent.html#event:click

--- a/docs/tutorials/ui-elements-progress.md
+++ b/docs/tutorials/ui-elements-progress.md
@@ -107,4 +107,4 @@ Changing the `width` makes the fill image larger and changing the `rect` makes s
 [1]: https://playcanvas.com/editor/scene/547906
 [2]: /user-manual/user-interface/elements/
 [3]: /user-manual/user-interface/screens/
-[8]: https://api.playcanvas.com/classes/Engine.ElementComponent.html#rect
+[8]: https://api.playcanvas.com/engine/classes/ElementComponent.html#rect

--- a/docs/tutorials/using-assets.md
+++ b/docs/tutorials/using-assets.md
@@ -206,9 +206,9 @@ this.app.assets.load(asset);
 
 The `asset.ready()` method will call it's callback as soon as the asset is loaded, if the asset is already loaded, it will call it straight away. `app.assets.load()` does nothing if the asset is already loaded.
 
-[1]: https://api.playcanvas.com/classes/Engine.AssetRegistry.html
+[1]: https://api.playcanvas.com/engine/classes/AssetRegistry.html
 [3]: https://playcanvas.com/project/406036
 [5]: pathname:///downloads/tutorials/A.dae
 [6]: pathname:///downloads/tutorials/B.dae
 [7]: pathname:///downloads/tutorials/C.dae
-[8]: https://api.playcanvas.com/classes/Engine.RenderComponent.html#asset
+[8]: https://api.playcanvas.com/engine/classes/RenderComponent.html#asset

--- a/docs/tutorials/webxr-ray-input.md
+++ b/docs/tutorials/webxr-ray-input.md
@@ -108,10 +108,10 @@ This UI interaction is agnostic to input source: either it originates from VR ha
 [1]: https://playcanvas.com/project/460449/overview/webvr-ray-input
 [2]: /user-manual/xr/using-webxr/
 [3]: /user-manual/user-interface/
-[4]: https://api.playcanvas.com/classes/Engine.XrInput.html
-[5]: https://api.playcanvas.com/classes/Engine.XrInputSource.html
-[6]: https://api.playcanvas.com/classes/Engine.ButtonComponent.html
-[7]: https://api.playcanvas.com/classes/Engine.ElementComponent.html
-[8]: https://api.playcanvas.com/classes/Engine.XrInputSource.html#getOrigin
-[9]: https://api.playcanvas.com/classes/Engine.XrInputSource.html#getDirection
-[10]: https://api.playcanvas.com/classes/Engine.ButtonComponent.html#event:click
+[4]: https://api.playcanvas.com/engine/classes/XrInput.html
+[5]: https://api.playcanvas.com/engine/classes/XrInputSource.html
+[6]: https://api.playcanvas.com/engine/classes/ButtonComponent.html
+[7]: https://api.playcanvas.com/engine/classes/ElementComponent.html
+[8]: https://api.playcanvas.com/engine/classes/XrInputSource.html#getOrigin
+[9]: https://api.playcanvas.com/engine/classes/XrInputSource.html#getDirection
+[10]: https://api.playcanvas.com/engine/classes/ButtonComponent.html#event:click

--- a/docs/user-manual/assets/import-pipeline/import-hierarchy.md
+++ b/docs/user-manual/assets/import-pipeline/import-hierarchy.md
@@ -60,6 +60,6 @@ How the Editor decides what is a new or removed mesh instance is done by the fol
 [material_asset]: /user-manual/assets/types/material/
 [texture_asset]: /user-manual/assets/types/texture/
 [template_asset]: /user-manual/editor/templates/
-[render_component]: https://api.playcanvas.com/classes/Engine.RenderComponent.html
-[collision_component]: https://api.playcanvas.com/classes/Engine.CollisionComponent.html
+[render_component]: https://api.playcanvas.com/engine/classes/RenderComponent.html
+[collision_component]: https://api.playcanvas.com/engine/classes/CollisionComponent.html
 [first_model_animation_import]: /tutorials/importing-first-model-and-animation/

--- a/docs/user-manual/editor/interface/assets.md
+++ b/docs/user-manual/editor/interface/assets.md
@@ -122,4 +122,4 @@ Selecting a reference will load it into the Inspector panel.
 [2]: /user-manual/editor/interface/inspector
 [3]: /user-manual/editor/interface/viewport
 [4]: /user-manual/editor/interface/settings
-[7]: https://api.playcanvas.com/classes/Engine.AssetRegistry.html#findByTag
+[7]: https://api.playcanvas.com/engine/classes/AssetRegistry.html#findByTag

--- a/docs/user-manual/graphics/advanced-rendering/batching.md
+++ b/docs/user-manual/graphics/advanced-rendering/batching.md
@@ -87,6 +87,6 @@ In this animation we have created 4 batch groups for the buildings, the cacti, t
 
 [6]: /user-manual/scenes/settings#batch-groups
 [7]: /user-manual/scenes/components/model
-[8]: https://api.playcanvas.com/classes/Engine.BatchManager.html
+[8]: https://api.playcanvas.com/engine/classes/BatchManager.html
 [9]: /user-manual/scenes/components/sprite
 [10]: /user-manual/scenes/components/element

--- a/docs/user-manual/graphics/advanced-rendering/hardware-instancing.md
+++ b/docs/user-manual/graphics/advanced-rendering/hardware-instancing.md
@@ -27,7 +27,7 @@ for (let i = 0; i < instanceCount; i++) {
 }
 ```
 
-Create a VertexBuffer which stores per-instance state and initialize it with the matrices. In the following example, we use [`pc.VertexFormat.getDefaultInstancingFormat`](https://api.playcanvas.com/classes/Engine.VertexFormat.html#getDefaultInstancingFormat) which allows us to store a per-instance Mat4 matrix. Then we enable instancing on a MeshInstance, which contains the mesh geometry we want to instance.
+Create a VertexBuffer which stores per-instance state and initialize it with the matrices. In the following example, we use [`pc.VertexFormat.getDefaultInstancingFormat`](https://api.playcanvas.com/engine/classes/VertexFormat.html#getDefaultInstancingFormat) which allows us to store a per-instance Mat4 matrix. Then we enable instancing on a MeshInstance, which contains the mesh geometry we want to instance.
 
 ```javascript
 const instanceCount = 10;

--- a/docs/user-manual/graphics/cameras/depth-layer.md
+++ b/docs/user-manual/graphics/cameras/depth-layer.md
@@ -26,8 +26,8 @@ These engine examples demonstrate the rendering of both the depth and the color 
 - GrabPass demonstrates the use of the color buffer: [`GrabPass`][2]
 - GroundFog demonstrates the use of the depth buffer: [`GroundFog`][3]
 
-[0]: https://api.playcanvas.com/classes/Engine.CameraComponent.html#requestSceneColorMap
-[1]: https://api.playcanvas.com/classes/Engine.CameraComponent.html#requestSceneDepthMap
+[0]: https://api.playcanvas.com/engine/classes/CameraComponent.html#requestSceneColorMap
+[1]: https://api.playcanvas.com/engine/classes/CameraComponent.html#requestSceneDepthMap
 [2]: https://playcanvas.github.io/#/graphics/grab-pass
 [3]: https://playcanvas.github.io/#/graphics/ground-fog
 [4]: /user-manual/graphics/layers/#choosing-the-layer-order

--- a/docs/user-manual/graphics/lighting/clustered-lighting.md
+++ b/docs/user-manual/graphics/lighting/clustered-lighting.md
@@ -126,5 +126,5 @@ this.app.scene.lighting.debugLayer = undefined;
 ```
 
 [shadows]: /user-manual/graphics/lighting/shadows/#soft-shadows-vs-hard-shadows
-[pc-layer-api]: https://api.playcanvas.com/classes/Engine.Layer.html
-[pc-lighting-debug-layer-api]: https://api.playcanvas.com/classes/Engine.LightingParams.html#debugLayer
+[pc-layer-api]: https://api.playcanvas.com/engine/classes/Layer.html
+[pc-lighting-debug-layer-api]: https://api.playcanvas.com/engine/classes/LightingParams.html#debugLayer

--- a/docs/user-manual/graphics/linear-workflow/hdr-rendering.md
+++ b/docs/user-manual/graphics/linear-workflow/hdr-rendering.md
@@ -72,7 +72,7 @@ material.emissive = pc.Color.YELLOW;
 material.emissiveIntensity = 50;
 ```
 
-For more detailed information, refer to the CameraFrame [API documentation](https://api.playcanvas.com/classes/Engine.CameraFrame.html).
+For more detailed information, refer to the CameraFrame [API documentation](https://api.playcanvas.com/engine/classes/CameraFrame.html).
 
 ## CameraFrame in the Editor
 

--- a/docs/user-manual/graphics/particles.md
+++ b/docs/user-manual/graphics/particles.md
@@ -41,5 +41,5 @@ this.entity.particlesystem.play();
 Soft particles are particles that are faded out near their intersections with scene geometry. If soft particles are enabled by using [```depthSoftening```][5], the camera which renders the particles needs to have a [Depth Map][6] rendering enabled.
 
 [4]: /user-manual/scenes/components/particlesystem
-[5]: https://api.playcanvas.com/classes/Engine.ParticleSystemComponent.html#depthSoftening
+[5]: https://api.playcanvas.com/engine/classes/ParticleSystemComponent.html#depthSoftening
 [6]: /user-manual/graphics/cameras/depth-layer

--- a/docs/user-manual/graphics/shaders/index.md
+++ b/docs/user-manual/graphics/shaders/index.md
@@ -95,7 +95,7 @@ The engine provides some defines automatically, allowing integration with render
 #define SHADOW_PICK 
 ```
 
-If you use a custom render pass, created using [`CameraComponent.setShaderPass`](https://api.playcanvas.com/classes/Engine.CameraComponent.html#setshaderpass), a matching define is automatically generated. For example:
+If you use a custom render pass, created using [`CameraComponent.setShaderPass`](https://api.playcanvas.com/engine/classes/CameraComponent.html#setshaderpass), a matching define is automatically generated. For example:
 
 ```javascript
 camera.setRenderPass('custom');
@@ -206,6 +206,6 @@ And Each created shader will be logged in the browser console, where you can ins
 
 ![sRGB](/img/user-manual/graphics/shaders/shader-log.png)
 
-For further information, refer to the [ShaderMaterial API documentation](https://api.playcanvas.com/classes/Engine.ShaderMaterial.html).
+For further information, refer to the [ShaderMaterial API documentation](https://api.playcanvas.com/engine/classes/ShaderMaterial.html).
 
 [1]: /user-manual/graphics/physical-rendering/physical-materials/

--- a/docs/user-manual/optimization/guidelines.md
+++ b/docs/user-manual/optimization/guidelines.md
@@ -39,7 +39,7 @@ Here are some tips and hints on how to achieve good performance in your PlayCanv
 
 [1]: /user-manual/graphics/advanced-rendering/batching
 [2]: /user-manual/optimization/runtime-devicepixelratio
-[3]: https://api.playcanvas.com/classes/Engine.Application.html#autoRender
-[4]: https://api.playcanvas.com/classes/Engine.Application.html#renderNextFrame
-[5]: https://api.playcanvas.com/classes/Engine.RenderComponent.html#customAabb
-[6]: https://api.playcanvas.com/classes/Engine.ModelComponent.html#customAabb
+[3]: https://api.playcanvas.com/engine/classes/Application.html#autoRender
+[4]: https://api.playcanvas.com/engine/classes/Application.html#renderNextFrame
+[5]: https://api.playcanvas.com/engine/classes/RenderComponent.html#customAabb
+[6]: https://api.playcanvas.com/engine/classes/ModelComponent.html#customAabb

--- a/docs/user-manual/optimization/runtime-devicepixelratio.md
+++ b/docs/user-manual/optimization/runtime-devicepixelratio.md
@@ -75,6 +75,6 @@ function isLowQualityGPU() {
 
 We also recommend to have an option in the application for the user to be able to switch between quality levels. This allows them to choose the level that they are comfortable with and also be able to lower the quality in favor of using lower device resources and extending battery life.
 
-[4]: https://api.playcanvas.com/classes/Engine.GraphicsDevice.html#maxPixelRatio
+[4]: https://api.playcanvas.com/engine/classes/GraphicsDevice.html#maxPixelRatio
 [5]: https://www.videocardbenchmark.net/GPU_mega_page.html
 [6]: https://www.notebookcheck.net/Smartphone-Graphics-Cards-Benchmark-List.149363.0.html

--- a/docs/user-manual/physics/forces-and-impulses.md
+++ b/docs/user-manual/physics/forces-and-impulses.md
@@ -29,4 +29,4 @@ MyScript.prototype.update = function(dt) {
 };
 ```
 
-[1]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html
+[1]: https://api.playcanvas.com/engine/classes/RigidBodyComponent.html

--- a/docs/user-manual/scenes/components/animation.md
+++ b/docs/user-manual/scenes/components/animation.md
@@ -28,4 +28,4 @@ The Animation component can be enabled or disabled using the toggle in the top r
 You can control an Animation component's properties using a [script component][2]. The Animation component's scripting interface is [here][3].
 
 [2]: /user-manual/scenes/components/script
-[3]: https://api.playcanvas.com/classes/Engine.AnimationComponent.html
+[3]: https://api.playcanvas.com/engine/classes/AnimationComponent.html

--- a/docs/user-manual/scenes/components/audiolistener.md
+++ b/docs/user-manual/scenes/components/audiolistener.md
@@ -13,4 +13,4 @@ The Audio Listener component can be enabled or disabled using the toggle in the 
 You can control an Audio Listener component's properties using a [script component][2]. The Audio Listener component's scripting interface is [here][3].
 
 [2]: /user-manual/scenes/components/script
-[3]: https://api.playcanvas.com/classes/Engine.AudioListenerComponent.html
+[3]: https://api.playcanvas.com/engine/classes/AudioListenerComponent.html

--- a/docs/user-manual/scenes/components/button.md
+++ b/docs/user-manual/scenes/components/button.md
@@ -46,4 +46,4 @@ You can control the properties of a Button component using a [script component][
 [1]: /user-manual/scenes/components/screen
 [2]: /user-manual/scenes/components/element
 [5]: /user-manual/scenes/components/script
-[6]: https://api.playcanvas.com/classes/Engine.ButtonComponent.html
+[6]: https://api.playcanvas.com/engine/classes/ButtonComponent.html

--- a/docs/user-manual/scenes/components/camera.md
+++ b/docs/user-manual/scenes/components/camera.md
@@ -28,4 +28,4 @@ The Camera component can be enabled or disabled using the toggle in the top righ
 You can control a Camera component's properties using a [script component][2]. The Camera component's scripting interface is [here][3].
 
 [2]: /user-manual/scenes/components/script
-[3]: https://api.playcanvas.com/classes/Engine.CameraComponent.html
+[3]: https://api.playcanvas.com/engine/classes/CameraComponent.html

--- a/docs/user-manual/scenes/components/collision.md
+++ b/docs/user-manual/scenes/components/collision.md
@@ -52,4 +52,4 @@ If the entity also has a rigidbody component, the collision component determines
 You can control a Collision component's properties using a [script component][8]. The Collision component's scripting interface is [here][9].
 
 [8]: /user-manual/scenes/components/script
-[9]: https://api.playcanvas.com/classes/Engine.CollisionComponent.html
+[9]: https://api.playcanvas.com/engine/classes/CollisionComponent.html

--- a/docs/user-manual/scenes/components/gsplat.md
+++ b/docs/user-manual/scenes/components/gsplat.md
@@ -17,4 +17,4 @@ The GSplat component can be enabled or disabled using the toggle in the top righ
 
 ## Scripting Interface
 
-You can control the properties of a GSplat component using a [script component](../script). The scripting interface for the GSplat component is [here](https://api.playcanvas.com/classes/Engine.GSplatComponent.html).
+You can control the properties of a GSplat component using a [script component](../script). The scripting interface for the GSplat component is [here](https://api.playcanvas.com/engine/classes/GSplatComponent.html).

--- a/docs/user-manual/scenes/components/layout-child.md
+++ b/docs/user-manual/scenes/components/layout-child.md
@@ -26,4 +26,4 @@ You can control an LayoutChild component's properties using a [script component]
 
 [0]: /user-manual/user-interface/layout-groups
 [2]: /user-manual/scenes/components/script
-[3]: https://api.playcanvas.com/classes/Engine.LayoutChildComponent.html
+[3]: https://api.playcanvas.com/engine/classes/LayoutChildComponent.html

--- a/docs/user-manual/scenes/components/layout-group.md
+++ b/docs/user-manual/scenes/components/layout-group.md
@@ -28,4 +28,4 @@ You can control an LayoutGroup component's properties using a [script component]
 
 [0]: /user-manual/user-interface/layout-groups
 [2]: /user-manual/scenes/components/script
-[3]: https://api.playcanvas.com/classes/Engine.LayoutGroupComponent.html
+[3]: https://api.playcanvas.com/engine/classes/LayoutGroupComponent.html

--- a/docs/user-manual/scenes/components/light.md
+++ b/docs/user-manual/scenes/components/light.md
@@ -45,4 +45,4 @@ The Light component can be enabled or disabled using the toggle in the top right
 You can control a Light component's properties using a [script component][4]. The Light component's scripting interface is [here][5].
 
 [4]: /user-manual/scenes/components/script
-[5]: https://api.playcanvas.com/classes/Engine.LightComponent.html
+[5]: https://api.playcanvas.com/engine/classes/LightComponent.html

--- a/docs/user-manual/scenes/components/model.md
+++ b/docs/user-manual/scenes/components/model.md
@@ -36,6 +36,6 @@ You can control a Model component's properties using a [script component][2]. Th
 You can learn how to customize the materials of your model [here][4].
 
 [2]: /user-manual/scenes/components/script
-[3]: https://api.playcanvas.com/classes/Engine.ModelComponent.html
+[3]: https://api.playcanvas.com/engine/classes/ModelComponent.html
 [4]: /user-manual/assets/types/material/#assigning-materials
 [5]: /user-manual/graphics/advanced-rendering/batching

--- a/docs/user-manual/scenes/components/particlesystem.md
+++ b/docs/user-manual/scenes/components/particlesystem.md
@@ -48,4 +48,4 @@ The Particle System component can be enabled or disabled using the toggle in the
 You can control a Particle System component's properties using a [script component][2]. The Particle System component's scripting interface is [here][3].
 
 [2]: /user-manual/scenes/components/script
-[3]: https://api.playcanvas.com/classes/Engine.ParticleSystemComponent.html
+[3]: https://api.playcanvas.com/engine/classes/ParticleSystemComponent.html

--- a/docs/user-manual/scenes/components/render.md
+++ b/docs/user-manual/scenes/components/render.md
@@ -28,4 +28,4 @@ The render component can be enabled or disabled using the toggle in the top righ
 You can control a render component's properties using a [script component][2]. The render component's scripting interface is [here][3].
 
 [2]: /user-manual/scenes/components/script
-[3]: https://api.playcanvas.com/classes/Engine.RenderComponent.html
+[3]: https://api.playcanvas.com/engine/classes/RenderComponent.html

--- a/docs/user-manual/scenes/components/rigidbody.md
+++ b/docs/user-manual/scenes/components/rigidbody.md
@@ -39,4 +39,4 @@ You can control a Rigid Body component's properties using a [script component][5
 
 [4]: /user-manual/scenes/components/collision/
 [5]: /user-manual/scenes/components/script
-[6]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html
+[6]: https://api.playcanvas.com/engine/classes/RigidBodyComponent.html

--- a/docs/user-manual/scenes/components/script.md
+++ b/docs/user-manual/scenes/components/script.md
@@ -20,4 +20,4 @@ To edit the script in the PlayCanvas Code Editor you can either click on the hyp
 
 The Script component's scripting interface is [here][2].
 
-[2]: https://api.playcanvas.com/classes/Engine.ScriptComponent.html
+[2]: https://api.playcanvas.com/engine/classes/ScriptComponent.html

--- a/docs/user-manual/scenes/components/sound.md
+++ b/docs/user-manual/scenes/components/sound.md
@@ -43,4 +43,4 @@ The Sound component can be enabled or disabled using the toggle in the top right
 You can control the properties of a Sound component using a [script component][2]. The scripting interface for the Sound component is [here][3].
 
 [2]: /user-manual/scenes/components/script
-[3]: https://api.playcanvas.com/classes/Engine.SoundComponent.html
+[3]: https://api.playcanvas.com/engine/classes/SoundComponent.html

--- a/docs/user-manual/scenes/components/sprite.md
+++ b/docs/user-manual/scenes/components/sprite.md
@@ -63,5 +63,5 @@ You can control the properties of a Sprite component using a [script component][
 
 [1]: /user-manual/assets/types/sprite
 [4]: /user-manual/scenes/components/script
-[5]: https://api.playcanvas.com/classes/Engine.SpriteComponent.html
+[5]: https://api.playcanvas.com/engine/classes/SpriteComponent.html
 [6]: /user-manual/graphics/advanced-rendering/batching

--- a/docs/user-manual/scenes/loading-scenes.md
+++ b/docs/user-manual/scenes/loading-scenes.md
@@ -74,7 +74,7 @@ Scenes are represented by [Scene Registry Items][sceneregistryitem-api] that are
 
 :::note
 
-The [application root node](https://api.playcanvas.com/classes/Engine.Application.html#root) is not the scene hierarchy root entity that is named 'Root' by default that you see in the scene with the Editor. The scene hierarchy root entity will be a child of the application root node.
+The [application root node](https://api.playcanvas.com/engine/classes/Application.html#root) is not the scene hierarchy root entity that is named 'Root' by default that you see in the scene with the Editor. The scene hierarchy root entity will be a child of the application root node.
 
 :::
 
@@ -200,15 +200,15 @@ The [example project][asset-load-for-scene-project] below loads the assets when 
 [additively-loading-scenes-project]: https://playcanvas.com/project/685077/overview/additive-loading-scenes
 [templates]: /user-manual/editor/templates/
 [assets]: /user-manual/assets/
-[loadscenehierarchy-api]: https://api.playcanvas.com/classes/Engine.SceneRegistry.html#loadSceneHierarchy
-[loadscenesettings-api]: https://api.playcanvas.com/classes/Engine.SceneRegistry.html#loadSceneSettings
-[sceneregistryitem-api]: https://api.playcanvas.com/classes/Engine.SceneRegistryItem.html
-[sceneregistry-api]: https://api.playcanvas.com/classes/Engine.SceneRegistry.html
-[application-sceneregistry-api]: https://api.playcanvas.com/classes/Engine.Application.html#scenes
+[loadscenehierarchy-api]: https://api.playcanvas.com/engine/classes/SceneRegistry.html#loadSceneHierarchy
+[loadscenesettings-api]: https://api.playcanvas.com/engine/classes/SceneRegistry.html#loadSceneSettings
+[sceneregistryitem-api]: https://api.playcanvas.com/engine/classes/SceneRegistryItem.html
+[sceneregistry-api]: https://api.playcanvas.com/engine/classes/SceneRegistry.html
+[application-sceneregistry-api]: https://api.playcanvas.com/engine/classes/Application.html#scenes
 [loadhierarchycallback-api]: https://api.playcanvas.com/modules/Engine.html#LoadHierarchyCallback
 [loadsettingscallback-api]: https://api.playcanvas.com/modules/Engine.html#LoadSettingsCallback
-[application-root-api]: https://api.playcanvas.com/classes/Engine.Application.html#root
-[loadscenedata-api]: https://api.playcanvas.com/classes/Engine.SceneRegistry.html#loadSceneData
+[application-root-api]: https://api.playcanvas.com/engine/classes/Application.html#root
+[loadscenedata-api]: https://api.playcanvas.com/engine/classes/SceneRegistry.html#loadSceneData
 [asset-tags-loading]: /user-manual/assets/preloading-and-streaming/#asset-tags
 [asset-load-for-scene-project]: https://playcanvas.com/project/926754/overview/asset-loading-for-scenes-example
-[changescene-api]: https://api.playcanvas.com/classes/Engine.SceneRegistry.html#changeScene
+[changescene-api]: https://api.playcanvas.com/engine/classes/SceneRegistry.html#changeScene

--- a/docs/user-manual/scripting/communication.md
+++ b/docs/user-manual/scripting/communication.md
@@ -94,4 +94,4 @@ Display.prototype.initialize = function () {
 
 As you can see, this reduces the amount of set up and makes for cleaner code.
 
-[1]: https://api.playcanvas.com/classes/Engine.EventHandler.html
+[1]: https://api.playcanvas.com/engine/classes/EventHandler.html

--- a/docs/user-manual/scripting/creating-new.md
+++ b/docs/user-manual/scripting/creating-new.md
@@ -41,4 +41,4 @@ To remove a script from a component use the `destroy` method
 entity.script.destroy("rotate");
 ```
 
-[3]: https://api.playcanvas.com/classes/Engine.AssetRegistry.html#load
+[3]: https://api.playcanvas.com/engine/classes/AssetRegistry.html#load

--- a/docs/user-manual/scripting/script-attributes.md
+++ b/docs/user-manual/scripting/script-attributes.md
@@ -179,4 +179,4 @@ We currently do not support defining JSON attributes as children of other JSON a
 
 :::
 
-[3]: https://api.playcanvas.com/classes/Engine.ScriptAttributes.html
+[3]: https://api.playcanvas.com/engine/classes/ScriptAttributes.html

--- a/docs/user-manual/user-interface/localization.md
+++ b/docs/user-manual/user-interface/localization.md
@@ -128,9 +128,9 @@ To retrieve the text from a key in script, use the APIs:
 For the complete engine API reference for localization see [this page][2].
 
 [1]: https://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html
-[2]: https://api.playcanvas.com/classes/Engine.I18n.html
-[3]: https://api.playcanvas.com/classes/Engine.I18n.html#getText
-[4]: https://api.playcanvas.com/classes/Engine.I18n.html#getPluralText
+[2]: https://api.playcanvas.com/engine/classes/I18n.html
+[3]: https://api.playcanvas.com/engine/classes/I18n.html#getText
+[4]: https://api.playcanvas.com/engine/classes/I18n.html#getPluralText
 [5]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString
 [6]: http://www.thai-language.com/ref/breaking-words
 [7]: https://en.wikipedia.org/wiki/Zero-width_space

--- a/docs/user-manual/xr/hand-tracking.md
+++ b/docs/user-manual/xr/hand-tracking.md
@@ -52,7 +52,7 @@ A skinned mesh for a hand can used. You can check out [this project][5] as an ex
 <img loading="lazy" src="/img/user-manual/xr/skinned-hands.webp" alt="Hand tracking using skinned meshes" width="512" />
 
 [1]: https://immersive-web.github.io/webxr-hand-input/
-[2]: https://api.playcanvas.com/classes/Engine.XrHand.html
-[3]: https://api.playcanvas.com/classes/Engine.XrFinger.html
-[4]: https://api.playcanvas.com/classes/Engine.XrJoint.html
+[2]: https://api.playcanvas.com/engine/classes/XrHand.html
+[3]: https://api.playcanvas.com/engine/classes/XrFinger.html
+[4]: https://api.playcanvas.com/engine/classes/XrJoint.html
 [5]: https://playcanvas.com/project/771952/overview/webxr-realistic-hands

--- a/docs/user-manual/xr/input-sources.md
+++ b/docs/user-manual/xr/input-sources.md
@@ -164,9 +164,9 @@ entity.button.on('selectstart', (evt) => {
 });
 ```
 
-[1]: https://api.playcanvas.com/classes/Engine.XrInputSource.html
-[2]: https://api.playcanvas.com/classes/Engine.XrInput.html
-[3]: https://api.playcanvas.com/classes/Engine.XrManager.html
+[1]: https://api.playcanvas.com/engine/classes/XrInputSource.html
+[2]: https://api.playcanvas.com/engine/classes/XrInput.html
+[3]: https://api.playcanvas.com/engine/classes/XrManager.html
 [4]: https://www.w3.org/TR/webxr-gamepads-module-1/
 [5]: https://w3c.github.io/gamepad/
 [6]: https://github.com/immersive-web/webxr-input-profiles/tree/master/packages/registry

--- a/docs/user-manual/xr/using-webxr.md
+++ b/docs/user-manual/xr/using-webxr.md
@@ -105,4 +105,4 @@ Position, orientation and rays of different XR objects: input sources, tracked m
 
 Entering WebXR is required by browsers to be triggered by a *user action*. That means that it must be in response to a key press, a mouse click or a touch event. For that reason, there is no way to enter XR immediately on loading a page.
 
-[2]: https://api.playcanvas.com/classes/Engine.XrManager.html
+[2]: https://api.playcanvas.com/engine/classes/XrManager.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/shader-editor/window-layout/inspector-pane/material-inspector.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/shader-editor/window-layout/inspector-pane/material-inspector.md
@@ -32,4 +32,4 @@ Basic、Render States、Parametersの3つのセクションがあります。
 パラメーターセクションには、グラフに配置されたパラメーターノードがリストされます。名前とタイプは、グラフノード自体から取得されます。
 
 [2]: /shader-editor/window-layout/assets-pane
-[3]: https://api.playcanvas.com/classes/Engine.Material.html#blendType
+[3]: https://api.playcanvas.com/engine/classes/Material.html#blendType

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/Using-forces-on-rigid-bodies.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/Using-forces-on-rigid-bodies.md
@@ -184,12 +184,12 @@ DynamicBody.prototype.reset = function () {
 };
 ```
 
-[1]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html#applyForce
-[2]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html#applyImpulse
-[3]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html#applyTorque
-[4]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html#applyTorqueImpulse
-[5]: https://api.playcanvas.com/classes/Engine.Vec3.html
-[6]: https://api.playcanvas.com/classes/Engine.CollisionComponent.html
+[1]: https://api.playcanvas.com/engine/classes/RigidBodyComponent.html#applyForce
+[2]: https://api.playcanvas.com/engine/classes/RigidBodyComponent.html#applyImpulse
+[3]: https://api.playcanvas.com/engine/classes/RigidBodyComponent.html#applyTorque
+[4]: https://api.playcanvas.com/engine/classes/RigidBodyComponent.html#applyTorqueImpulse
+[5]: https://api.playcanvas.com/engine/classes/Vec3.html
+[6]: https://api.playcanvas.com/engine/classes/CollisionComponent.html
 [7]: https://api.playcanvas.com/modules/Engine.html
 [8]: /tutorials/first-person-movement/
 [9]: /tutorials/collision-and-triggers/

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/audio-effects.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/audio-effects.md
@@ -68,4 +68,4 @@ Soundコンポーネント APIの詳細については[こちら][8]をご覧く
 [5]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API
 [6]: https://developer.mozilla.org/en-US/docs/Web/API/ConvolverNode
 [7]: https://developer.mozilla.org/en-US/docs/Web/API/ConvolverNode/buffer
-[8]: https://api.playcanvas.com/classes/Engine.Sound.html
+[8]: https://api.playcanvas.com/engine/classes/Sound.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/collision-and-triggers.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/collision-and-triggers.md
@@ -137,4 +137,4 @@ Collider.prototype.onCollisionStart = function (result) {
 
 [1]: https://playcanvas.com/project/405871
 [5]: /user-manual/scenes/components/rigidbody/
-[8]: https://api.playcanvas.com/classes/Engine.Entity.html
+[8]: https://api.playcanvas.com/engine/classes/Entity.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/controlling-lights.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/controlling-lights.md
@@ -125,5 +125,5 @@ LightHandler.prototype.pivot = function () {
 };
 ```
 
-[1]: https://api.playcanvas.com/classes/Engine.LightComponent.html
+[1]: https://api.playcanvas.com/engine/classes/LightComponent.html
 [2]: https://playcanvas.com/project/405812/overview/tutorial-controlling-lights

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/custom-shaders.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/custom-shaders.md
@@ -286,7 +286,7 @@ CustomShader.prototype.update = function(dt) {
 
 以上がそのスクリプトの全体です。このスクリプトを動作させるには、バーテックスシェーダとフラグメントシェーダのアセットを作成する必要があることを忘れないでください。
 
-[1]: https://api.playcanvas.com/classes/Engine.Shader.html
+[1]: https://api.playcanvas.com/engine/classes/Shader.html
 [2]: /user-manual/scripting/script-attributes/
 [3]: /user-manual/graphics/physical-rendering/physical-materials/
 [project]: https://playcanvas.com/project/406044/overview/tutorial-custom-shaders

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/entity-picking.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/entity-picking.md
@@ -146,5 +146,5 @@ PickerFramebuffer.prototype.onSelect = function (event) {
 ```
 
 [1]: https://playcanvas.com/project/405856
-[2]: https://api.playcanvas.com/classes/Engine.RigidBodyComponentSystem.html#raycastFirst
-[3]: https://api.playcanvas.com/classes/Engine.Picker.html
+[2]: https://api.playcanvas.com/engine/classes/RigidBodyComponentSystem.html#raycastFirst
+[3]: https://api.playcanvas.com/engine/classes/Picker.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/first-person-movement.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/first-person-movement.md
@@ -144,4 +144,4 @@ FirstPersonMovement.prototype._createCamera = function () {
 ```
 
 [1]: https://playcanvas.com/project/405842
-[3]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html#applyForce
+[3]: https://api.playcanvas.com/engine/classes/RigidBodyComponent.html#applyForce

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/light-halos.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/light-halos.md
@@ -126,4 +126,4 @@ Halo.prototype.update = function(dt) {
 以上です。シーンに追加するシンプルで綺麗な効果です。詳細は[プロジェクト][4]でご確認ください。
 
 [4]: https://playcanvas.com/project/406040
-[5]: https://api.playcanvas.com/classes/Engine.MeshInstance.html
+[5]: https://api.playcanvas.com/engine/classes/MeshInstance.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/music-visualizer.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/music-visualizer.md
@@ -139,4 +139,4 @@ updateループでは、周波数データ (Frequency)および 時間領域 (Ti
 [1]: https://playcanvas.com/project/405891
 [2]: https://developer.mozilla.org/en/docs/Web/API/AudioContext
 [3]: https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode
-[4]: https://api.playcanvas.com/classes/Engine.Application.html#renderLines
+[4]: https://api.playcanvas.com/engine/classes/Application.html#renderLines

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/procedural-levels.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/procedural-levels.md
@@ -55,5 +55,5 @@ Generate.prototype.initialize = function() {
 };
 ```
 
-[1]: https://api.playcanvas.com/classes/Engine.Entity.html#clone
+[1]: https://api.playcanvas.com/engine/classes/Entity.html#clone
 [2]: https://playcanvas.com/project/405864

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/terrain-generation.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/terrain-generation.md
@@ -164,5 +164,5 @@ Terrain.prototype.createTerrainFromHeightMap = function (img, subdivisions) {
 };
 ```
 
-[1]: https://api.playcanvas.com/classes/Engine.Mesh.html
+[1]: https://api.playcanvas.com/engine/classes/Mesh.html
 [2]: https://playcanvas.com/project/406046

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/touch-joypad.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/touch-joypad.md
@@ -136,8 +136,8 @@ console.log('Was pressed: ' + buttons.wasPressed('button0'));
 [project-link]: https://playcanvas.com/project/1007506/overview/touchscreen-joypad-controls
 [playcanvas-ui]: /user-manual/user-interface/
 [add-template-docs]: /user-manual/editor/templates/#adding-templates-in-your-scene
-[pc-app-mouse-api]: https://api.playcanvas.com/classes/Engine.Mouse.html
-[pc-app-touch-api]: https://api.playcanvas.com/classes/Engine.Touch.html
+[pc-app-mouse-api]: https://api.playcanvas.com/engine/classes/Mouse.html
+[pc-app-touch-api]: https://api.playcanvas.com/engine/classes/Touch.html
 [elements-manual]: /user-manual/user-interface/elements/
 [orbit-camera-joypad-input-script]: https://playcanvas.com/editor/code/1007506?tabs=111433673
 [player-controller-script]: https://playcanvas.com/editor/code/1007506?tabs=111432679

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-elements-buttons.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-elements-buttons.md
@@ -149,4 +149,4 @@ this.entity.button.on('click', function(event) {
 [1]: https://playcanvas.com/editor/scene/547900
 [2]: /user-manual/user-interface/elements/
 [3]: /user-manual/user-interface/screens/
-[click-event-api]: https://api.playcanvas.com/classes/Engine.ButtonComponent.html#event:click
+[click-event-api]: https://api.playcanvas.com/engine/classes/ButtonComponent.html#event:click

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-elements-progress.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/ui-elements-progress.md
@@ -107,4 +107,4 @@ ProgressBar.prototype.update = function(dt) {
 [1]: https://playcanvas.com/editor/scene/547906
 [2]: /user-manual/user-interface/elements/
 [3]: /user-manual/user-interface/screens/
-[8]: https://api.playcanvas.com/classes/Engine.ElementComponent.html#rect
+[8]: https://api.playcanvas.com/engine/classes/ElementComponent.html#rect

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/using-assets.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/using-assets.md
@@ -206,9 +206,9 @@ this.app.assets.load(asset);
 
 `asset.ready()`メソッドはアセットが読み込まれるとすぐにそのコールバックを呼びます。また、アセットがすでに読み込まれている場合、すぐにそれを呼び出します。アセットがすでに読み込まれている場合、 `app.assets.load()`は何もしません。
 
-[1]: https://api.playcanvas.com/classes/Engine.AssetRegistry.html
+[1]: https://api.playcanvas.com/engine/classes/AssetRegistry.html
 [3]: https://playcanvas.com/project/406036
 [5]: pathname:///downloads/tutorials/A.dae
 [6]: pathname:///downloads/tutorials/B.dae
 [7]: pathname:///downloads/tutorials/C.dae
-[8]: https://api.playcanvas.com/classes/Engine.RenderComponent.html#asset
+[8]: https://api.playcanvas.com/engine/classes/RenderComponent.html#asset

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-ray-input.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/webxr-ray-input.md
@@ -107,10 +107,10 @@ entity.button.on('click', function() {
 [1]: https://playcanvas.com/project/460449/overview/webvr-ray-input
 [2]: /user-manual/xr/using-webxr/
 [3]: /user-manual/user-interface/
-[4]: https://api.playcanvas.com/classes/Engine.XrInput.html
-[5]: https://api.playcanvas.com/classes/Engine.XrInputSource.html
-[6]: https://api.playcanvas.com/classes/Engine.ButtonComponent.html
-[7]: https://api.playcanvas.com/classes/Engine.ElementComponent.html
-[8]: https://api.playcanvas.com/classes/Engine.XrInputSource.html#getOrigin
-[9]: https://api.playcanvas.com/classes/Engine.XrInputSource.html#getDirection
-[10]: https://api.playcanvas.com/classes/Engine.ButtonComponent.html#event:click
+[4]: https://api.playcanvas.com/engine/classes/XrInput.html
+[5]: https://api.playcanvas.com/engine/classes/XrInputSource.html
+[6]: https://api.playcanvas.com/engine/classes/ButtonComponent.html
+[7]: https://api.playcanvas.com/engine/classes/ElementComponent.html
+[8]: https://api.playcanvas.com/engine/classes/XrInputSource.html#getOrigin
+[9]: https://api.playcanvas.com/engine/classes/XrInputSource.html#getDirection
+[10]: https://api.playcanvas.com/engine/classes/ButtonComponent.html#event:click

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/assets/import-pipeline/import-hierarchy.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/assets/import-pipeline/import-hierarchy.md
@@ -60,6 +60,6 @@ PlayCanvasでは、シーン内のエンティティ階層ごとにメッシュ�
 [material_asset]: /user-manual/assets/types/material/
 [texture_asset]: /user-manual/assets/types/texture/
 [template_asset]: /user-manual/editor/templates/
-[render_component]: https://api.playcanvas.com/classes/Engine.RenderComponent.html
-[collision_component]: https://api.playcanvas.com/classes/Engine.CollisionComponent.html
+[render_component]: https://api.playcanvas.com/engine/classes/RenderComponent.html
+[collision_component]: https://api.playcanvas.com/engine/classes/CollisionComponent.html
 [first_model_animation_import]: /tutorials/importing-first-model-and-animation/

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/editor/interface/assets.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/editor/interface/assets.md
@@ -122,4 +122,4 @@ Editorはコードで作成されたアセットの参照を検出できませ�
 [2]: /user-manual/editor/interface/inspector
 [3]: /user-manual/editor/interface/viewport
 [4]: /user-manual/editor/interface/settings
-[7]: https://api.playcanvas.com/classes/Engine.AssetRegistry.html#findByTag
+[7]: https://api.playcanvas.com/engine/classes/AssetRegistry.html#findByTag

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/advanced-rendering/batching.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/advanced-rendering/batching.md
@@ -88,6 +88,6 @@ if (element.batchGroupId)
 
 [6]: /user-manual/scenes/settings#batch-groups
 [7]: /user-manual/scenes/components/model
-[8]: https://api.playcanvas.com/classes/Engine.BatchManager.html
+[8]: https://api.playcanvas.com/engine/classes/BatchManager.html
 [9]: /user-manual/scenes/components/sprite
 [10]: /user-manual/scenes/components/element

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/advanced-rendering/hardware-instancing.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/advanced-rendering/hardware-instancing.md
@@ -28,7 +28,7 @@ for (let i = 0; i < instanceCount; i++) {
 }
 ```
 
-Create a VertexBuffer which stores per-instance state and initialize it with the matrices. In the following example, we use [`pc.VertexFormat.getDefaultInstancingFormat`](https://api.playcanvas.com/classes/Engine.VertexFormat.html#getDefaultInstancingFormat) which allows us to store a per-instance Mat4 matrix. Then we enable instancing on a MeshInstance, which contains the mesh geometry we want to instance.
+Create a VertexBuffer which stores per-instance state and initialize it with the matrices. In the following example, we use [`pc.VertexFormat.getDefaultInstancingFormat`](https://api.playcanvas.com/engine/classes/VertexFormat.html#getDefaultInstancingFormat) which allows us to store a per-instance Mat4 matrix. Then we enable instancing on a MeshInstance, which contains the mesh geometry we want to instance.
 
 ```javascript
 const instanceCount = 10;

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/cameras/depth-layer.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/cameras/depth-layer.md
@@ -26,8 +26,8 @@ sidebar_position: 2
 - GrabPass はColorバッファの使用を示します:[`GrabPass`] [2]
 - GroundFog はDepthバッファの使用を示します:[`GroundFog`] [3]
 
-[0]: https://api.playcanvas.com/classes/Engine.CameraComponent.html#requestSceneColorMap
-[1]: https://api.playcanvas.com/classes/Engine.CameraComponent.html#requestSceneDepthMap
+[0]: https://api.playcanvas.com/engine/classes/CameraComponent.html#requestSceneColorMap
+[1]: https://api.playcanvas.com/engine/classes/CameraComponent.html#requestSceneDepthMap
 [2]: https://playcanvas.github.io/#/graphics/grab-pass
 [3]: https://playcanvas.github.io/#/graphics/ground-fog
 [4]: /user-manual/graphics/layers/#choosing-the-layer-order

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/lighting/clustered-lighting.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/lighting/clustered-lighting.md
@@ -128,5 +128,5 @@ this.app.scene.lighting.debugLayer = undefined;
 ```
 
 [shadows]: /user-manual/graphics/lighting/shadows/#soft-shadows-vs-hard-shadows
-[pc-layer-api]: https://api.playcanvas.com/classes/Engine.Layer.html
-[pc-lighting-debug-layer-api]: https://api.playcanvas.com/classes/Engine.LightingParams.html#debugLayer
+[pc-layer-api]: https://api.playcanvas.com/engine/classes/Layer.html
+[pc-lighting-debug-layer-api]: https://api.playcanvas.com/engine/classes/LightingParams.html#debugLayer

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/particles.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/particles.md
@@ -41,5 +41,5 @@ this.entity.particlesystem.play();
 ソフトパーティクルは、シーンジオメトリと交差する場所近くでフェードアウトするパーティクルのことを意味します。[```depthSoftening```][5]を使用してSoftパーティクルを有効にした場合は、パーティクルを描画するカメラに[Depthマップ][6]レンダリングを有効にする必要があります。
 
 [4]: /user-manual/scenes/components/particlesystem
-[5]: https://api.playcanvas.com/classes/Engine.ParticleSystemComponent.html#depthSoftening
+[5]: https://api.playcanvas.com/engine/classes/ParticleSystemComponent.html#depthSoftening
 [6]: /user-manual/graphics/cameras/depth-layer

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/optimization/guidelines.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/optimization/guidelines.md
@@ -39,7 +39,7 @@ PlayCanvasアプリで最適なパフォーマンスを得るためのヒント�
 
 [1]: /user-manual/graphics/advanced-rendering/batching
 [2]: /user-manual/optimization/runtime-devicepixelratio
-[3]: https://api.playcanvas.com/classes/Engine.Application.html#autoRender
-[4]: https://api.playcanvas.com/classes/Engine.Application.html#renderNextFrame
-[5]: https://api.playcanvas.com/classes/Engine.RenderComponent.html#customAabb
-[6]: https://api.playcanvas.com/classes/Engine.ModelComponent.html#customAabb
+[3]: https://api.playcanvas.com/engine/classes/Application.html#autoRender
+[4]: https://api.playcanvas.com/engine/classes/Application.html#renderNextFrame
+[5]: https://api.playcanvas.com/engine/classes/RenderComponent.html#customAabb
+[6]: https://api.playcanvas.com/engine/classes/ModelComponent.html#customAabb

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/optimization/runtime-devicepixelratio.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/optimization/runtime-devicepixelratio.md
@@ -75,6 +75,6 @@ function isLowQualityGPU() {
 
 また、ユーザーが品質レベルを切り替えることができるオプションをアプリケーションに設けることをお勧めします。これにより、ユーザーは自分が快適に感じるレベルを選択し、デバイスのリソースを節約しバッテリー寿命を延ばすために品質を下げることも可能になります。
 
-[4]: https://api.playcanvas.com/classes/Engine.GraphicsDevice.html#maxPixelRatio
+[4]: https://api.playcanvas.com/engine/classes/GraphicsDevice.html#maxPixelRatio
 [5]: https://www.videocardbenchmark.net/GPU_mega_page.html
 [6]: https://www.notebookcheck.net/Smartphone-Graphics-Cards-Benchmark-List.149363.0.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/physics/forces-and-impulses.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/physics/forces-and-impulses.md
@@ -29,4 +29,4 @@ MyScript.prototype.update = function(dt) {
 };
 ```
 
-[1]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html
+[1]: https://api.playcanvas.com/engine/classes/RigidBodyComponent.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/animation.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/animation.md
@@ -28,4 +28,4 @@ Animationコンポーネントは、コンポーネントパネルの右上に�
 [Scriptコンポーネント][2]を使用してAnimationコンポーネントのプロパティを制御することができます。Animationコンポーネントのスクリプトインターフェースは[こちら][3]です。
 
 [2]: /user-manual/scenes/components/script
-[3]: https://api.playcanvas.com/classes/Engine.AnimationComponent.html
+[3]: https://api.playcanvas.com/engine/classes/AnimationComponent.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/audiolistener.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/audiolistener.md
@@ -14,4 +14,4 @@ Audio Listenerコンポーネントは、コンポーネントパネルの右上
 [Script component][2]を使用して、Audio Listenerコンポーネントのプロパティをコントロールできます。Audio Listenerコンポーネントのスクリプティングインターフェイスは[こちら][3]です。
 
 [2]: /user-manual/scenes/components/script
-[3]: https://api.playcanvas.com/classes/Engine.AudioListenerComponent.html
+[3]: https://api.playcanvas.com/engine/classes/AudioListenerComponent.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/button.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/button.md
@@ -47,4 +47,4 @@ Buttonコンポーネントのプロパティは、[Scriptコンポーネント]
 [1]: /user-manual/scenes/components/screen
 [2]: /user-manual/scenes/components/element
 [5]: /user-manual/scenes/components/script
-[6]: https://api.playcanvas.com/classes/Engine.ButtonComponent.html
+[6]: https://api.playcanvas.com/engine/classes/ButtonComponent.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/camera.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/camera.md
@@ -28,4 +28,4 @@ Cameraコンポーネントは、コンポーネントパネルの右上にあ�
 [Scriptコンポーネント][2]を使用して、Cameraコンポーネントのプロパティを制御できます。Cameraコンポーネントのスクリプトインターフェースは[こちら][3]です。
 
 [2]: /user-manual/scenes/components/script
-[3]: https://api.playcanvas.com/classes/Engine.CameraComponent.html
+[3]: https://api.playcanvas.com/engine/classes/CameraComponent.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/collision.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/collision.md
@@ -39,4 +39,4 @@ Collisionコンポーネントは、コンポーネントパネルの右上に�
 [Scriptコンポーネント][8]を使用してCollisionコンポーネントのプロパティを制御できます。Collisionコンポーネントのスクリプティングインターフェイスは[こちら][9]です。
 
 [8]: /user-manual/scenes/components/script
-[9]: https://api.playcanvas.com/classes/Engine.CollisionComponent.html
+[9]: https://api.playcanvas.com/engine/classes/CollisionComponent.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/gsplat.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/gsplat.md
@@ -17,4 +17,4 @@ The GSplat component can be enabled or disabled using the toggle in the top righ
 
 ## スクリプトインターフェース
 
-You can control the properties of a GSplat component using a [script component](../script). The scripting interface for the GSplat component is [here](https://api.playcanvas.com/classes/Engine.GSplatComponent.html).
+You can control the properties of a GSplat component using a [script component](../script). The scripting interface for the GSplat component is [here](https://api.playcanvas.com/engine/classes/GSplatComponent.html).

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/layout-child.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/layout-child.md
@@ -26,4 +26,4 @@ LayoutChildコンポーネントは、LayoutGroupコンポーネントによっ�
 
 [0]: /user-manual/user-interface/layout-groups
 [2]: /user-manual/scenes/components/script
-[3]: https://api.playcanvas.com/classes/Engine.LayoutChildComponent.html
+[3]: https://api.playcanvas.com/engine/classes/LayoutChildComponent.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/layout-group.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/layout-group.md
@@ -28,4 +28,4 @@ LayoutGroupコンポーネントは、エンティティが子ElementのElement�
 
 [0]: /user-manual/user-interface/layout-groups
 [2]: /user-manual/scenes/components/script
-[3]: https://api.playcanvas.com/classes/Engine.LayoutGroupComponent.html
+[3]: https://api.playcanvas.com/engine/classes/LayoutGroupComponent.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/light.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/light.md
@@ -45,4 +45,4 @@ Lightコンポーネントは、コンポーネントパネルの右上にある
 Lightコンポーネントのプロパティを[Scriptコンポーネント][4]を使用して制御できます。Lightコンポーネントのスクリプトインターフェースは[こちら][5]です。
 
 [4]: /user-manual/scenes/components/script
-[5]: https://api.playcanvas.com/classes/Engine.LightComponent.html
+[5]: https://api.playcanvas.com/engine/classes/LightComponent.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/model.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/model.md
@@ -36,6 +36,6 @@ Modelコンポーネントは、コンポーネントパネルの右上にある
 モデルのマテリアルをカスタマイズする方法については、[こちら][4]を参照してください。
 
 [2]: /user-manual/scenes/components/script
-[3]: https://api.playcanvas.com/classes/Engine.ModelComponent.html
+[3]: https://api.playcanvas.com/engine/classes/ModelComponent.html
 [4]: /user-manual/assets/types/material/#assigning-materials
 [5]: /user-manual/graphics/advanced-rendering/batching

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/particlesystem.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/particlesystem.md
@@ -48,4 +48,4 @@ Particle Systemコンポーネントは、コンポーネントパネルの右�
 Particle Systemコンポーネントのプロパティは[script component][2]を使用して制御できます。Particle Systemコンポーネントのスクリプティングインターフェイスは[こちら][3]です。
 
 [2]: /user-manual/scenes/components/script
-[3]: https://api.playcanvas.com/classes/Engine.ParticleSystemComponent.html
+[3]: https://api.playcanvas.com/engine/classes/ParticleSystemComponent.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/render.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/render.md
@@ -28,4 +28,4 @@ Renderコンポーネントは、コンポーネントパネルの右上にあ�
 [Scriptコンポーネント][2]を使用して、Renderコンポーネントのプロパティを制御できます。Renderコンポーネントのスクリプトインタフェースは[こちら][3]です。
 
 [2]: /user-manual/scenes/components/script
-[3]: https://api.playcanvas.com/classes/Engine.RenderComponent.html
+[3]: https://api.playcanvas.com/engine/classes/RenderComponent.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/rigidbody.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/rigidbody.md
@@ -39,4 +39,4 @@ Note that you must add a [collision component][4] to the same entity in order to
 
 [4]: /user-manual/scenes/components/collision/
 [5]: /user-manual/scenes/components/script
-[6]: https://api.playcanvas.com/classes/Engine.RigidBodyComponent.html
+[6]: https://api.playcanvas.com/engine/classes/RigidBodyComponent.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/script.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/script.md
@@ -20,4 +20,4 @@ PlayCanvasコードエディターでスクリプトを編集するには、リ�
 
 Scriptコンポーネントのスクリプトのインターフェースは[こちら][2]から確認できます。
 
-[2]: https://api.playcanvas.com/classes/Engine.ScriptComponent.html
+[2]: https://api.playcanvas.com/engine/classes/ScriptComponent.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/sound.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/sound.md
@@ -44,4 +44,4 @@ Soundコンポーネントは、コンポーネントパネルの右上にある
 [Scriptコンポーネント][2]を使用して、Soundコンポーネントのプロパティを制御することができます。Soundコンポーネントのスクリプトインターフェイスは[こちら][3]です。
 
 [2]: /user-manual/scenes/components/script
-[3]: https://api.playcanvas.com/classes/Engine.SoundComponent.html
+[3]: https://api.playcanvas.com/engine/classes/SoundComponent.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/sprite.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/components/sprite.md
@@ -64,5 +64,5 @@ Spriteコンポーネントは、[Spriteアセット][1]をシーンに表示さ
 
 [1]: /user-manual/assets/types/sprite
 [4]: /user-manual/scenes/components/script
-[5]: https://api.playcanvas.com/classes/Engine.SpriteComponent.html
+[5]: https://api.playcanvas.com/engine/classes/SpriteComponent.html
 [6]: /user-manual/graphics/advanced-rendering/batching

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/loading-scenes.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scenes/loading-scenes.md
@@ -74,7 +74,7 @@ Sometimes developers use this approach to ensure that certain code and entities 
 
 :::note
 
-[アプリケーションルートノード](https://api.playcanvas.com/classes/Engine.Application.html#root)は、エディタで見ることができるデフォルトで 'Root' と名前が付けられたシーンヒエラルキールートエンティティではありません。シーンヒエラルキールートエンティティは、アプリケーションルートノードの子になります。
+[アプリケーションルートノード](https://api.playcanvas.com/engine/classes/Application.html#root)は、エディタで見ることができるデフォルトで 'Root' と名前が付けられたシーンヒエラルキールートエンティティではありません。シーンヒエラルキールートエンティティは、アプリケーションルートノードの子になります。
 
 :::
 
@@ -200,15 +200,15 @@ this.app.scenes.loadSceneHierarchy(sceneItem, function (err, loadedSceneRootEnti
 [additively-loading-scenes-project]: https://playcanvas.com/project/685077/overview/additive-loading-scenes
 [templates]: /user-manual/editor/templates/
 [assets]: /user-manual/assets/
-[loadscenehierarchy-api]: https://api.playcanvas.com/classes/Engine.SceneRegistry.html#loadSceneHierarchy
-[loadscenesettings-api]: https://api.playcanvas.com/classes/Engine.SceneRegistry.html#loadSceneSettings
-[sceneregistryitem-api]: https://api.playcanvas.com/classes/Engine.SceneRegistryItem.html
-[sceneregistry-api]: https://api.playcanvas.com/classes/Engine.SceneRegistry.html
-[application-sceneregistry-api]: https://api.playcanvas.com/classes/Engine.Application.html#scenes
+[loadscenehierarchy-api]: https://api.playcanvas.com/engine/classes/SceneRegistry.html#loadSceneHierarchy
+[loadscenesettings-api]: https://api.playcanvas.com/engine/classes/SceneRegistry.html#loadSceneSettings
+[sceneregistryitem-api]: https://api.playcanvas.com/engine/classes/SceneRegistryItem.html
+[sceneregistry-api]: https://api.playcanvas.com/engine/classes/SceneRegistry.html
+[application-sceneregistry-api]: https://api.playcanvas.com/engine/classes/Application.html#scenes
 [loadhierarchycallback-api]: https://api.playcanvas.com/modules/Engine.html#LoadHierarchyCallback
 [loadsettingscallback-api]: https://api.playcanvas.com/modules/Engine.html#LoadSettingsCallback
-[application-root-api]: https://api.playcanvas.com/classes/Engine.Application.html#root
-[loadscenedata-api]: https://api.playcanvas.com/classes/Engine.SceneRegistry.html#loadSceneData
+[application-root-api]: https://api.playcanvas.com/engine/classes/Application.html#root
+[loadscenedata-api]: https://api.playcanvas.com/engine/classes/SceneRegistry.html#loadSceneData
 [asset-tags-loading]: /user-manual/assets/preloading-and-streaming/#asset-tags
 [asset-load-for-scene-project]: https://playcanvas.com/project/926754/overview/asset-loading-for-scenes-example
-[changescene-api]: https://api.playcanvas.com/classes/Engine.SceneRegistry.html#changeScene
+[changescene-api]: https://api.playcanvas.com/engine/classes/SceneRegistry.html#changeScene

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scripting/communication.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scripting/communication.md
@@ -94,4 +94,4 @@ Display.prototype.initialize = function () {
 
 ご覧の通り、これにより設定コードを減らし、よりクリーンなコードになります。
 
-[1]: https://api.playcanvas.com/classes/Engine.EventHandler.html
+[1]: https://api.playcanvas.com/engine/classes/EventHandler.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scripting/creating-new.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scripting/creating-new.md
@@ -41,4 +41,4 @@ entity.script.create("rotate", {
 entity.script.destroy("rotate");
 ```
 
-[3]: https://api.playcanvas.com/classes/Engine.AssetRegistry.html#load
+[3]: https://api.playcanvas.com/engine/classes/AssetRegistry.html#load

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scripting/script-attributes.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scripting/script-attributes.md
@@ -179,4 +179,4 @@ MyScript.prototype.update = function (dt) {
 
 :::
 
-[3]: https://api.playcanvas.com/classes/Engine.ScriptAttributes.html
+[3]: https://api.playcanvas.com/engine/classes/ScriptAttributes.html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/user-interface/localization.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/user-interface/localization.md
@@ -128,9 +128,9 @@ console.log(localeNumberString);
 ローカライゼーションのための完全なエンジンAPIリファレンスについては、[このページ][2]を参照してください。
 
 [1]: https://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html
-[2]: https://api.playcanvas.com/classes/Engine.I18n.html
-[3]: https://api.playcanvas.com/classes/Engine.I18n.html#getText
-[4]: https://api.playcanvas.com/classes/Engine.I18n.html#getPluralText
+[2]: https://api.playcanvas.com/engine/classes/I18n.html
+[3]: https://api.playcanvas.com/engine/classes/I18n.html#getText
+[4]: https://api.playcanvas.com/engine/classes/I18n.html#getPluralText
 [5]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString
 [6]: http://www.thai-language.com/ref/breaking-words
 [7]: https://en.wikipedia.org/wiki/Zero-width_space

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/xr/hand-tracking.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/xr/hand-tracking.md
@@ -52,7 +52,7 @@ A skinned mesh for a hand can used. You can check out [this project][5] as an ex
 <img loading="lazy" src="/img/user-manual/xr/skinned-hands.webp" alt="Hand tracking using skinned meshes" width="512" />
 
 [1]: https://immersive-web.github.io/webxr-hand-input/
-[2]: https://api.playcanvas.com/classes/Engine.XrHand.html
-[3]: https://api.playcanvas.com/classes/Engine.XrFinger.html
-[4]: https://api.playcanvas.com/classes/Engine.XrJoint.html
+[2]: https://api.playcanvas.com/engine/classes/XrHand.html
+[3]: https://api.playcanvas.com/engine/classes/XrFinger.html
+[4]: https://api.playcanvas.com/engine/classes/XrJoint.html
 [5]: https://playcanvas.com/project/771952/overview/webxr-realistic-hands

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/xr/input-sources.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/xr/input-sources.md
@@ -164,9 +164,9 @@ entity.button.on('selectstart', (evt) => {
 });
 ```
 
-[1]: https://api.playcanvas.com/classes/Engine.XrInputSource.html
-[2]: https://api.playcanvas.com/classes/Engine.XrInput.html
-[3]: https://api.playcanvas.com/classes/Engine.XrManager.html
+[1]: https://api.playcanvas.com/engine/classes/XrInputSource.html
+[2]: https://api.playcanvas.com/engine/classes/XrInput.html
+[3]: https://api.playcanvas.com/engine/classes/XrManager.html
 [4]: https://www.w3.org/TR/webxr-gamepads-module-1/
 [5]: https://w3c.github.io/gamepad/
 [6]: https://github.com/immersive-web/webxr-input-profiles/tree/master/packages/registry

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/xr/using-webxr.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/xr/using-webxr.md
@@ -105,4 +105,4 @@ Position, orientation and rays of different XR objects: input sources, tracked m
 
 Entering WebXR is required by browsers to be triggered by a *user action*. That means that it must be in response to a key press, a mouse click or a touch event. For that reason, there is no way to enter XR immediately on loading a page.
 
-[2]: https://api.playcanvas.com/classes/Engine.XrManager.html
+[2]: https://api.playcanvas.com/engine/classes/XrManager.html


### PR DESCRIPTION
API Reference URL format has changed recently.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/main/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
