### PR TITLE
docs: document app download format

### DIFF
--- a/docs/user-manual/api/app-download.md
+++ b/docs/user-manual/api/app-download.md
@@ -1,6 +1,6 @@
 ---
 title: Apps - Download app
-description: POST apps/download starts a self-hostable app or npm project export job; poll jobs until complete to retrieve the packaged export download URL.
+description: POST apps/download starts an app export job in static, npm, or web lens format; poll jobs until complete to retrieve the packaged export download URL.
 ---
 
 ## Route URL
@@ -13,12 +13,12 @@ POST https://playcanvas.com/api/apps/download
 
 This will allow you to download an app which you can self host on your own server. The request will start an export job and the job details will be returned in the response. You can [poll the job by id](/user-manual/api/job-get) until its status is either 'complete' or 'error'. When the job is done, its data will contain a URL to download the exported app.
 
-Set `npm_project` to `true` to download the app as a Vite-based npm project instead of the standard static self-hostable package.
+Use `format` to choose the package type. Omit it or set it to `static` for the standard self-hostable package, set it to `npm` for a Vite-based npm project, or set it to `web_lens` for a Lens Studio web lens package. The `web_lens` format is available to super users only.
 
 ## Example
 
 ```none
-curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json" -X POST -d '{"project_id": 9999999, "scenes": [9999999], "name": "My App", "npm_project": true}' "https://playcanvas.com/api/apps/download"
+curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json" -X POST -d '{"project_id": 9999999, "scenes": [9999999], "name": "My App", "format": "npm"}' "https://playcanvas.com/api/apps/download"
 ```
 
 ## Parameters
@@ -36,7 +36,7 @@ curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json
 | `scripts_minify`        | `boolean`  |          | Set it to true if you want scripts to be minified. Defaults to true.                                                                                                  |
 | `scripts_sourcemaps`    | `boolean`  |          | Set it to true if you want script sourcemaps to be generated. Defaults to false.                                                                                      |
 | `optimize_scene_format` | `boolean`  |          | Set it to true if you want scenes to be in an optimized format (see [Optimize Scene Format](/user-manual/optimization/optimizing-scene-format) for more information). |
