### PR TITLE
Add React API landing page

### DIFF
--- a/docs/user-manual/react/api/index.md
+++ b/docs/user-manual/react/api/index.md
@@ -1,0 +1,39 @@
+---
+title: API
+description: API reference for PlayCanvas React components and hooks
+---
+
+PlayCanvas React provides a declarative, component-based API for building 3D applications. The API is organized into core components, engine components and hooks.
+
+## Core
+
+- **[`<Application/>`](./application)** - Root component that initializes the PlayCanvas engine and provides a rendering context
+- **[`<Entity/>`](./entity)** - Fundamental scene graph building block with position, rotation and scale
+- **[`<Gltf/>`](./gltf)** - Load and instantiate GLB/GLTF scenes
+- **[`<Modify.*>`](./modify)** - Declaratively modify entities and components inside an imported GLB
+
+## Components
+
+Components add behavior to entities. Nest them inside an `<Entity/>` to attach the corresponding PlayCanvas component.
+
+- **[`<Anim/>`](./anim)** - State-based animation
+- **[`<Align/>`](./align)** - Alignment helper
+- **[`<Camera/>`](./camera)** - Camera and viewport
+- **[`<Collision/>`](./collision)** - Physics collision shapes
+- **[`<Environment/>`](./environment)** - Scene environment and skybox
+- **[`<GSplat/>`](./gsplat)** - Gaussian splat rendering
+- **[`<Light/>`](./light)** - Directional, point and spot lights
+- **[`<Render/>`](./render)** - Mesh rendering (primitives and assets)
+- **[`<Rigidbody/>`](./rigidbody)** - Physics rigid bodies
+- **[`<Script/>`](./script)** - Custom script components
+
+## Hooks
+
+React hooks for integrating with the PlayCanvas engine lifecycle. See the [Hooks overview](./hooks/) for usage patterns and best practices.
+
+- **[useApp](./hooks/use-app)** - Access the PlayCanvas Application instance
+- **[useParent](./hooks/use-parent)** - Get the parent Entity from context
+- **[useAsset](./hooks/use-asset)** - Load any type of PlayCanvas asset
+- **[useAppEvent](./hooks/use-app-event)** - Subscribe to application events
+- **[useMaterial](./hooks/use-material)** - Create and manage materials
+- **[usePhysics](./hooks/use-physics)** - Access physics context and state

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/react/api/index.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/react/api/index.md
@@ -1,0 +1,39 @@
+---
+title: API
+description: PlayCanvas ReactコンポーネントとフックのAPIリファレンス
+---
+
+PlayCanvas Reactは、3Dアプリケーションを構築するための宣言的なコンポーネントベースのAPIを提供します。APIはコアコンポーネント、エンジンコンポーネント、フックで構成されています。
+
+## コア
+
+- **[`<Application/>`](./application)** - PlayCanvas Engineを初期化し、レンダリングコンテキストを提供するルートコンポーネント
+- **[`<Entity/>`](./entity)** - 位置、回転、スケールを持つシーングラフの基本的な構成要素
+- **[`<Gltf/>`](./gltf)** - GLB/GLTFシーンの読み込みとインスタンス化
+- **[`<Modify.*>`](./modify)** - インポートしたGLB内のEntityとComponentを宣言的に変更
+
+## コンポーネント
+
+コンポーネントはEntityに動作を追加します。`<Entity/>`内にネストして、対応するPlayCanvas Componentをアタッチします。
+
+- **[`<Anim/>`](./anim)** - ステートベースのアニメーション
+- **[`<Align/>`](./align)** - 整列ヘルパー
+- **[`<Camera/>`](./camera)** - カメラとビューポート
+- **[`<Collision/>`](./collision)** - 物理コリジョン形状
+- **[`<Environment/>`](./environment)** - シーン環境とスカイボックス
+- **[`<GSplat/>`](./gsplat)** - Gaussian Splatレンダリング
+- **[`<Light/>`](./light)** - ディレクショナル、ポイント、スポットライト
+- **[`<Render/>`](./render)** - メッシュレンダリング（プリミティブとアセット）
+- **[`<Rigidbody/>`](./rigidbody)** - 物理リジッドボディ
+- **[`<Script/>`](./script)** - カスタムスクリプトコンポーネント
+
+## フック
+
+PlayCanvas Engineのライフサイクルと統合するためのReactフックです。使用パターンとベストプラクティスについては、[フックの概要](./hooks/)を参照してください。
+
+- **[useApp](./hooks/use-app)** - PlayCanvas Applicationインスタンスへのアクセス
+- **[useParent](./hooks/use-parent)** - コンテキストから親Entityを取得
+- **[useAsset](./hooks/use-asset)** - あらゆる種類のPlayCanvas Assetの読み込み
+- **[useAppEvent](./hooks/use-app-event)** - Applicationイベントの購読
+- **[useMaterial](./hooks/use-material)** - マテリアルの作成と管理
+- **[usePhysics](./hooks/use-physics)** - 物理コンテキストと状態へのアクセス

--- a/sidebars.js
+++ b/sidebars.js
@@ -426,6 +426,10 @@ const sidebars = {
         {
           type: 'category',
           label: 'API',
+          link: {
+            type: 'doc',
+            id: 'user-manual/react/api/index',
+          },
           items: [
             'user-manual/react/api/application',
             'user-manual/react/api/entity',


### PR DESCRIPTION
## Summary

- Add an API landing page (`docs/user-manual/react/api/index.md`) so `/user-manual/react/api` resolves to an overview of all React components and hooks
- Update `sidebars.js` to link the API category to the new page
- Add Japanese translation

## Test plan

- [x] Run `npm run start` and verify `/user-manual/react/api` renders the new page
- [x] Verify the API sidebar category is clickable and navigates to the landing page
- [x] Run `npm run start -- --locale ja` and verify the Japanese translation renders
