### PR TITLE
docs: document WGSL language extensions (EN + JA)

### DIFF
--- a/docs/user-manual/graphics/shaders/compute-shaders.md
+++ b/docs/user-manual/graphics/shaders/compute-shaders.md
@@ -21,6 +21,10 @@ if (device.supportsCompute) {
 }
 ```
 
+## WGSL language extensions
+
+When the browser exposes optional WGSL features (for example [linear workgroup / invocation indexing](https://developer.chrome.com/blog/new-in-webgpu-147-148#wgsl_linear_indexing_extension), subgroups, or half-float), the engine sets the matching `device.supports*` flags and `CAPS_*` preprocessor defines. For a full list and usage notes, see [WGSL language extensions](/user-manual/graphics/shaders/wgsl-specifics#wgsl-language-extensions).
+
 ## Creating a Compute Shader
 
 A compute shader is created using the `Shader` class with WGSL code. The shader definition includes the compute shader source (`cshader`), bind group format, and optionally uniform buffer formats.

--- a/docs/user-manual/graphics/shaders/wgsl-specifics.md
+++ b/docs/user-manual/graphics/shaders/wgsl-specifics.md
@@ -180,7 +180,7 @@ struct Particle {
 var<storage, read> particles: array<Particle>;
 ```
 
-### Half-Precision Types
+### Half-Precision Types {#half-precision-types}
 
 When the device supports 16-bit floating-point operations (`device.supportsShaderF16`), shaders can use native WGSL half-precision types for improved performance and reduced memory bandwidth:
 
@@ -275,7 +275,7 @@ pcPrimitiveIndex  // when supported
 
 :::note
 
