### PR TITLE
docs: Fix project export API parameter name to match route URL

### DIFF
--- a/docs/user-manual/api/project-export.md
+++ b/docs/user-manual/api/project-export.md
@@ -17,14 +17,14 @@ The request will start an export job and the job details will be returned in the
 ## Example
 
 ```none
-curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json" -X POST -d '{"branch_id": "99999999-9999-9999-9999-999999999999"}' "https://playcanvas.com/api/projects/{projectId}/export"
+curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json" -X POST -d '{"branch_id": "99999999-9999-9999-9999-999999999999"}' "https://playcanvas.com/api/projects/{id}/export"
 ```
 
 ## Parameters
 
 | Name        | Type     | Required | Description                                                                |
 | ----------- | -------- | :------: | -------------------------------------------------------------------------- |
-| `projectId` | `number` | ✔️      | The id of the project.                                                     |
+| `id`        | `number` | ✔️      | The id of the project.                                                     |
 | `branch_id` | `string` |          | The id of the branch. If no id is specified, the main branch will be used. |
 
 ## Response Schema

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/api/project-export.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/api/project-export.md
@@ -17,14 +17,14 @@ POST https://playcanvas.com/api/projects/:id/export
 ## 例
 
 ```none
-curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json" -X POST -d '{"branch_id": "99999999-9999-9999-9999-999999999999"}' "https://playcanvas.com/api/projects/{projectId}/export"
+curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json" -X POST -d '{"branch_id": "99999999-9999-9999-9999-999999999999"}' "https://playcanvas.com/api/projects/{id}/export"
 ```
 
 ## パラメーター
 
 | 名前        | タイプ     | Required | 説明                                                                |
 | ----------- | -------- | :------: | -------------------------------------------------------------------------- |
-| `projectId` | `number` | ✔️      | The id of the project.                                                     |
+| `id`        | `number` | ✔️      | The id of the project.                                                     |
 | `branch_id` | `string` |          | The id of the branch. If no id is specified, the main branch will be used. |
 
 ## レスポンススキーマ


### PR DESCRIPTION
## Summary

- Rename `projectId` to `id` in the project export API parameter table and curl example to match the route URL pattern (`POST .../projects/:id/export`) and the convention used in other endpoint docs (`app-get`, `job-get`, `checkpoint-get`)
- Apply the same fix to the Japanese translation

## Test plan

- [ ] Verify the parameter table shows `id` instead of `projectId`
- [ ] Verify the curl example uses `{id}` instead of `{projectId}`
- [ ] Verify the Japanese translation matches


Made with [Cursor](https://cursor.com)