-| `npm_project`           | `boolean`  |          | Set it to true to export a Vite-based npm project instead of the standard static self-hostable package.                                                               |
+| `format`                | `string`   |          | Export package type: `static`, `npm`, or `web_lens`. Defaults to `static`. The `web_lens` format is available to super users only.                                   |
 | `engine_version`        | `string`   |          | Set it to a Engine version string ([full list of releases](https://github.com/playcanvas/engine/releases)) if a specific version is needed for the app. Defaults to the latest Editor supported major version depending on your project.              |
 
 ## Response Schema
@@ -55,7 +55,7 @@ Status: 201 Created
         "concatenate": boolean,
         "branch_id": string,
         "optimize_scene_format": boolean,
-        "npm_project": boolean,
+        "format": "static" | "npm" | "web_lens",
         "minify": boolean,
         "name": string,
         "sourcemaps": boolean,

--- a/docs/user-manual/api/app-download.md
+++ b/docs/user-manual/api/app-download.md
@@ -1,6 +1,6 @@
 ---
 title: Apps - Download app
-description: POST apps/download starts an app export job in static, npm, or web lens format; poll jobs until complete to retrieve the packaged export download URL.
+description: POST apps/download starts an app export job in static or npm format; poll jobs until complete to retrieve the packaged export download URL.
 ---
 
 ## Route URL
@@ -13,7 +13,7 @@ POST https://playcanvas.com/api/apps/download
 
 This will allow you to download an app which you can self host on your own server. The request will start an export job and the job details will be returned in the response. You can [poll the job by id](/user-manual/api/job-get) until its status is either 'complete' or 'error'. When the job is done, its data will contain a URL to download the exported app.
 
-Use `format` to choose the package type. Omit it or set it to `static` for the standard self-hostable package, set it to `npm` for a Vite-based npm project, or set it to `web_lens` for a Lens Studio web lens package. The `web_lens` format is available to super users only.
+Use `format` to choose the package type. Omit it or set it to `static` for the standard self-hostable package, or set it to `npm` for a Vite-based npm project.
 
 ## Example
 
@@ -36,7 +36,7 @@ curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json
 | `scripts_minify`        | `boolean`  |          | Set it to true if you want scripts to be minified. Defaults to true.                                                                                                  |
 | `scripts_sourcemaps`    | `boolean`  |          | Set it to true if you want script sourcemaps to be generated. Defaults to false.                                                                                      |
 | `optimize_scene_format` | `boolean`  |          | Set it to true if you want scenes to be in an optimized format (see [Optimize Scene Format](/user-manual/optimization/optimizing-scene-format) for more information). |
-| `format`                | `string`   |          | Export package type: `static`, `npm`, or `web_lens`. Defaults to `static`. The `web_lens` format is available to super users only.                                   |
+| `format`                | `string`   |          | Export package type: `static` or `npm`. Defaults to `static`.                                                                                                         |
 | `engine_version`        | `string`   |          | Set it to a Engine version string ([full list of releases](https://github.com/playcanvas/engine/releases)) if a specific version is needed for the app. Defaults to the latest Editor supported major version depending on your project.              |
 
 ## Response Schema
@@ -55,7 +55,7 @@ Status: 201 Created
         "concatenate": boolean,
         "branch_id": string,
         "optimize_scene_format": boolean,
-        "format": "static" | "npm" | "web_lens",
+        "format": "static" | "npm",
         "minify": boolean,
         "name": string,
         "sourcemaps": boolean,

--- a/docs/user-manual/api/app-download.md
+++ b/docs/user-manual/api/app-download.md
@@ -1,6 +1,6 @@
 ---
 title: Apps - Download app
-description: POST apps/download starts a self-hostable app export job; poll jobs until complete to retrieve the packaged app download URL.
+description: POST apps/download starts a self-hostable app or npm project export job; poll jobs until complete to retrieve the packaged export download URL.
 ---
 
 ## Route URL
@@ -13,10 +13,12 @@ POST https://playcanvas.com/api/apps/download
 
 This will allow you to download an app which you can self host on your own server. The request will start an export job and the job details will be returned in the response. You can [poll the job by id](/user-manual/api/job-get) until its status is either 'complete' or 'error'. When the job is done, its data will contain a URL to download the exported app.
 
+Set `npm_project` to `true` to download the app as a Vite-based npm project instead of the standard static self-hostable package.
+
 ## Example
 
 ```none
-curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json" -X POST -d '{"project_id": 9999999, "scenes": [9999999], "name": "My App"}' "https://playcanvas.com/api/apps/download"
+curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json" -X POST -d '{"project_id": 9999999, "scenes": [9999999], "name": "My App", "npm_project": true}' "https://playcanvas.com/api/apps/download"
 ```
 
 ## Parameters
@@ -34,6 +36,7 @@ curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json
 | `scripts_minify`        | `boolean`  |          | Set it to true if you want scripts to be minified. Defaults to true.                                                                                                  |
 | `scripts_sourcemaps`    | `boolean`  |          | Set it to true if you want script sourcemaps to be generated. Defaults to false.                                                                                      |
 | `optimize_scene_format` | `boolean`  |          | Set it to true if you want scenes to be in an optimized format (see [Optimize Scene Format](/user-manual/optimization/optimizing-scene-format) for more information). |
+| `npm_project`           | `boolean`  |          | Set it to true to export a Vite-based npm project instead of the standard static self-hostable package.                                                               |
 | `engine_version`        | `string`   |          | Set it to a Engine version string ([full list of releases](https://github.com/playcanvas/engine/releases)) if a specific version is needed for the app. Defaults to the latest Editor supported major version depending on your project.              |
 
 ## Response Schema
@@ -52,6 +55,7 @@ Status: 201 Created
         "concatenate": boolean,
         "branch_id": string,
         "optimize_scene_format": boolean,
+        "npm_project": boolean,
         "minify": boolean,
         "name": string,
         "sourcemaps": boolean,

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/api/app-download.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/api/app-download.md
@@ -1,6 +1,6 @@
 ---
 title: アプリ - Download app
-description: POST apps/downloadでセルフホスト可能なアプリのエクスポートジョブを開始し、完了までjobsをポーリングしてパッケージ化されたアプリのダウンロードURLを取得します。
+description: POST apps/downloadでセルフホスト可能なアプリまたはnpmプロジェクトのエクスポートジョブを開始し、完了までjobsをポーリングしてパッケージ化されたエクスポートのダウンロードURLを取得します。
 ---
 
 ## ルートURL
@@ -13,10 +13,12 @@ POST https://playcanvas.com/api/apps/download
 
 自分のサーバーでセルフホストすることができるアプリをダウンロードできます。リクエストによりエクスポートジョブが開始され、ジョブの詳細がレスポンスで返されます。[idを指定してジョブをポール](/user-manual/api/job-get)して、そのステータスが「完了」または「エラー」になるまで待ちます。ジョブが完了すると、そのデータにはエクスポートされたアプリをダウンロードするためのURLが含まれます。
 
+標準の静的なセルフホスト用パッケージの代わりに、Viteベースのnpmプロジェクトとしてアプリをダウンロードするには、`npm_project`を`true`に設定します。
+
 ## 例
 
 ```none
-curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json" -X POST -d '{"project_id": 9999999, "scenes": [9999999], "name": "My App"}' "https://playcanvas.com/api/apps/download"
+curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json" -X POST -d '{"project_id": 9999999, "scenes": [9999999], "name": "My App", "npm_project": true}' "https://playcanvas.com/api/apps/download"
 ```
 
 ## パラメーター
@@ -34,6 +36,7 @@ curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json
 | `scripts_minify`        | `boolean`  |          | Set it to true if you want scripts to be minified. Defaults to true.                                                                                                  |
 | `scripts_sourcemaps`    | `boolean`  |          | Set it to true if you want script sourcemaps to be generated. Defaults to false.                                                                                      |
 | `optimize_scene_format` | `boolean`  |          | Set it to true if you want scenes to be in an optimized format (see [Optimize Scene Format](/user-manual/optimization/optimizing-scene-format) for more information). |
+| `npm_project`           | `boolean`  |          | 標準の静的なセルフホスト用パッケージの代わりに、Viteベースのnpmプロジェクトとしてエクスポートする場合はtrueに設定します。                                              |
 | `engine_version`        | `string`   |          | Set it to a Engine version string ([full list of releases](https://github.com/playcanvas/engine/releases)) if a specific version is needed for the app.               |
 
 ## レスポンススキーマ
@@ -52,6 +55,7 @@ curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json
         "concatenate": boolean,
         "branch_id": string,
         "optimize_scene_format": boolean,
+        "npm_project": boolean,
         "minify": boolean,
         "name": string,
         "sourcemaps": boolean,

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/api/app-download.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/api/app-download.md
@@ -1,6 +1,6 @@
 ---
 title: アプリ - Download app
-description: POST apps/downloadでセルフホスト可能なアプリまたはnpmプロジェクトのエクスポートジョブを開始し、完了までjobsをポーリングしてパッケージ化されたエクスポートのダウンロードURLを取得します。
+description: POST apps/downloadでstatic、npm、web lens形式のアプリのエクスポートジョブを開始し、完了までjobsをポーリングしてパッケージ化されたエクスポートのダウンロードURLを取得します。
 ---
 
 ## ルートURL
@@ -13,12 +13,12 @@ POST https://playcanvas.com/api/apps/download
 
 自分のサーバーでセルフホストすることができるアプリをダウンロードできます。リクエストによりエクスポートジョブが開始され、ジョブの詳細がレスポンスで返されます。[idを指定してジョブをポール](/user-manual/api/job-get)して、そのステータスが「完了」または「エラー」になるまで待ちます。ジョブが完了すると、そのデータにはエクスポートされたアプリをダウンロードするためのURLが含まれます。
 
-標準の静的なセルフホスト用パッケージの代わりに、Viteベースのnpmプロジェクトとしてアプリをダウンロードするには、`npm_project`を`true`に設定します。
+`format`でパッケージタイプを選択します。省略するか`static`に設定すると標準のセルフホスト用パッケージ、`npm`に設定するとViteベースのnpmプロジェクト、`web_lens`に設定するとLens Studioのweb lensパッケージとしてエクスポートされます。`web_lens`形式はsuper userのみ利用できます。
 
 ## 例
 
 ```none
-curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json" -X POST -d '{"project_id": 9999999, "scenes": [9999999], "name": "My App", "npm_project": true}' "https://playcanvas.com/api/apps/download"
+curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json" -X POST -d '{"project_id": 9999999, "scenes": [9999999], "name": "My App", "format": "npm"}' "https://playcanvas.com/api/apps/download"
 ```
 
 ## パラメーター
@@ -36,7 +36,7 @@ curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json
 | `scripts_minify`        | `boolean`  |          | Set it to true if you want scripts to be minified. Defaults to true.                                                                                                  |
 | `scripts_sourcemaps`    | `boolean`  |          | Set it to true if you want script sourcemaps to be generated. Defaults to false.                                                                                      |
 | `optimize_scene_format` | `boolean`  |          | Set it to true if you want scenes to be in an optimized format (see [Optimize Scene Format](/user-manual/optimization/optimizing-scene-format) for more information). |
-| `npm_project`           | `boolean`  |          | 標準の静的なセルフホスト用パッケージの代わりに、Viteベースのnpmプロジェクトとしてエクスポートする場合はtrueに設定します。                                              |
+| `format`                | `string`   |          | エクスポートするパッケージタイプ: `static`、`npm`、`web_lens`。デフォルトは`static`です。`web_lens`形式はsuper userのみ利用できます。                                  |
 | `engine_version`        | `string`   |          | Set it to a Engine version string ([full list of releases](https://github.com/playcanvas/engine/releases)) if a specific version is needed for the app.               |
 
 ## レスポンススキーマ
@@ -55,7 +55,7 @@ curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json
         "concatenate": boolean,
         "branch_id": string,
         "optimize_scene_format": boolean,
-        "npm_project": boolean,
+        "format": "static" | "npm" | "web_lens",
         "minify": boolean,
         "name": string,
         "sourcemaps": boolean,

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/api/app-download.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/api/app-download.md
@@ -1,6 +1,6 @@
 ---
 title: アプリ - Download app
-description: POST apps/downloadでstatic、npm、web lens形式のアプリのエクスポートジョブを開始し、完了までjobsをポーリングしてパッケージ化されたエクスポートのダウンロードURLを取得します。
+description: POST apps/downloadでstaticまたはnpm形式のアプリのエクスポートジョブを開始し、完了までjobsをポーリングしてパッケージ化されたエクスポートのダウンロードURLを取得します。
 ---
 
 ## ルートURL
@@ -13,7 +13,7 @@ POST https://playcanvas.com/api/apps/download
 
 自分のサーバーでセルフホストすることができるアプリをダウンロードできます。リクエストによりエクスポートジョブが開始され、ジョブの詳細がレスポンスで返されます。[idを指定してジョブをポール](/user-manual/api/job-get)して、そのステータスが「完了」または「エラー」になるまで待ちます。ジョブが完了すると、そのデータにはエクスポートされたアプリをダウンロードするためのURLが含まれます。
 
-`format`でパッケージタイプを選択します。省略するか`static`に設定すると標準のセルフホスト用パッケージ、`npm`に設定するとViteベースのnpmプロジェクト、`web_lens`に設定するとLens Studioのweb lensパッケージとしてエクスポートされます。`web_lens`形式はsuper userのみ利用できます。
+`format`でパッケージタイプを選択します。省略するか`static`に設定すると標準のセルフホスト用パッケージ、`npm`に設定するとViteベースのnpmプロジェクトとしてエクスポートされます。
 
 ## 例
 
@@ -36,7 +36,7 @@ curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json
 | `scripts_minify`        | `boolean`  |          | Set it to true if you want scripts to be minified. Defaults to true.                                                                                                  |
 | `scripts_sourcemaps`    | `boolean`  |          | Set it to true if you want script sourcemaps to be generated. Defaults to false.                                                                                      |
 | `optimize_scene_format` | `boolean`  |          | Set it to true if you want scenes to be in an optimized format (see [Optimize Scene Format](/user-manual/optimization/optimizing-scene-format) for more information). |
-| `format`                | `string`   |          | エクスポートするパッケージタイプ: `static`、`npm`、`web_lens`。デフォルトは`static`です。`web_lens`形式はsuper userのみ利用できます。                                  |
+| `format`                | `string`   |          | エクスポートするパッケージタイプ: `static`または`npm`。デフォルトは`static`です。                                                                                      |
 | `engine_version`        | `string`   |          | Set it to a Engine version string ([full list of releases](https://github.com/playcanvas/engine/releases)) if a specific version is needed for the app.               |
 
 ## レスポンススキーマ
@@ -55,7 +55,7 @@ curl -H "Authorization: Bearer {accessToken}" -H "Content-Type: application/json
         "concatenate": boolean,
         "branch_id": string,
         "optimize_scene_format": boolean,
-        "format": "static" | "npm" | "web_lens",
+        "format": "static" | "npm",
         "minify": boolean,
         "name": string,
         "sourcemaps": boolean,


### PR DESCRIPTION
I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer-site/blob/main/.github/CONTRIBUTING.md).

Summary:
- Document `format` for app download requests.
- Note that omitted `format` defaults to `static`.
- Cover `static` and `npm` values in English and Japanese REST API docs.

Manual tests: not run