### PR TITLE
docs: add loading screen image guidance

### DIFF
--- a/docs/tutorials/advance-loading-screen.md
+++ b/docs/tutorials/advance-loading-screen.md
@@ -7,7 +7,7 @@ thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/4580
 
 import Link from '@docusaurus/Link';
 
-Project sample showing how to embed images directly in the loading screen.
+Project sample showing how to embed Base64 data URI images directly in the loading screen.
 
 <div className="iframe-container">
     <iframe src="https://playcanv.as/p/Di3Fb3fx/" title="Base64 Loading Screen Images" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>

--- a/docs/tutorials/advance-loading-screen.md
+++ b/docs/tutorials/advance-loading-screen.md
@@ -1,16 +1,16 @@
 ---
-title: 'Advance loading screen'
-description: Customize the loading screen with project image assets so branding and splash art show while the app initializes.
+title: 'Base64 Loading Screen Images'
+description: Customize the loading screen with embedded Base64 images so branding and splash art show while the app initializes.
 tags: [loading, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/458028/1A9054-image-75.jpg
 ---
 
 import Link from '@docusaurus/Link';
 
-Project sample showing how to use project image assets in the loading screen.
+Project sample showing how to embed images directly in the loading screen.
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/Di3Fb3fx/" title="Advance loading screen" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
+    <iframe src="https://playcanv.as/p/Di3Fb3fx/" title="Base64 Loading Screen Images" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/458028/'>Open Project ↗</Link>

--- a/docs/user-manual/editor/interface/launch-page/loading-screen.md
+++ b/docs/user-manual/editor/interface/launch-page/loading-screen.md
@@ -109,24 +109,24 @@ To create one:
 
 ```javascript
 pc.script.createLoadingScreen((app) => {
-    const LOGO_IMAGE = 'data:image/png;base64,iVBORw0KGgo...';
+    const LOGO_IMAGE = "data:image/png;base64,iVBORw0KGgo...";
 
-    const wrapper = document.createElement('div');
-    wrapper.style.position = 'absolute';
-    wrapper.style.inset = '0';
-    wrapper.style.display = 'flex';
-    wrapper.style.alignItems = 'center';
-    wrapper.style.justifyContent = 'center';
-    wrapper.style.backgroundColor = '#232323';
+    const wrapper = document.createElement("div");
+    wrapper.style.position = "absolute";
+    wrapper.style.inset = "0";
+    wrapper.style.display = "flex";
+    wrapper.style.alignItems = "center";
+    wrapper.style.justifyContent = "center";
+    wrapper.style.backgroundColor = "#232323";
     document.body.appendChild(wrapper);
 
-    const logo = document.createElement('img');
-    logo.alt = '';
+    const logo = document.createElement("img");
+    logo.alt = "";
     logo.src = LOGO_IMAGE;
-    logo.style.width = '240px';
+    logo.style.width = "240px";
     wrapper.appendChild(logo);
 
-    app.once('start', () => {
+    app.once("start", () => {
         document.body.removeChild(wrapper);
     });
 });

--- a/docs/user-manual/editor/interface/launch-page/loading-screen.md
+++ b/docs/user-manual/editor/interface/launch-page/loading-screen.md
@@ -110,6 +110,7 @@ To create one:
 ```javascript
 pc.script.createLoadingScreen((app) => {
     const LOGO_IMAGE = 'data:image/png;base64,iVBORw0KGgo...';
+    const LOGO_ALT = 'Your product or company name';
 
     const wrapper = document.createElement('div');
     wrapper.style.position = 'absolute';
@@ -121,7 +122,7 @@ pc.script.createLoadingScreen((app) => {
     document.body.appendChild(wrapper);
 
     const logo = document.createElement('img');
-    logo.alt = 'Logo';
+    logo.alt = LOGO_ALT;
     logo.src = LOGO_IMAGE;
     logo.style.width = '240px';
     wrapper.appendChild(logo);
@@ -134,11 +135,13 @@ pc.script.createLoadingScreen((app) => {
 
 Embedding images this way increases the loading screen script size, so keep the image small and avoid using this technique for large background art.
 
+Set `LOGO_ALT` to the product or company name shown in the image. If the image is purely decorative, use an empty string instead.
+
 For a project example that embeds images directly in a loading screen with Base64 data URIs, see the [Base64 Loading Screen Images tutorial](/tutorials/advance-loading-screen/).
 
 #### Other Image Sources
 
-Project assets are still possible for non-critical decorative images where delayed appearance is acceptable, but they are not the best choice for images that need to appear immediately. The loading screen script runs very early, before the application has been fully initialized and configured. Engine APIs that depend on the initialized app, such as `app.assets`, are not immediately usable, and waiting for `preload:start` or asset registry events can add a visible delay before the image appears.
+Project assets are still possible for non-critical decorative images where delayed appearance is acceptable, but they are not the best choice for images that need to appear immediately. The loading screen script runs very early, before the application has been fully initialized and configured. The `app.assets` registry exists, but the project asset records you need may not be available until the app has been configured, and waiting for `preload:start` or asset registry events can add a visible delay before the image appears.
 
 Relative paths are also not recommended. In the Editor, assets are served through API-generated URLs, not simple paths next to the loading screen script. A relative URL can behave differently between the Launch Page, published builds, and downloaded or self-hosted builds.
 

--- a/docs/user-manual/editor/interface/launch-page/loading-screen.md
+++ b/docs/user-manual/editor/interface/launch-page/loading-screen.md
@@ -109,9 +109,9 @@ To create one:
 
 ```javascript
 pc.script.createLoadingScreen((app) => {
-    const LOGO_IMAGE = "data:image/png;base64,iVBORw0KGgo...";
+    const LOGO_IMAGE = 'data:image/png;base64,iVBORw0KGgo...';
 
-    const wrapper = document.createElement("div");
+    const wrapper = document.createElement('div');
     wrapper.style.position = "absolute";
     wrapper.style.inset = "0";
     wrapper.style.display = "flex";
@@ -120,13 +120,13 @@ pc.script.createLoadingScreen((app) => {
     wrapper.style.backgroundColor = "#232323";
     document.body.appendChild(wrapper);
 
-    const logo = document.createElement("img");
-    logo.alt = "";
+    const logo = document.createElement('img');
+    logo.alt = '';
     logo.src = LOGO_IMAGE;
     logo.style.width = "240px";
     wrapper.appendChild(logo);
 
-    app.once("start", () => {
+    app.once('start', () => {
         document.body.removeChild(wrapper);
     });
 });

--- a/docs/user-manual/editor/interface/launch-page/loading-screen.md
+++ b/docs/user-manual/editor/interface/launch-page/loading-screen.md
@@ -110,7 +110,6 @@ To create one:
 ```javascript
 pc.script.createLoadingScreen((app) => {
     const LOGO_IMAGE = 'data:image/png;base64,iVBORw0KGgo...';
-    const LOGO_ALT = 'Your product or company name';
 
     const wrapper = document.createElement('div');
     wrapper.style.position = 'absolute';
@@ -122,7 +121,7 @@ pc.script.createLoadingScreen((app) => {
     document.body.appendChild(wrapper);
 
     const logo = document.createElement('img');
-    logo.alt = LOGO_ALT;
+    logo.alt = '';
     logo.src = LOGO_IMAGE;
     logo.style.width = '240px';
     wrapper.appendChild(logo);
@@ -134,8 +133,6 @@ pc.script.createLoadingScreen((app) => {
 ```
 
 Embedding images this way increases the loading screen script size, so keep the image small and avoid using this technique for large background art.
-
-Set `LOGO_ALT` to the product or company name shown in the image. If the image is purely decorative, use an empty string instead.
 
 For a project example that embeds images directly in a loading screen with Base64 data URIs, see the [Base64 Loading Screen Images tutorial](/tutorials/advance-loading-screen/).
 

--- a/docs/user-manual/editor/interface/launch-page/loading-screen.md
+++ b/docs/user-manual/editor/interface/launch-page/loading-screen.md
@@ -109,7 +109,7 @@ To create one:
 
 ```javascript
 pc.script.createLoadingScreen((app) => {
-    const LOGO_IMAGE = 'data:image/png;base64,iVBORw0KGgo...';
+    const LOGO_IMAGE = "data:image/png;base64,iVBORw0KGgo...";
 
     const wrapper = document.createElement('div');
     wrapper.style.position = "absolute";
@@ -121,7 +121,7 @@ pc.script.createLoadingScreen((app) => {
     document.body.appendChild(wrapper);
 
     const logo = document.createElement('img');
-    logo.alt = '';
+    logo.alt = "";
     logo.src = LOGO_IMAGE;
     logo.style.width = "240px";
     wrapper.appendChild(logo);

--- a/docs/user-manual/editor/interface/launch-page/loading-screen.md
+++ b/docs/user-manual/editor/interface/launch-page/loading-screen.md
@@ -92,4 +92,56 @@ pc.script.createLoadingScreen((app) => {
 });
 ```
 
+### Adding Images
+
+A custom loading screen is normal DOM content, so you can add images with standard HTML and CSS. For branding images that should appear as soon as the loading screen is shown, the recommended approach is to embed the image as a Base64 data URI in the loading screen script.
+
+#### Recommended: Base64 Data URIs
+
+A Base64 data URI is an image encoded as text, for example `data:image/png;base64,...`. Since the data is already in the loading screen script, the browser does not need to wait for the PlayCanvas asset registry or make a separate request before it can display the image.
+
+To create one:
+
+1. Export and compress the image first. Keep logos and splash images as small as practical.
+2. Convert the image with an in-browser tool that keeps files local, such as [img64](https://www.img64.dev/), or use your team's preferred local encoder.
+3. Copy the full `data:image/...;base64,...` string into the loading screen script.
+4. Assign that string directly to `img.src`, or use it in CSS with `background-image: url("...")`.
+
+```javascript
+pc.script.createLoadingScreen((app) => {
+    const LOGO_IMAGE = 'data:image/png;base64,iVBORw0KGgo...';
+
+    const wrapper = document.createElement('div');
+    wrapper.style.position = 'absolute';
+    wrapper.style.inset = '0';
+    wrapper.style.display = 'flex';
+    wrapper.style.alignItems = 'center';
+    wrapper.style.justifyContent = 'center';
+    wrapper.style.backgroundColor = '#232323';
+    document.body.appendChild(wrapper);
+
+    const logo = document.createElement('img');
+    logo.alt = 'Logo';
+    logo.src = LOGO_IMAGE;
+    logo.style.width = '240px';
+    wrapper.appendChild(logo);
+
+    app.once('start', () => {
+        document.body.removeChild(wrapper);
+    });
+});
+```
+
+Embedding images this way increases the loading screen script size, so keep the image small and avoid using this technique for large background art.
+
+For a project example that embeds images directly in a loading screen with Base64 data URIs, see the [Base64 Loading Screen Images tutorial](/tutorials/advance-loading-screen/).
+
+#### Other Image Sources
+
+Project assets are still possible for non-critical decorative images where delayed appearance is acceptable, but they are not the best choice for images that need to appear immediately. The loading screen script runs very early, before the application has been fully initialized and configured. Engine APIs that depend on the initialized app, such as `app.assets`, are not immediately usable, and waiting for `preload:start` or asset registry events can add a visible delay before the image appears.
+
+Relative paths are also not recommended. In the Editor, assets are served through API-generated URLs, not simple paths next to the loading screen script. A relative URL can behave differently between the Launch Page, published builds, and downloaded or self-hosted builds.
+
+Hosted or CDN URLs can also work. Use the full URL directly in `img.src` or CSS `background-image`, and make sure the hosting, caching, and cross-origin behavior match your deployment requirements.
+
 Feel free to get creative! Use whatever HTML and CSS you like to create the loading screen of your dreams.

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/advance-loading-screen.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/advance-loading-screen.md
@@ -1,16 +1,16 @@
 ---
-title: '高度なローディング画面'
+title: 'Base64 ローディング画面画像'
 tags: [loading, tutorial]
 thumb: https://s3-eu-west-1.amazonaws.com/images.playcanvas.com/projects/12/458028/1A9054-image-75.jpg
-description: プロジェクトの画像 Asset でローディング画面をカスタマイズし、アプリ初期化中にブランディングやスプラッシュを表示します。
+description: Base64 画像を埋め込んでローディング画面をカスタマイズし、アプリ初期化中にブランディングやスプラッシュを表示します。
 ---
 
 import Link from '@docusaurus/Link';
 
-ローディング画面でプロジェクトの画像アセットを使用する方法を示すサンプルプロジェクト
+Base64 画像をローディング画面に直接埋め込む方法を示すサンプルプロジェクトです。
 
 <div className="iframe-container">
-    <iframe src="https://playcanv.as/p/Di3Fb3fx/" title="Advance loading screen" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
+    <iframe src="https://playcanv.as/p/Di3Fb3fx/" title="Base64 Loading Screen Images" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>
 </div>
 
 <Link to='https://playcanvas.com/project/458028/'>プロジェクトを開く ↗</Link>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/advance-loading-screen.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorials/advance-loading-screen.md
@@ -7,7 +7,7 @@ description: Base64 画像を埋め込んでローディング画面をカスタ
 
 import Link from '@docusaurus/Link';
 
-Base64 画像をローディング画面に直接埋め込む方法を示すサンプルプロジェクトです。
+Base64 の Data URI 画像をローディング画面に直接埋め込む方法を示すサンプルプロジェクトです。
 
 <div className="iframe-container">
     <iframe src="https://playcanv.as/p/Di3Fb3fx/" title="Base64 Loading Screen Images" allow="camera; microphone; xr-spatial-tracking; fullscreen" allowfullscreen></iframe>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/editor/interface/launch-page/loading-screen.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/editor/interface/launch-page/loading-screen.md
@@ -109,9 +109,9 @@ Base64 の Data URI は、画像をテキストとしてエンコードしたも
 
 ```javascript
 pc.script.createLoadingScreen((app) => {
-    const LOGO_IMAGE = "data:image/png;base64,iVBORw0KGgo...";
+    const LOGO_IMAGE = 'data:image/png;base64,iVBORw0KGgo...';
 
-    const wrapper = document.createElement("div");
+    const wrapper = document.createElement('div');
     wrapper.style.position = "absolute";
     wrapper.style.inset = "0";
     wrapper.style.display = "flex";
@@ -120,13 +120,13 @@ pc.script.createLoadingScreen((app) => {
     wrapper.style.backgroundColor = "#232323";
     document.body.appendChild(wrapper);
 
-    const logo = document.createElement("img");
-    logo.alt = "";
+    const logo = document.createElement('img');
+    logo.alt = '';
     logo.src = LOGO_IMAGE;
     logo.style.width = "240px";
     wrapper.appendChild(logo);
 
-    app.once("start", () => {
+    app.once('start', () => {
         document.body.removeChild(wrapper);
     });
 });

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/editor/interface/launch-page/loading-screen.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/editor/interface/launch-page/loading-screen.md
@@ -110,6 +110,7 @@ Base64 の Data URI は、画像をテキストとしてエンコードしたも
 ```javascript
 pc.script.createLoadingScreen((app) => {
     const LOGO_IMAGE = 'data:image/png;base64,iVBORw0KGgo...';
+    const LOGO_ALT = '製品名または会社名';
 
     const wrapper = document.createElement('div');
     wrapper.style.position = 'absolute';
@@ -121,7 +122,7 @@ pc.script.createLoadingScreen((app) => {
     document.body.appendChild(wrapper);
 
     const logo = document.createElement('img');
-    logo.alt = 'Logo';
+    logo.alt = LOGO_ALT;
     logo.src = LOGO_IMAGE;
     logo.style.width = '240px';
     wrapper.appendChild(logo);
@@ -134,11 +135,13 @@ pc.script.createLoadingScreen((app) => {
 
 この方法で画像を埋め込むとローディング画面スクリプトのサイズが大きくなるため、画像は小さく保ち、大きな背景画像には使用しないでください。
 
+`LOGO_ALT` には画像に表示されている製品名または会社名を設定してください。画像が純粋に装飾目的の場合は、代わりに空文字列を使用します。
+
 Base64 の Data URI を使って画像をローディング画面に直接埋め込むプロジェクト例については、[Base64 ローディング画面画像チュートリアル](/tutorials/advance-loading-screen/)を参照してください。
 
 #### その他の画像ソース
 
-プロジェクトアセットは、表示が遅れても問題ない補助的な装飾画像であれば使用できますが、すぐに表示する必要がある画像には最適ではありません。ローディング画面スクリプトは非常に早い段階で実行され、アプリケーションが完全に初期化および設定される前に動きます。`app.assets` のような初期化済みアプリに依存する Engine API はすぐには使用できず、`preload:start` やアセットレジストリのイベントを待つと、画像が表示されるまでに目に見える遅延が発生することがあります。
+プロジェクトアセットは、表示が遅れても問題ない補助的な装飾画像であれば使用できますが、すぐに表示する必要がある画像には最適ではありません。ローディング画面スクリプトは非常に早い段階で実行され、アプリケーションが完全に初期化および設定される前に動きます。`app.assets` レジストリ自体は存在しますが、必要なプロジェクトアセットのレコードはアプリの設定が完了するまで利用できない場合があり、`preload:start` やアセットレジストリのイベントを待つと、画像が表示されるまでに目に見える遅延が発生することがあります。
 
 相対パスもおすすめしません。Editor では、アセットはローディング画面スクリプトの隣にある単純なパスではなく、API で生成された URL を通して配信されます。相対 URL は Launch Page、公開ビルド、ダウンロードまたはセルフホストしたビルドで異なる挙動になる可能性があります。
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/editor/interface/launch-page/loading-screen.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/editor/interface/launch-page/loading-screen.md
@@ -109,24 +109,24 @@ Base64 の Data URI は、画像をテキストとしてエンコードしたも
 
 ```javascript
 pc.script.createLoadingScreen((app) => {
-    const LOGO_IMAGE = 'data:image/png;base64,iVBORw0KGgo...';
+    const LOGO_IMAGE = "data:image/png;base64,iVBORw0KGgo...";
 
-    const wrapper = document.createElement('div');
-    wrapper.style.position = 'absolute';
-    wrapper.style.inset = '0';
-    wrapper.style.display = 'flex';
-    wrapper.style.alignItems = 'center';
-    wrapper.style.justifyContent = 'center';
-    wrapper.style.backgroundColor = '#232323';
+    const wrapper = document.createElement("div");
+    wrapper.style.position = "absolute";
+    wrapper.style.inset = "0";
+    wrapper.style.display = "flex";
+    wrapper.style.alignItems = "center";
+    wrapper.style.justifyContent = "center";
+    wrapper.style.backgroundColor = "#232323";
     document.body.appendChild(wrapper);
 
-    const logo = document.createElement('img');
-    logo.alt = '';
+    const logo = document.createElement("img");
+    logo.alt = "";
     logo.src = LOGO_IMAGE;
-    logo.style.width = '240px';
+    logo.style.width = "240px";
     wrapper.appendChild(logo);
 
-    app.once('start', () => {
+    app.once("start", () => {
         document.body.removeChild(wrapper);
     });
 });

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/editor/interface/launch-page/loading-screen.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/editor/interface/launch-page/loading-screen.md
@@ -110,7 +110,6 @@ Base64 の Data URI は、画像をテキストとしてエンコードしたも
 ```javascript
 pc.script.createLoadingScreen((app) => {
     const LOGO_IMAGE = 'data:image/png;base64,iVBORw0KGgo...';
-    const LOGO_ALT = '製品名または会社名';
 
     const wrapper = document.createElement('div');
     wrapper.style.position = 'absolute';
@@ -122,7 +121,7 @@ pc.script.createLoadingScreen((app) => {
     document.body.appendChild(wrapper);
 
     const logo = document.createElement('img');
-    logo.alt = LOGO_ALT;
+    logo.alt = '';
     logo.src = LOGO_IMAGE;
     logo.style.width = '240px';
     wrapper.appendChild(logo);
@@ -134,8 +133,6 @@ pc.script.createLoadingScreen((app) => {
 ```
 
 この方法で画像を埋め込むとローディング画面スクリプトのサイズが大きくなるため、画像は小さく保ち、大きな背景画像には使用しないでください。
-
-`LOGO_ALT` には画像に表示されている製品名または会社名を設定してください。画像が純粋に装飾目的の場合は、代わりに空文字列を使用します。
 
 Base64 の Data URI を使って画像をローディング画面に直接埋め込むプロジェクト例については、[Base64 ローディング画面画像チュートリアル](/tutorials/advance-loading-screen/)を参照してください。
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/editor/interface/launch-page/loading-screen.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/editor/interface/launch-page/loading-screen.md
@@ -109,7 +109,7 @@ Base64 の Data URI は、画像をテキストとしてエンコードしたも
 
 ```javascript
 pc.script.createLoadingScreen((app) => {
-    const LOGO_IMAGE = 'data:image/png;base64,iVBORw0KGgo...';
+    const LOGO_IMAGE = "data:image/png;base64,iVBORw0KGgo...";
 
     const wrapper = document.createElement('div');
     wrapper.style.position = "absolute";
@@ -121,7 +121,7 @@ pc.script.createLoadingScreen((app) => {
     document.body.appendChild(wrapper);
 
     const logo = document.createElement('img');
-    logo.alt = '';
+    logo.alt = "";
     logo.src = LOGO_IMAGE;
     logo.style.width = "240px";
     wrapper.appendChild(logo);

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/editor/interface/launch-page/loading-screen.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/editor/interface/launch-page/loading-screen.md
@@ -92,4 +92,56 @@ pc.script.createLoadingScreen((app) => {
 });
 ```
 
+### 画像を追加する
+
+カスタムローディング画面は通常の DOM コンテンツなので、標準の HTML と CSS で画像を追加できます。ローディング画面が表示されたらすぐに見せたいブランド画像には、画像を Base64 の Data URI としてローディング画面スクリプトに埋め込む方法をおすすめします。
+
+#### 推奨: Base64 Data URI
+
+Base64 の Data URI は、画像をテキストとしてエンコードしたものです。たとえば `data:image/png;base64,...` のような形式になります。画像データがすでにローディング画面スクリプト内にあるため、ブラウザーは PlayCanvas のアセットレジストリや追加のリクエストを待たずに画像を表示できます。
+
+作成手順は次のとおりです。
+
+1. まず画像を書き出して圧縮します。ロゴやスプラッシュ画像はできるだけ小さくしてください。
+2. [img64](https://www.img64.dev/) のようにファイルをローカルに保ったままブラウザー内で処理するツールで画像を変換するか、チームで使用しているローカルエンコーダーを使用します。
+3. 完全な `data:image/...;base64,...` 文字列をローディング画面スクリプトにコピーします。
+4. その文字列を直接 `img.src` に代入するか、CSS の `background-image: url("...")` で使用します。
+
+```javascript
+pc.script.createLoadingScreen((app) => {
+    const LOGO_IMAGE = 'data:image/png;base64,iVBORw0KGgo...';
+
+    const wrapper = document.createElement('div');
+    wrapper.style.position = 'absolute';
+    wrapper.style.inset = '0';
+    wrapper.style.display = 'flex';
+    wrapper.style.alignItems = 'center';
+    wrapper.style.justifyContent = 'center';
+    wrapper.style.backgroundColor = '#232323';
+    document.body.appendChild(wrapper);
+
+    const logo = document.createElement('img');
+    logo.alt = 'Logo';
+    logo.src = LOGO_IMAGE;
+    logo.style.width = '240px';
+    wrapper.appendChild(logo);
+
+    app.once('start', () => {
+        document.body.removeChild(wrapper);
+    });
+});
+```
+
+この方法で画像を埋め込むとローディング画面スクリプトのサイズが大きくなるため、画像は小さく保ち、大きな背景画像には使用しないでください。
+
+Base64 の Data URI を使って画像をローディング画面に直接埋め込むプロジェクト例については、[Base64 ローディング画面画像チュートリアル](/tutorials/advance-loading-screen/)を参照してください。
+
+#### その他の画像ソース
+
+プロジェクトアセットは、表示が遅れても問題ない補助的な装飾画像であれば使用できますが、すぐに表示する必要がある画像には最適ではありません。ローディング画面スクリプトは非常に早い段階で実行され、アプリケーションが完全に初期化および設定される前に動きます。`app.assets` のような初期化済みアプリに依存する Engine API はすぐには使用できず、`preload:start` やアセットレジストリのイベントを待つと、画像が表示されるまでに目に見える遅延が発生することがあります。
+
+相対パスもおすすめしません。Editor では、アセットはローディング画面スクリプトの隣にある単純なパスではなく、API で生成された URL を通して配信されます。相対 URL は Launch Page、公開ビルド、ダウンロードまたはセルフホストしたビルドで異なる挙動になる可能性があります。
+
+ホスト済み URL や CDN URL も使用できます。完全な URL を `img.src` や CSS の `background-image` に直接指定し、ホスティング、キャッシュ、クロスオリジンの挙動がデプロイ要件に合っていることを確認してください。
+
 自由にクリエイティブになってください！あなたの夢のローディング画面を作成するために、好きなHTMLとCSSを使用してください。

--- a/src/pages/tutorial-data.json
+++ b/src/pages/tutorial-data.json
@@ -61,7 +61,8 @@
       "filename": "additive-loading-scenes"
     },
     {
-      "title": "Advance loading screen",
+      "title": "Base64 Loading Screen Images",
+      "description": "Customize the loading screen with embedded Base64 images so branding and splash art show while the app initializes.",
       "tags": [
         "loading",
         "tutorial"


### PR DESCRIPTION
## Summary
- Recommend Base64 data URIs for immediate loading screen branding images.
- Document the encoding workflow with an in-browser local tool and copy-paste example.
- Clarify project asset, relative path, and hosted URL tradeoffs, and update the Base64 tutorial naming in English and Japanese.

## Testing
- npm.cmd run lint
