### PR TITLE
docs: add missing description frontmatter

### DIFF
--- a/docs/user-manual/graphics/advanced-rendering/html-in-canvas.md
+++ b/docs/user-manual/graphics/advanced-rendering/html-in-canvas.md
@@ -1,6 +1,6 @@
 ---
 title: HTML-in-Canvas
-description: Render live HTML and CSS as WebGL textures with full styling, hit testing, and accessibility — plus fallback strategies.
+description: Render live HTML and CSS into 3D scenes as GPU textures with full styling, hit testing, and accessibility — plus fallback strategies.
 ---
 
 HTML-in-Canvas allows you to render live HTML and CSS content directly as WebGL textures. This enables styled text, interactive UI panels, forms, and other DOM content to appear on surfaces within a 3D scene — complete with accessibility, internationalization, and full CSS styling support.

--- a/docs/user-manual/graphics/advanced-rendering/html-in-canvas.md
+++ b/docs/user-manual/graphics/advanced-rendering/html-in-canvas.md
@@ -1,5 +1,6 @@
 ---
 title: HTML-in-Canvas
+description: Render live HTML and CSS as WebGL textures with full styling, hit testing, and accessibility — plus fallback strategies.
 ---
 
 HTML-in-Canvas allows you to render live HTML and CSS content directly as WebGL textures. This enables styled text, interactive UI panels, forms, and other DOM content to appear on surfaces within a 3D scene — complete with accessibility, internationalization, and full CSS styling support.

--- a/docs/user-manual/react/examples/index.md
+++ b/docs/user-manual/react/examples/index.md
@@ -1,3 +1,4 @@
 ---
 title: Examples
+description: Live, editable PlayCanvas React examples you can run and modify directly in the documentation.
 ---

--- a/docs/user-manual/react/examples/physics.mdx
+++ b/docs/user-manual/react/examples/physics.mdx
@@ -1,5 +1,6 @@
 ---
 title: Physics
+description: Live PlayCanvas React example — a cluster of rigid bodies disturbed by pointer movement in zero gravity.
 ---
 
 import { CodeExample } from '@site/src/components/playcanvas-react/CodeExample';

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/advanced-rendering/html-in-canvas.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/advanced-rendering/html-in-canvas.md
@@ -1,5 +1,6 @@
 ---
 title: HTML-in-Canvas
+description: ライブのHTMLとCSSをWebGLテクスチャとしてレンダリングし、スタイリング、ヒットテスト、アクセシビリティを完全サポートします。フォールバック戦略も解説します。
 ---
 
 HTML-in-Canvas allows you to render live HTML and CSS content directly as WebGL textures. This enables styled text, interactive UI panels, forms, and other DOM content to appear on surfaces within a 3D scene — complete with accessibility, internationalization, and full CSS styling support.

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/advanced-rendering/html-in-canvas.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/advanced-rendering/html-in-canvas.md
@@ -1,6 +1,6 @@
 ---
 title: HTML-in-Canvas
-description: ライブのHTMLとCSSをWebGLテクスチャとしてレンダリングし、スタイリング、ヒットテスト、アクセシビリティを完全サポートします。フォールバック戦略も解説します。
+description: ライブのHTMLとCSSを3DシーンにGPUテクスチャとしてレンダリングし、スタイリング、ヒットテスト、アクセシビリティを完全サポートします。フォールバック戦略も解説します。
 ---
 
 HTML-in-Canvas allows you to render live HTML and CSS content directly as WebGL textures. This enables styled text, interactive UI panels, forms, and other DOM content to appear on surfaces within a 3D scene — complete with accessibility, internationalization, and full CSS styling support.

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/react/examples/index.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/react/examples/index.md
@@ -1,3 +1,4 @@
 ---
 title: 例
+description: ドキュメント内で直接実行・編集できる、ライブのPlayCanvas Reactサンプル集です。
 ---

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/react/examples/physics.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/react/examples/physics.mdx
@@ -1,5 +1,6 @@
 ---
 title: 物理
+description: PlayCanvas Reactのライブサンプル — 無重力空間でポインターの動きにより乱される剛体のクラスター。
 ---
 
 import { CodeExample } from '@site/src/components/playcanvas-react/CodeExample';


### PR DESCRIPTION
## Summary

Three documentation pages were missing `description:` frontmatter, which Docusaurus uses to populate `<meta name="description">` for search engines and social previews. Adding it gives each page a meaningful snippet rather than letting Docusaurus fall back to whatever it can auto-extract.

| File | New description |
|---|---|
| `docs/user-manual/graphics/advanced-rendering/html-in-canvas.md` | Render live HTML and CSS as WebGL textures with full styling, hit testing, and accessibility — plus fallback strategies. |
| `docs/user-manual/react/examples/index.md` | Live, editable PlayCanvas React examples you can run and modify directly in the documentation. |
| `docs/user-manual/react/examples/physics.mdx` | Live PlayCanvas React example — a cluster of rigid bodies disturbed by pointer movement in zero gravity. |

The Japanese counterparts under `i18n/ja/...` are updated in lockstep with localized descriptions, per the repo's localisation rule.

## Test plan

- [x] After deploy, view-source on the three pages and confirm `<meta name="description" content="...">` matches the new frontmatter.
- [x] Same check for the `/ja/...` versions.
