### PR TITLE
docs: remove duplicate 'formats' in texture inspector page

### DIFF
--- a/docs/user-manual/editor/assets/inspectors/texture.md
+++ b/docs/user-manual/editor/assets/inspectors/texture.md
@@ -30,7 +30,7 @@ Imported JPG, PNG, AVIF, WebP and GIF files remain in their original format.
 
 GIF, TGA, BMP and TIF image types will be converted to JPG or PNG on import. If the imported image has transparency, it will be converted to PNG. Otherwise, it will be converted to JPG.
 
-HDR and EXR are [high dynamic range formats](https://en.wikipedia.org/wiki/High-dynamic-range_imaging) formats. Images of these types are converted to PNG on import and marked as being stored in RGBM format. RGBM essentially stores a multiplier for RGB values in the PNG's alpha channel, enabling the compression of an HDR format into a low dynamic range format.
+HDR and EXR are [high dynamic range](https://en.wikipedia.org/wiki/High-dynamic-range_imaging) formats. Images of these types are converted to PNG on import and marked as being stored in RGBM format. RGBM essentially stores a multiplier for RGB values in the PNG's alpha channel, enabling the compression of an HDR format into a low dynamic range format.
 
 By default, imported images will be resized to the nearest power of two. For example, an image that is 323x414 will be resized to 256x512 on import. This is done because the graphics engine cannot utilize mipmapping with non-power of two textures. However, this behavior can be overridden by disabling the 'Textures POT' setting in the Asset Import panel before importing a non-power of two texture.
 


### PR DESCRIPTION
## Summary
- Fix duplicate word in [Texture inspector page](https://developer.playcanvas.com/user-manual/editor/assets/inspectors/texture/): the sentence read "HDR and EXR are [high dynamic range formats](...) formats." The link text included "formats" and was followed by another "formats". Removed it from the link text so the sentence reads "HDR and EXR are [high dynamic range](...) formats."
- Japanese translation already reads correctly ("高ダイナミックレンジフォーマット" with no duplicate), so no changes needed there.

Fixes #984

## Test plan
- [x] Verified diff in `docs/user-manual/editor/assets/inspectors/texture.md`
- [x] Checked `i18n/ja/.../texture.md` — no duplicate, no change required