### PR TITLE
docs: Add url field to App REST API response schemas

### DIFF
--- a/docs/user-manual/api/app-get-primary.md
+++ b/docs/user-manual/api/app-get-primary.md
@@ -49,7 +49,8 @@ Status: 200
     "views": int,
     "completed_at": date,
     "created_at": date,
-    "modified_at": date
+    "modified_at": date,
+    "url": string
 }
 ```
 

--- a/docs/user-manual/api/app-get-project.md
+++ b/docs/user-manual/api/app-get-project.md
@@ -50,7 +50,8 @@ Status: 200
     "views": int,
     "completed_at": date,
     "created_at": date,
-    "modified_at": date
+    "modified_at": date,
+    "url": string
   }, ... ],
   "pagination": {
      ...

--- a/docs/user-manual/api/app-get.md
+++ b/docs/user-manual/api/app-get.md
@@ -49,7 +49,8 @@ Status: 200
     "views": int,
     "completed_at": date,
     "created_at": date,
-    "modified_at": date
+    "modified_at": date,
+    "url": string
 }
 ```
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/api/app-get-primary.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/api/app-get-primary.md
@@ -49,7 +49,8 @@ curl -H "Authorization: Bearer {accessToken}" https://playcanvas.com/api/project
     "views": int,
     "completed_at": date,
     "created_at": date,
-    "modified_at": date
+    "modified_at": date,
+    "url": string
 }
 ```
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/api/app-get-project.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/api/app-get-project.md
@@ -50,7 +50,8 @@ curl -H "Authorization: Bearer {accessToken}" https://playcanvas.com/api/project
     "views": int,
     "completed_at": date,
     "created_at": date,
-    "modified_at": date
+    "modified_at": date,
+    "url": string
   }, ... ],
   "pagination": {
      ...

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/api/app-get.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/api/app-get.md
@@ -49,7 +49,8 @@ curl -H "Authorization: Bearer {accessToken}" https://playcanvas.com/api/apps/{i
     "views": int,
     "completed_at": date,
     "created_at": date,
-    "modified_at": date
+    "modified_at": date,
+    "url": string
 }
 ```
 


### PR DESCRIPTION
## Summary

- Adds the `url` field to the response schema documentation for the App REST API endpoints: `GET /api/apps/:id`, `GET /api/projects/:projectId/app`, and `GET /api/projects/:projectId/apps`
- Updates both English and Japanese documentation

The publish URL (e.g. `https://playcanv.as/b/{hash}`) is being added to the public API responses in the backend. This PR updates the docs to match.

Fixes https://github.com/playcanvas/editor/issues/894