### PR TITLE
Document new WGSL language extensions from engine v2.19.0

### DIFF
--- a/docs/user-manual/graphics/shaders/wgsl-specifics.md
+++ b/docs/user-manual/graphics/shaders/wgsl-specifics.md
@@ -393,6 +393,26 @@ At device creation, the engine reads `navigator.gpu.wgslLanguageFeatures` and ad
   - **Preprocessor define:** `CAPS_STORAGE_TEXTURE_READ` (set when the device can load from storage textures; use to share code paths)
   - **Shader stages:** compute, when you use the feature
   - **Details:** The engine only advertises the capability; the `requires` line is author-written so usage stays explicit
+- **`device.supportsUnrestrictedPointerParameters`**
+  - **Engine injects:** `requires unrestricted_pointer_parameters;`
+  - **Preprocessor define:** `CAPS_UNRESTRICTED_POINTER_PARAMETERS`
+  - **Shader stages:** vertex, fragment, and compute
+  - **Details:** Allows passing pointers in the `storage`, `uniform`, and `workgroup` address spaces as function arguments
+- **`device.supportsPointerCompositeAccess`**
+  - **Engine injects:** `requires pointer_composite_access;`
+  - **Preprocessor define:** `CAPS_POINTER_COMPOSITE_ACCESS`
+  - **Shader stages:** vertex, fragment, and compute
+  - **Details:** Syntactic sugar for dereferencing pointers to composite types — write `p.field` and `p[i]` instead of `(*p).field` and `(*p)[i]`
+- **`device.supportsPacked4x8IntegerDotProduct`**
+  - **Engine injects:** `requires packed_4x8_integer_dot_product;`
+  - **Preprocessor define:** `CAPS_PACKED_4X8_INTEGER_DOT_PRODUCT`
+  - **Shader stages:** vertex, fragment, and compute
+  - **Details:** Exposes the DP4a-family built-ins (`dot4U8Packed`, `dot4I8Packed`, and the `pack4x{I,U}8`, `pack4x{I,U}8Clamp`, `unpack4x{I,U}8` helpers) for 8-bit packed integer dot products; useful for quantized inference and integer-heavy compute
+- **`device.supportsTextureAndSamplerLet`**
+  - **Engine injects:** `requires texture_and_sampler_let;`
+  - **Preprocessor define:** `CAPS_TEXTURE_AND_SAMPLER_LET`
+  - **Shader stages:** vertex, fragment, and compute
+  - **Details:** Allows assigning texture and sampler variables to `let` bindings (preparation for bindless-style indirection patterns)
 
 Example (compute) — use a linear workgroup index when `CAPS_LINEAR_INDEXING` is set, otherwise fall back to manual layout math:
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/wgsl-specifics.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/wgsl-specifics.md
@@ -393,6 +393,26 @@ fragDepth: @builtin(frag_depth)
   - **プリプロセッサ定義:** `CAPS_STORAGE_TEXTURE_READ`（デバイスがストレージテクスチャの読み取りに対応しているときに有効。コードパス分岐用）
   - **シェーダー段階:** 機能を使う場合にコンピュート
   - **説明:** エンジンは能力の宣言のみ。`requires` は必ず筆者が書く想定
+- **`device.supportsUnrestrictedPointerParameters`**
+  - **エンジンが注入:** `requires unrestricted_pointer_parameters;`
+  - **プリプロセッサ定義:** `CAPS_UNRESTRICTED_POINTER_PARAMETERS`
+  - **シェーダー段階:** 頂点・フラグメント・コンピュート
+  - **説明:** `storage`・`uniform`・`workgroup` アドレス空間のポインタを関数の引数として渡せるようにします
+- **`device.supportsPointerCompositeAccess`**
+  - **エンジンが注入:** `requires pointer_composite_access;`
+  - **プリプロセッサ定義:** `CAPS_POINTER_COMPOSITE_ACCESS`
+  - **シェーダー段階:** 頂点・フラグメント・コンピュート
+  - **説明:** 複合型へのポインタのデリファレンスの糖衣構文。`(*p).field` や `(*p)[i]` の代わりに `p.field` や `p[i]` と書けます
+- **`device.supportsPacked4x8IntegerDotProduct`**
+  - **エンジンが注入:** `requires packed_4x8_integer_dot_product;`
+  - **プリプロセッサ定義:** `CAPS_PACKED_4X8_INTEGER_DOT_PRODUCT`
+  - **シェーダー段階:** 頂点・フラグメント・コンピュート
+  - **説明:** 8ビットパック整数の内積向け DP4a 系の組み込み関数（`dot4U8Packed`、`dot4I8Packed`、および `pack4x{I,U}8`、`pack4x{I,U}8Clamp`、`unpack4x{I,U}8` ヘルパー）を公開します。量子化推論や整数中心のコンピュートに有用
+- **`device.supportsTextureAndSamplerLet`**
+  - **エンジンが注入:** `requires texture_and_sampler_let;`
+  - **プリプロセッサ定義:** `CAPS_TEXTURE_AND_SAMPLER_LET`
+  - **シェーダー段階:** 頂点・フラグメント・コンピュート
+  - **説明:** テクスチャ・サンプラー変数を `let` バインディングに代入できるようにします（バインドレス的な間接参照パターンへの準備）
 
 使用例（コンピュート）— `CAPS_LINEAR_INDEXING` があるときは線形のワークグループ番号を使い、なければ従来の方法で求めます。
 


### PR DESCRIPTION
Engine [v2.19.0](https://github.com/playcanvas/engine/releases/tag/v2.19.0) added detection for several more WGSL language features (device caps that auto-inject `requires …;` directives). This adds them to the **WGSL Specifics → WGSL language extensions** list.

**New entries (each injected for vertex/fragment/compute):**
- `device.supportsUnrestrictedPointerParameters` → `requires unrestricted_pointer_parameters;` / `CAPS_UNRESTRICTED_POINTER_PARAMETERS` (PR #8785)
- `device.supportsPointerCompositeAccess` → `requires pointer_composite_access;` / `CAPS_POINTER_COMPOSITE_ACCESS` (PR #8786)
- `device.supportsPacked4x8IntegerDotProduct` → `requires packed_4x8_integer_dot_product;` / `CAPS_PACKED_4X8_INTEGER_DOT_PRODUCT` (PR #8787)
- `device.supportsTextureAndSamplerLet` → `requires texture_and_sampler_let;` / `CAPS_TEXTURE_AND_SAMPLER_LET` (PR #8790)

The release's other WGSL change (`linear_indexing` + `CAPS_STORAGE_TEXTURE_READ`, PR #8648) was already documented.

Names, injected directives, and CAPS defines verified against the engine source (`graphics-device.js`, `shader-definition-utils.js`). Mirrored across the Japanese (`i18n/ja`) docs.