### PR TITLE
Add LCC file example to LOD format generation docs

### DIFF
--- a/docs/user-manual/gaussian-splatting/editing/splat-transform.md
+++ b/docs/user-manual/gaussian-splatting/editing/splat-transform.md
@@ -363,6 +363,10 @@ node --max-old-space-size=32000 node_modules/.bin/splat-transform \
   output/lod-meta.json \
   --filter-nan \
   --filter-harmonics 0
+
+# Generate LOD streaming format directly from an LCC file
+# (LCC files already contain multiple LOD levels)
+splat-transform scene.lcc output/lod-meta.json
 ```
 
 **Tips:**

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/gaussian-splatting/editing/splat-transform.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/gaussian-splatting/editing/splat-transform.md
@@ -363,6 +363,10 @@ node --max-old-space-size=32000 node_modules/.bin/splat-transform \
   output/lod-meta.json \
   --filter-nan \
   --filter-harmonics 0
+
+# LCCファイルから直接LODストリーミング形式を生成
+# (LCCファイルには複数のLODレベルが既に含まれています)
+splat-transform scene.lcc output/lod-meta.json
 ```
 
 **ヒント:**


### PR DESCRIPTION
Add a command line example showing how to generate LOD streaming format directly from an LCC file, since LCC files already contain multiple LOD levels internally. Updated both English and Japanese documentation.

**Changes:**
- Add `splat-transform scene.lcc output/lod-meta.json` example to the "Generating LOD Format" section in SplatTransform docs