-The `primitiveIndex` / `pcPrimitiveIndex` built-in is only available when `device.supportsPrimitiveIndex` is true. This feature is WebGPU-only (not available on WebGL2). When the feature is supported, the engine automatically adds the required `enable primitive_index;` WGSL directive and the shader define `CAPS_PRIMITIVE_INDEX` is available for conditional compilation.
+The `primitiveIndex` / `pcPrimitiveIndex` built-in is only available when `device.supportsPrimitiveIndex` is true. This feature is WebGPU-only (not available on WebGL2). See [WGSL language extensions](#wgsl-language-extensions) for `enable primitive_index;` and `CAPS_PRIMITIVE_INDEX`.
 
 :::
 
@@ -321,3 +321,58 @@ Example:
 Support for rendering to integer textures (output format other than `vec4f`) is not available yet, and will be added in the future.
 
 :::
+
+### WGSL language extensions {#wgsl-language-extensions}
+
+At device creation, the engine reads `navigator.gpu.wgslLanguageFeatures` and adds the necessary `enable …;` and `requires …;` directives to generated WGSL so shaders can use optional language features. Your shader source can branch on the matching `CAPS_*` defines (merged with your own `vertexDefines`, `fragmentDefines`, and `cdefines` on the `Shader` definition, where applicable).
+
+- **`device.supportsShaderF16`**
+  - **Engine injects:** `enable f16;`
+  - **Preprocessor define:** `CAPS_SHADER_F16`
+  - **Shader stages:** vertex, fragment, and compute
+  - **Details:** [Half-precision types](#half-precision-types) on this page, plus the engine’s `half` / `half2` / … aliases
+- **`device.supportsPrimitiveIndex`**
+  - **Engine injects:** `enable primitive_index;`
+  - **Preprocessor define:** `CAPS_PRIMITIVE_INDEX`
+  - **Shader stages:** fragment
+  - **Details:** Simplified API exposes `primitiveIndex` on `FragmentInput` and the global `pcPrimitiveIndex` when the device supports the feature
+- **`device.supportsSubgroups`**
+  - **Engine injects:** `enable subgroups;`
+  - **Preprocessor define:** `CAPS_SUBGROUPS`
+  - **Shader stages:** fragment and compute
+  - **Details:** Subgroup builtins (`subgroupBroadcast`, `subgroupAdd`, …). `device.supportsSubgroupUniformity` does not add a separate `requires` or `enable` line; the driver uses it together with the subgroups feature
+- **`device.supportsSubgroupId`**
+  - **Engine injects:** `requires subgroup_id;`
+  - **Preprocessor define:** `CAPS_SUBGROUP_ID`
+  - **Shader stages:** whatever stages the engine compiles that shader module to as WGSL (typically all relevant stages in your `Shader` definition)
+  - **Details:** `subgroup_id` and `num_subgroups` built-ins in workgroups
+- **`device.supportsLinearIndexing`**
+  - **Engine injects:** `requires linear_indexing;` (compute **module** entries only, not vertex/fragment)
+  - **Preprocessor define:** `CAPS_LINEAR_INDEXING`
+  - **Shader stages:** compute
+  - **Details:** `global_invocation_index` and `workgroup_index`; see the [WebGPU 147-148](https://developer.chrome.com/blog/new-in-webgpu-147-148#wgsl_linear_indexing_extension) overview
+- **`device.supportsStorageTextureRead`**
+  - **Engine injects:** *(none)* — add `requires readonly_and_readwrite_storage_textures;` in your own WGSL if you read from storage textures
+  - **Preprocessor define:** `CAPS_STORAGE_TEXTURE_READ` (set when the device can load from storage textures; use to share code paths)
+  - **Shader stages:** compute, when you use the feature
+  - **Details:** The engine only advertises the capability; the `requires` line is author-written so usage stays explicit
+
+Example (compute) — use a linear workgroup index when `CAPS_LINEAR_INDEXING` is set, otherwise fall back to manual layout math:
+
+```wgsl
+@compute @workgroup_size(64, 1, 1)
+fn main(
+    @builtin(global_invocation_id) global_id: vec3u,
+    @builtin(num_workgroups) nwg: vec3u,
+#ifdef CAPS_LINEAR_INDEXING
+    @builtin(workgroup_index) flat_wg: u32,
+#endif
+) {
+#ifdef CAPS_LINEAR_INDEXING
+    let wg = flat_wg;
+#else
+    let wg = global_id.x; // 1D dispatch; extend for 2D/3D as needed
+#endif
+    _ = wg;
+}
+```

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/compute-shaders.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/compute-shaders.md
@@ -21,6 +21,10 @@ if (device.supportsCompute) {
 }
 ```
 
+## WGSL 言語拡張
+
+ブラウザが任意の WGSL 機能（例: [線形ワーカー / 呼び出しインデックス](https://developer.chrome.com/blog/new-in-webgpu-147-148#wgsl_linear_indexing_extension)、サブグループ、半精度 float）を公開している場合、エンジンは対応する `device.supports*` フラグと `CAPS_*` プリプロセッサ定義を設定します。一覧と注意点は [WGSL の詳細 — 言語拡張](/user-manual/graphics/shaders/wgsl-specifics#wgsl-language-extensions) を参照してください。
+
 ## コンピュートシェーダーの作成
 
 コンピュートシェーダーは、WGSLコードを使用して`Shader`クラスで作成されます。シェーダー定義には、コンピュートシェーダーソース（`cshader`）、バインドグループフォーマット、およびオプションでユニフォームバッファフォーマットが含まれます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/wgsl-specifics.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/wgsl-specifics.md
@@ -180,7 +180,7 @@ struct Particle {
 var<storage, read> particles: array<Particle>;
 ```
 
-### 半精度型
+### 半精度型 {#half-precision-types}
 
 デバイスが16ビット浮動小数点演算をサポートしている場合（`device.supportsShaderF16`）、シェーダーはネイティブWGSL半精度型を使用してパフォーマンスを向上させ、メモリ帯域幅を削減できます：
 
@@ -275,7 +275,7 @@ pcPrimitiveIndex  // サポート時
 
 :::note
 
-`primitiveIndex` / `pcPrimitiveIndex`組み込み変数は、`device.supportsPrimitiveIndex`がtrueの場合にのみ利用可能です。この機能はWebGPU専用です（WebGL2では利用不可）。機能がサポートされている場合、エンジンは必要な`enable primitive_index;` WGSLディレクティブを自動的に追加し、条件付きコンパイル用のシェーダー定義`CAPS_PRIMITIVE_INDEX`が利用可能になります。
+`primitiveIndex` / `pcPrimitiveIndex` 組み込み変数は、`device.supportsPrimitiveIndex` が true の場合にのみ利用可能です。この機能は WebGPU 専用です（WebGL2 では利用不可）。`enable primitive_index;` および `CAPS_PRIMITIVE_INDEX` については [WGSL 言語拡張](#wgsl-language-extensions) を参照してください。
 
 :::
 
@@ -321,3 +321,58 @@ fragDepth: @builtin(frag_depth)
 整数テクスチャへのレンダリング（`vec4f`以外の出力フォーマット）のサポートはまだ利用できませんが、将来追加される予定です。
 
 :::
+
+### WGSL 言語拡張 {#wgsl-language-extensions}
+
+デバイス作成時に、エンジンは `navigator.gpu.wgslLanguageFeatures` を読み取り、任意の言語機能用に必要な `enable …;` および `requires …;` ディレクティブを生成される WGSL に付加します。シェーダー側では、対応する `CAPS_*` 定義（`Shader` 定義の `vertexDefines` / `fragmentDefines` / `cdefines` とマージ）で分岐できます。
+
+- **`device.supportsShaderF16`**
+  - **エンジンが注入:** `enable f16;`
+  - **プリプロセッサ定義:** `CAPS_SHADER_F16`
+  - **シェーダー段階:** 頂点、フラグメント、コンピュート
+  - **説明:** 本ページの [半精度型](#half-precision-types) および、エンジンが付与する `half` / `half2` などのエイリアス
+- **`device.supportsPrimitiveIndex`**
+  - **エンジンが注入:** `enable primitive_index;`
+  - **プリプロセッサ定義:** `CAPS_PRIMITIVE_INDEX`
+  - **シェーダー段階:** フラグメント
+  - **説明:** 簡略 API では、対応端末向けに `FragmentInput` の `primitiveIndex` およびグローバル `pcPrimitiveIndex`
+- **`device.supportsSubgroups`**
+  - **エンジンが注入:** `enable subgroups;`
+  - **プリプロセッサ定義:** `CAPS_SUBGROUPS`
+  - **シェーダー段階:** フラグメントとコンピュート
+  - **説明:** サブグループ組み込み（`subgroupBroadcast` 等）。`device.supportsSubgroupUniformity` 専用の `requires` / `enable` は追加されず、subgroups 機能と合わせて扱う
+- **`device.supportsSubgroupId`**
+  - **エンジンが注入:** `requires subgroup_id;`
+  - **プリプロセッサ定義:** `CAPS_SUBGROUP_ID`
+  - **シェーダー段階:** その `Shader` 定義に応じ、エンジンが WGSL へコンパイルする段階（使用する各段階向けのモジュール）
+  - **説明:** ワークグループ内の `subgroup_id` / `num_subgroups` 組み込み
+- **`device.supportsLinearIndexing`**
+  - **エンジンが注入:** `requires linear_indexing;`（**コンピュート** エントリのモジュールのみ。頂点・フラグメントには入れない）
+  - **プリプロセッサ定義:** `CAPS_LINEAR_INDEXING`
+  - **シェーダー段階:** コンピュート
+  - **説明:** `global_invocation_index` / `workgroup_index`。解説: [WebGPU 147-148](https://developer.chrome.com/blog/new-in-webgpu-147-148#wgsl_linear_indexing_extension)
+- **`device.supportsStorageTextureRead`**
+  - **エンジンが注入:** *なし* — ストレージテクスチャを読む場合は、WGSL 内に `requires readonly_and_readwrite_storage_textures;` を自前で記述
+  - **プリプロセッサ定義:** `CAPS_STORAGE_TEXTURE_READ`（デバイスがストレージテクスチャの読み取りに対応しているときに有効。コードパス分岐用）
+  - **シェーダー段階:** 機能を使う場合にコンピュート
+  - **説明:** エンジンは能力の宣言のみ。`requires` は必ず筆者が書く想定
+
+使用例（コンピュート）— `CAPS_LINEAR_INDEXING` があるときは線形のワークグループ番号を使い、なければ従来の方法で求めます。
+
+```wgsl
+@compute @workgroup_size(64, 1, 1)
+fn main(
+    @builtin(global_invocation_id) global_id: vec3u,
+    @builtin(num_workgroups) nwg: vec3u,
+#ifdef CAPS_LINEAR_INDEXING
+    @builtin(workgroup_index) flat_wg: u32,
+#endif
+) {
+#ifdef CAPS_LINEAR_INDEXING
+    let wg = flat_wg;
+#else
+    let wg = global_id.x; // 1D ディスパッチ; 2D/3D は必要に応じて拡張
+#endif
+    _ = wg;
+}
+```


### PR DESCRIPTION
User manual: optional WGSL features, matching `device.supports*` properties, `enable` / `requires` behavior, and `CAPS_*` defines—without a wide table (nested bullets). Section lives at the end of WGSL Specifics; Compute Shaders links to it.

**Changes:**
- `wgsl-specifics.md` (EN) and Japanese mirror: WGSL language extensions section with `device.*` headers, sub-bullets, explicit heading id `#wgsl-language-extensions`.
- `compute-shaders.md` (EN + JA): short "WGSL language extensions" pointer with link to the section.

**Related engine PR:** playcanvas/engine — WGSL `linear_indexing` detection and `requires` injection for compute.
https://github.com/playcanvas/engine/pull/8648