### PR TITLE
docs: update checkpoint create api response

### DIFF
--- a/docs/user-manual/api/checkpoint-create.md
+++ b/docs/user-manual/api/checkpoint-create.md
@@ -1,6 +1,6 @@
 ---
 title: Checkpoints - Create checkpoint
-description: Capture the current branch state with POST /api/checkpoints for later restore, including description field and example request body.
+description: Start an asynchronous checkpoint creation job with POST /api/checkpoints, then poll the returned job until the checkpoint is created.
 ---
 
 ## Route URL
@@ -11,7 +11,9 @@ POST https://playcanvas.com/api/checkpoints
 
 ## Description
 
-Create a new checkpoint for a branch. A checkpoint captures the current state of a branch so that it can be restored later.
+Start a job to create a new checkpoint for a branch. A checkpoint captures the current state of a branch so that it can be restored later.
+
+The request will return job details immediately. You can [poll the job by id](/user-manual/api/job-get) until its status is either `complete` or `error`. When the job is complete, its data will contain the created checkpoint.
 
 ## Example
 
@@ -46,6 +48,30 @@ Content-Type: application/json
 ```none
 Status: 201 Created
 ```
+
+```json
+{
+    "id": int,
+    "created_at": date,
+    "modified_at": date,
+    "status": "running" | "complete" | "error",
+    "messages": list of strings,
+    "data": {
+        "type": "checkpoint_create",
+        "project_id": int,
+        "branch_id": string,
+        "user_id": int,
+        "user": {
+            "id": int,
+            "fullName": string,
+            "username": string
+        },
+        "description": string
+    }
+}
+```
+
+When the job is complete, the `data` field contains the created checkpoint:
 
 ```json
 {

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/api/checkpoint-create.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/api/checkpoint-create.md
@@ -1,6 +1,6 @@
 ---
 title: チェックポイント - Create checkpoint
-description: POST /api/checkpointsで現在のブランチ状態を後から復元できるよう記録し、descriptionフィールドとリクエストボディの例を含みます。
+description: POST /api/checkpointsで非同期のチェックポイント作成ジョブを開始し、返されたジョブをポーリングして作成完了を確認します。
 ---
 
 ## ルートURL
@@ -11,7 +11,9 @@ POST https://playcanvas.com/api/checkpoints
 
 ## 説明
 
-ブランチの新しいチェックポイントを作成します。チェックポイントはブランチの現在の状態をキャプチャし、後で復元できるようにします。
+ブランチの新しいチェックポイントを作成するジョブを開始します。チェックポイントはブランチの現在の状態をキャプチャし、後で復元できるようにします。
+
+リクエストはジョブの詳細をすぐに返します。ステータスが `complete` または `error` になるまで、[ジョブを id でポーリング](/user-manual/api/job-get)できます。ジョブが完了すると、`data` に作成されたチェックポイントが含まれます。
 
 ## 例
 
@@ -46,6 +48,30 @@ Content-Type: application/json
 ```none
 ステータス: 201 Created
 ```
+
+```json
+{
+    "id": int,
+    "created_at": date,
+    "modified_at": date,
+    "status": "running" | "complete" | "error",
+    "messages": list of strings,
+    "data": {
+        "type": "checkpoint_create",
+        "project_id": int,
+        "branch_id": string,
+        "user_id": int,
+        "user": {
+            "id": int,
+            "fullName": string,
+            "username": string
+        },
+        "description": string
+    }
+}
+```
+
+ジョブが完了すると、`data` フィールドには作成されたチェックポイントが含まれます。
 
 ```json
 {


### PR DESCRIPTION
### Changes
- Document `POST /api/checkpoints` as an asynchronous checkpoint creation job.
- Link to job polling and show the completed checkpoint payload.
- Update the Japanese API translation.

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer-site/blob/main/.github/CONTRIBUTING.md).
- Manual tests: not run
