### PR TITLE
docs: clean up stale boilerplate in docusaurus.config.js (and fix editUrl)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -20,10 +20,9 @@ const config = {
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',
 
-  // GitHub pages deployment config.
-  // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'playcanvas', // Usually your GitHub org/user name.
-  projectName: 'developer.playcanvas.com', // Usually your repo name.
+  // GitHub Pages deployment config (used by docusaurus deploy and the gh-pages workflow).
+  organizationName: 'playcanvas',
+  projectName: 'developer-site',
 
   trailingSlash: true,
 
@@ -233,10 +232,8 @@ const config = {
               }
             }]
           ],
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/playcanvas/developer.playcanvas.com/tree/dev/',
+            'https://github.com/playcanvas/developer-site/tree/main/',
         },
         blog: false,
         theme: {
@@ -255,7 +252,6 @@ const config = {
         indexName: 'developer-playcanvas',
         contextualSearch: true,
       },
-      // Replace with your project's social card
       image: 'img/playcanvas-social-card.jpg',
       navbar: {
         title: 'PlayCanvas Docs',


### PR DESCRIPTION
## Summary

Clean up three stale boilerplate comments in `docusaurus.config.js`. Two of the three sites also had **incorrect values** I'd missed at first glance, so this is a small bug fix as well as a cleanup.

## What changed

### `editUrl` was 404'ing on every page

```diff
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/playcanvas/developer.playcanvas.com/tree/dev/',
+            'https://github.com/playcanvas/developer-site/tree/main/',
```

The repo `playcanvas/developer.playcanvas.com` does not exist (the actual repo is `playcanvas/developer-site`), and the branch `dev` does not exist (the default branch is `main`). The "Edit this page" link in the footer of every doc page on the live site was 404'ing as a result.

### `projectName` had the wrong value

```diff
-  // GitHub pages deployment config.
-  // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'playcanvas', // Usually your GitHub org/user name.
-  projectName: 'developer.playcanvas.com', // Usually your repo name.
+  // GitHub Pages deployment config (used by docusaurus deploy and the gh-pages workflow).
+  organizationName: 'playcanvas',
+  projectName: 'developer-site',
```

`projectName` is supposed to match the GitHub repo name. We don't currently use `docusaurus deploy` (the `peaceiris/actions-gh-pages` workflow handles deployment), so this was inert — but it'd bite us the next time anyone reached for `docusaurus deploy` or any tool that reads it.

### Stale "you should change this" comment on the social card

```diff
-      // Replace with your project's social card
       image: 'img/playcanvas-social-card.jpg',
```

The image is set to the actual PlayCanvas social card already.

## Test plan

- [x] `node --check docusaurus.config.js` passes
- [x] `npm run lint` passes (1194 files, 0 errors)
- [x] Once merged, confirm that the "Edit this page" link in any user-manual page now lands on the correct repo + branch.
