### PR TITLE
Add missing direct dependencies for js-yaml and gray-matter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "canvas-confetti": "^1.9.4",
         "clsx": "^2.1.1",
         "docusaurus-plugin-sass": "^0.2.6",
+        "js-yaml": "^4.1.1",
         "leva": "^0.10.1",
         "playcanvas": "^2.17.2",
         "prism-react-renderer": "^2.4.1",
@@ -36,6 +37,7 @@
       "devDependencies": {
         "@docusaurus/module-type-aliases": "^3.10.0",
         "@docusaurus/types": "^3.10.0",
+        "gray-matter": "^4.0.3",
         "markdownlint-cli2": "^0.22.0",
         "marked": "^18.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "canvas-confetti": "^1.9.4",
     "clsx": "^2.1.1",
     "docusaurus-plugin-sass": "^0.2.6",
+    "js-yaml": "^4.1.1",
     "leva": "^0.10.1",
     "playcanvas": "^2.17.2",
     "prism-react-renderer": "^2.4.1",
@@ -64,6 +65,7 @@
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.10.0",
     "@docusaurus/types": "^3.10.0",
+    "gray-matter": "^4.0.3",
     "markdownlint-cli2": "^0.22.0",
     "marked": "^18.0.0"
   },


### PR DESCRIPTION
## Summary

- Add `js-yaml` as a direct dependency (used by `docusaurus-plugin-llms` during build)
- Add `gray-matter` as a direct dev dependency (used by `generate-tutorial-data` script)

Both packages were previously only available as transitive dependencies of `@docusaurus/core`. Relying on transitive dependencies is fragile — a patch update to Docusaurus could drop or change them, breaking the build or utility scripts.

## Test plan

- [x] `npm run build` passes
- [x] `npm run generate-tutorial-data` passes
