### PR TITLE
docs: correct useApp camera lookup

### DIFF
--- a/docs/user-manual/react/api/hooks/use-app.mdx
+++ b/docs/user-manual/react/api/hooks/use-app.mdx
@@ -14,13 +14,16 @@ function MyComponent() {
   
   // Access application properties
   console.log('Scene:', app.scene)
-  console.log('Camera:', app.scene.camera)
+  
+  // Cameras are components on entities, so look them up from the root
+  const cameras = app.root.findComponents('camera')
+  console.log('Cameras:', cameras)
   
   return null
 }
 ```
 
-A reference to the app gives you access to the scene, camera, systems, etc.
+A reference to the app gives you access to the scene, root entity, systems, assets, events, etc.
 
 ## Application context
 


### PR DESCRIPTION
## Summary
- replace `app.scene.camera` in `useApp` docs with a correct camera component lookup
- Fixes the confusion caused in https://github.com/playcanvas/react/issues/311
- https://api.playcanvas.com/engine/classes/Scene.html 