### PR TITLE
docs: dual Color LUT crossfade and 256×16 LUT requirement

### DIFF
--- a/docs/user-manual/graphics/linear-workflow/hdr-rendering.md
+++ b/docs/user-manual/graphics/linear-workflow/hdr-rendering.md
@@ -83,7 +83,7 @@ For more detailed information, refer to the CameraFrame [API documentation](http
 
 ### Color LUT {#color-lut}
 
-`CameraFrame` supports color grading via a 3D Color Lookup Table (LUT). The LUT is a 2D "horizontal strip" texture representing an unwrapped 3D LUT, in the same format used by Unreal Engine: for an N×N×N 3D LUT the texture is N²×N pixels (a 16×16×16 LUT is 256×16, a 32×32×32 LUT is 1024×32). HALD LUTs and Unity-style LUTs use different layouts and are not compatible.
+`CameraFrame` supports color grading via a 3D Color Lookup Table (LUT). The LUT must be a **256×16** 2D "horizontal strip" texture representing an unwrapped 16×16×16 3D LUT in Unreal Engine layout: 16 horizontal slices along the blue axis, each slice mapping red to the X-axis and green to the Y-axis. HALD LUTs and Unity-style LUTs use different layouts and are not compatible.
 
 Start from the neutral identity LUT below — applying it to a scene produces no change — and modify it in an image editor to create your own grade:
 
@@ -122,6 +122,21 @@ app.assets.load(lutAsset);
 If any of the texture settings above are wrong, the engine emits a debug-build warning naming the specific properties to change (this check is stripped from release builds).
 
 LUTs can be authored by taking a screenshot of the scene, applying color adjustments in an image editor such as Photoshop, dragging those adjustments onto the neutral identity LUT, and exporting the result as a PNG. In the PlayCanvas Editor, set the texture asset's **sRGB** flag on, **Mipmaps** off, and **Filter** to **Linear**.
+
+#### Crossfading between two LUTs
+
+For transitions between two graded looks (day → night, location A → location B, etc.) the LUT slot supports an optional second texture and a blend factor. Both LUTs are sampled at the same time and the two graded results are crossfaded in linear space:
+
+```javascript
+cameraFrame.colorLUT.texture  = lutDayAsset.resource;
+cameraFrame.colorLUT.texture2 = lutNightAsset.resource;
+cameraFrame.colorLUT.intensity  = 1; // strength of LUT 1 against the original
+cameraFrame.colorLUT.intensity2 = 1; // strength of LUT 2 against the original
+cameraFrame.colorLUT.blend = 0;      // 0 = only LUT 1, 1 = only LUT 2, animate this for a fade
+cameraFrame.update();
+```
+
+The second texture must satisfy the same size and filtering requirements as the first. When `texture2` is `null`, the single-LUT path is used and the `intensity2` / `blend` values are ignored.
 
 ## CameraFrame in the Editor
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/linear-workflow/hdr-rendering.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/linear-workflow/hdr-rendering.md
@@ -76,7 +76,7 @@ material.emissiveIntensity = 50;
 
 ### カラー LUT {#color-lut}
 
-`CameraFrame` は、3D カラールックアップテーブル（LUT）によるカラーグレーディングをサポートします。LUT は、Unreal Engine と同じ形式で 3D LUT を 2D の「水平ストリップ」テクスチャに展開したものです。N×N×N の 3D LUT の場合、テクスチャは N²×N ピクセルになります（16×16×16 LUT は 256×16、32×32×32 LUT は 1024×32）。HALD LUT や Unity 形式の LUT はレイアウトが異なるため互換性がありません。
+`CameraFrame` は、3D カラールックアップテーブル（LUT）によるカラーグレーディングをサポートします。LUT は、Unreal Engine と同じレイアウトで 16×16×16 の 3D LUT を 2D の「水平ストリップ」テクスチャに展開した **256×16** のテクスチャである必要があります。青軸に沿って 16 個の水平スライスが並び、各スライスは赤を X 軸、緑を Y 軸にマッピングします。HALD LUT や Unity 形式の LUT はレイアウトが異なるため互換性がありません。
 
 以下の中立な恒等 LUT を出発点にしてください — シーンに適用しても変化はありません — そして画像エディタで編集して独自のグレーディングを作成します：
 
@@ -115,6 +115,21 @@ app.assets.load(lutAsset);
 上記のテクスチャ設定のいずれかが誤っている場合、エンジンはデバッグビルドで変更すべきプロパティを示す警告を発します（リリースビルドではこのチェックは削除されます）。
 
 LUT は、シーンのスクリーンショットを撮り、Photoshop などの画像エディタで色調整を行い、それらの調整を中立な恒等 LUT にドラッグしてから PNG として書き出すことでオーサリングできます。PlayCanvas Editor では、テクスチャアセットの **sRGB** フラグをオン、**Mipmaps** をオフ、**Filter** を **Linear** に設定してください。
+
+#### 2 つの LUT をクロスフェードする
+
+2 つのグレード間でトランジション（昼 → 夜、場所 A → 場所 B など）を行うために、LUT スロットはオプションの 2 つ目のテクスチャとブレンド係数をサポートします。両方の LUT が同時にサンプリングされ、2 つのグレーディング結果がリニア空間でクロスフェードされます：
+
+```javascript
+cameraFrame.colorLUT.texture  = lutDayAsset.resource;
+cameraFrame.colorLUT.texture2 = lutNightAsset.resource;
+cameraFrame.colorLUT.intensity  = 1; // 元の色に対する LUT 1 の強度
+cameraFrame.colorLUT.intensity2 = 1; // 元の色に対する LUT 2 の強度
+cameraFrame.colorLUT.blend = 0;      // 0 = LUT 1 のみ、1 = LUT 2 のみ。これをアニメーションさせてフェードします
+cameraFrame.update();
+```
+
+2 つ目のテクスチャは、1 つ目と同じサイズおよびフィルタリングの要件を満たす必要があります。`texture2` が `null` の場合は単一 LUT のパスが使用され、`intensity2` と `blend` の値は無視されます。
 
 ## エディターでのCameraFrame {#cameraframe-in-the-editor}
 


### PR DESCRIPTION
## Summary

Updates the Color LUT section in HDR rendering docs to match the engine: fixed **256×16** strip size and optional second LUT with crossfade controls.

## Changes

- Document 256×16 Unreal strip requirement (remove 32³ size mention).
- Add **Crossfading between two LUTs** subsection with `texture2`, `intensity2`, and `blend` example.
- Japanese (`i18n/ja`) mirror updated.

## Test plan

- [ ] Preview HDR rendering page (EN + JA) on local Docusaurus build if needed.