### PR TITLE
Surface the Streaming page in the SuperSplat overview and regroup it

### DIFF
--- a/docs/user-manual/supersplat/index.md
+++ b/docs/user-manual/supersplat/index.md
@@ -18,6 +18,7 @@ flowchart LR
     Explore([Explore])
     Viewer([Viewer<br/>embed / self-host])
     Convert([Convert])
+    Streaming([Streamed SOG / LOD])
 
     PLY --> Editor --> Manage
     PLY --> Upload --> Manage
@@ -27,6 +28,9 @@ flowchart LR
     Manage --> Scene
     Scene --> Explore
     Scene --> Viewer
+    Editor -.-> Streaming
+    Upload -.-> Streaming
+    Streaming -.-> Viewer
 ```
 
 :::tip You can skip the Editor
@@ -48,6 +52,8 @@ If you already have a clean splat file, you don't need to use the Editor. Hit th
 | **[User Profile](user-profile)** | A user's public page: avatar, bio, social links, their published splats. | `superspl.at/user?id=<username>` |
 | **[Viewer](viewer/)** | The open-source web viewer that powers scene pages and Editor HTML exports. Embed in your own page or self-host. | npm `@playcanvas/supersplat-viewer`, [GitHub](https://github.com/playcanvas/supersplat-viewer) |
 | **[Convert](convert)** | Web frontend to the [splat-transform](/user-manual/splat-transform/) CLI: convert formats, transform, and filter in the browser. | [superspl.at/convert](https://superspl.at/convert) |
+
+Behind the scenes, every published splat is compressed to the SOG format, and large splats (over 1 million Gaussians) are automatically LOD-streamed for fast loading on any device — see [Streaming & Performance](streaming).
 
 ## Open source vs hosted
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/supersplat/index.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/supersplat/index.md
@@ -18,6 +18,7 @@ flowchart LR
     Explore([Explore])
     Viewer([Viewer<br/>embed / self-host])
     Convert([Convert])
+    Streaming([Streamed SOG / LOD])
 
     PLY --> Editor --> Manage
     PLY --> Upload --> Manage
@@ -27,6 +28,9 @@ flowchart LR
     Manage --> Scene
     Scene --> Explore
     Scene --> Viewer
+    Editor -.-> Streaming
+    Upload -.-> Streaming
+    Streaming -.-> Viewer
 ```
 
 :::tip Editorを省略することもできます
@@ -48,6 +52,8 @@ flowchart LR
 | **[User Profile](user-profile)** | ユーザーの公開ページ：アバター、自己紹介、ソーシャルリンク、公開済みスプラット。 | `superspl.at/user?id=<username>` |
 | **[Viewer](viewer/)** | シーンページとEditorのHTMLエクスポートを動かしているオープンソースのウェブビューア。自分のページに埋め込むか、セルフホストできます。 | npm `@playcanvas/supersplat-viewer`、[GitHub](https://github.com/playcanvas/supersplat-viewer) |
 | **[Convert](convert)** | [splat-transform](/user-manual/splat-transform/) CLIのウェブフロントエンド：ブラウザ上で形式変換、トランスフォーム、フィルタを実行します。 | [superspl.at/convert](https://superspl.at/convert) |
+
+舞台裏では、公開されたすべてのスプラットはSOG形式に圧縮され、大きなスプラット（100万ガウシアンを超えるもの）は、どのデバイスでも高速に読み込めるよう自動的にLODストリーミングされます — [ストリーミングとパフォーマンス](streaming)を参照してください。
 
 ## オープンソース vs ホスト型
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -559,7 +559,6 @@ const sidebars = {
         },
         'user-manual/supersplat/upload',
         'user-manual/supersplat/manage',
-        'user-manual/supersplat/streaming',
         {
           type: 'category',
           label: 'Studio',
@@ -579,6 +578,7 @@ const sidebars = {
         'user-manual/supersplat/scene-page',
         'user-manual/supersplat/explore',
         'user-manual/supersplat/user-profile',
+        'user-manual/supersplat/streaming',
         {
           type: 'category',
           label: 'Viewer',


### PR DESCRIPTION
## Overview

Follow-up to #1021. A holistic review of the SuperSplat docs structure found the organization sound overall, with one weak spot: the new **Streaming & Performance** page was undiscoverable from the overview and sat mid-creator-flow in the sidebar. This addresses both. EN + JA.

## Changes

- **Sidebar (`sidebars.js`)** — moved `streaming` from after **Manage** to just before the **Viewer** category, grouping the delivery/runtime topics (Streaming + Viewer) instead of interrupting the creator-surfaces run (Editor → Upload → Manage → Studio).
- **Overview (`index.md`)** — the Streaming page had zero references on the SuperSplat landing page. Added:
  - a behind-the-scenes node in the mermaid diagram (`Editor`/`Upload` -.-> `Streamed SOG / LOD` -.-> `Viewer`, dotted), and
  - a one-line link after the platform table noting large published splats are auto LOD-streamed.

  (Streaming is a process, not a "surface" with a URL, so it's intentionally not added as a row in the surfaces table.)

## Verification

- `markdownlint-cli2` → 0 errors.
- `npm run build` → passes; mermaid renders (new edges reuse existing `-.->` syntax), sidebar shows Streaming in its new slot, overview link resolves. Only the pre-existing unrelated `gaussian-splatting/lod-streaming` anchor warning remains.

---

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer-site/blob/main/.github/CONTRIBUTING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)