### PR TITLE
Engine semantic versioning

### DIFF
--- a/docs/user-manual/engine/versioning.md
+++ b/docs/user-manual/engine/versioning.md
@@ -27,7 +27,7 @@ This type of release follows the standard outlined by [semantic versioning](http
 
 :::important
 
-If you are using the engine with NPM it is recommended to use the `~X.X.X` notation to pin the major and minor version numbers and only update to the latest patch
+If you are using the engine with NPM it is recommended to use the `~X.X.X` notation to pin the major and minor version numbers and only update to the latest patch.
 
 :::
 


### PR DESCRIPTION
Migrates engine versioning issue [here](https://github.com/playcanvas/engine/issues/7799) to a dedicated page outlining engine version structure and what each version represents.