### PR TITLE
Fix FAQ generated path docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,13 +14,13 @@ Documentation site for PlayCanvas built with Docusaurus 3.
 docs/           # English documentation (source of truth)
 i18n/ja/        # Japanese translations
 static/img/     # Images (mirrors docs/ structure)
-faq/            # FAQ source files (auto-generates docs/user-manual/faq.md)
+faq/            # FAQ source files (auto-generates docs/user-manual/editor/faq.md)
 ```
 
 ## Critical Rules
 
 1. **Localization**: When updating `docs/`, also update the corresponding file in `i18n/ja/docusaurus-plugin-content-docs/current/`
-2. **FAQ**: Do not edit `docs/user-manual/faq.md` directly - it is auto-generated from `faq/`. Run `npm run faq` after editing FAQ source files.
+2. **FAQ**: Do not edit `docs/user-manual/editor/faq.md` directly - it is auto-generated from `faq/`. Run `npm run faq` after editing FAQ source files.
 3. **File operations**: Use `git mv` and `git rm` for moving/deleting files to ensure proper version control tracking.
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Tutorials are regular markdown files and can be edited directly. However, if you
 
 ## Update FAQ
 
-The User Manual on the developer site has a FAQ page which can be found at `docs/user-manual/faq.md`. This is the only Markdown file that is generated from other files (located in the `faq` directory). If you would like to add additional FAQs, check them in to the `faq` directory and to regenerate `docs/user-manual/faq.md` run:
+The User Manual on the developer site has a FAQ page which can be found at `docs/user-manual/editor/faq.md`. This is the only Markdown file that is generated from other files (located in the `faq` directory). If you would like to add additional FAQs, check them in to the `faq` directory and to regenerate `docs/user-manual/editor/faq.md` run:
 
 ```sh
 npm run faq


### PR DESCRIPTION
## Summary
- update README FAQ instructions to point at docs/user-manual/editor/faq.md
- update AGENTS.md with the same generated FAQ path

## Testing
- npm.cmd run lint
- npm.cmd run build
