### PR TITLE
Fix docs build warnings

### DIFF
--- a/docs/user-manual/react/api/hooks/use-material.mdx
+++ b/docs/user-manual/react/api/hooks/use-material.mdx
@@ -42,13 +42,13 @@ The hooks accepts an object with the following properties that closely match tho
 
 <details>
   <summary><b>Parameters</b></summary>
-  <p>
-  ```tsx asTypedoc
-  import { useMaterial } from '@playcanvas/react/hooks'
-  type $ = Parameters<typeof useMaterial>[0];
-  export default $;
-  ```
-  </p>
+
+```tsx asTypedoc
+import { useMaterial } from '@playcanvas/react/hooks'
+type $ = Parameters<typeof useMaterial>[0];
+export default $;
+```
+
 </details>
 
 ## Returns

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/compute-shaders.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/compute-shaders.md
@@ -434,7 +434,7 @@ storageBuffer.read(0, undefined, resultData, true).then((data) => {
 
 | インクルード | 説明 |
 |-------------|------|
-| `halfTypesCS` | 半精度型エイリアス（`half`、`half2`など）。サポートされている場合はf16に、そうでない場合はf32に解決されます。[半精度型](/user-manual/graphics/shaders/wgsl-specifics#半精度型)を参照。 |
+| `halfTypesCS` | 半精度型エイリアス（`half`、`half2`など）。サポートされている場合はf16に、そうでない場合はf32に解決されます。[半精度型](/user-manual/graphics/shaders/wgsl-specifics#half-precision-types)を参照。 |
 
 例：
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/react/api/hooks/use-material.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/react/api/hooks/use-material.mdx
@@ -42,13 +42,13 @@ import { MaterialExample } from './material-example.jsx';
 
 <details>
   <summary><b>パラメータ</b></summary>
-  <p>
-  ```tsx asTypedoc
-  import { useMaterial } from '@playcanvas/react/hooks'
-  type $ = Parameters<typeof useMaterial>[0];
-  export default $;
-  ```
-  </p>
+
+```tsx asTypedoc
+import { useMaterial } from '@playcanvas/react/hooks'
+type $ = Parameters<typeof useMaterial>[0];
+export default $;
+```
+
 </details>
 
 ## 戻り値


### PR DESCRIPTION
## Summary
- remove invalid paragraph wrappers around the useMaterial typedoc code fence in English and Japanese docs
- update the Japanese compute shader link to use the explicit half-precision anchor

## Testing
- npm.cmd run lint
- npm.cmd run build
