### PR TITLE
docs: use m/s^2 for default gravity in physics settings

### DIFF
--- a/docs/user-manual/editor/interface/settings/physics.md
+++ b/docs/user-manual/editor/interface/settings/physics.md
@@ -23,7 +23,7 @@ Here is a breakdown of the available settings:
 | Setting | Description |
 | --- | --- |
 | **Physics Library** | Add the Ammo asm.js and WebAssembly modules to this project from the PlayCanvas Store. |
-| **Gravity** | Gravity is the acceleration applied every frame to all rigid bodies in your scene. By default, it is set to -9.8 meters per second per second, which essentially approximates Earth's gravity. If you are making a game in space, you might want to set this to 0, 0, 0 (zero g). |
+| **Gravity** | Gravity is the acceleration applied every frame to all rigid bodies in your scene. By default, it is set to -9.8 m/s^2, which essentially approximates Earth's gravity. If you are making a game in space, you might want to set this to 0, 0, 0 (zero g). |
 
 ### Notes
 


### PR DESCRIPTION
## Summary

- Replace awkward "meters per second per second" with `m/s^2` in the English Physics Settings gravity description, matching the existing Japanese manual.
- Fixes https://github.com/playcanvas/developer-site/issues/970

## Test plan

- [ ] Preview the Physics Settings doc page and confirm the Gravity row reads `-9.8 m/s^2`