### PR TITLE
Fix SOG shN ordering and clear up filenames

### DIFF
--- a/docs/user-manual/gaussian-splatting/formats/sog.md
+++ b/docs/user-manual/gaussian-splatting/formats/sog.md
@@ -226,7 +226,7 @@ const a = sh0.a / 255;
 
 ### 3.5 Higher-order SH (optional)
 
-> `shN_labels.webp`, `shN_centroids.webp`
+> `shN_centroids.webp`, `shN_labels.webp`
 
 If present, higher-order (AC) SH coefficients are stored via a palette:
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/gaussian-splatting/formats/sog.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/gaussian-splatting/formats/sog.md
@@ -226,20 +226,12 @@ const a = sh0.a / 255;
 
 ### 3.5 高次SH (オプション)
 
-> `shN_labels.webp`, `shN_centroids.webp`
+> `shN_centroids.webp`, `shN_labels.webp`
 
 存在する場合、高次 (AC) SH係数はパレットを介して格納されます。
 
 * `shN.count` ∈ **\[1,64k]** エントリの数。
 * `shN.bands` ∈ **\[1,3]** エントリあたりのバンド数。
-
-#### ラベル
-
-* `shN_labels.webp` は、Gaussianごとに範囲 (0..count-1) の**16ビットインデックス**を格納します。
-
-```ts
-const index = shN_labels.r + (shN_labels.g << 8);
-```
 
 #### セントロイド (パレット)
 
@@ -260,6 +252,14 @@ const index = shN_labels.r + (shN_labels.g << 8);
 const coeffs = [3, 8, 15];
 const u = (n % 64) * coeffs[bands] + c;
 const v = Math.floor(n / 64);
+```
+
+#### ラベル
+
+* `shN_labels.webp` は、Gaussianごとに範囲 (0..count-1) の**16ビットインデックス**を格納します。
+
+```ts
+const index = shN_labels.r + (shN_labels.g << 8);
 ```
 
 ---


### PR DESCRIPTION
Address issues raised in https://github.com/playcanvas/splat-transform/issues/120.

This PR:
- fixes the example meta.json filename ordering
- adds a note on meta.json filenames and their ordering