### PR TITLE
Make sidebar section headings stand out with an orange accent bar

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -294,23 +294,21 @@ html[data-theme='dark'] .navbar--github-link:before {
 
 /* Sidebar section headers */
 .sidebar-section-header {
-  font-weight: 600;
-  font-size: 0.85rem;
+  font-weight: 700;
+  font-size: 0.78rem;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: var(--ifm-color-emphasis-600);
+  letter-spacing: 0.6px;
+  color: var(--ifm-color-emphasis-900); /* near-foreground, high contrast, stays neutral */
   margin: 1.5rem 0 0.5rem 0;
   padding: 0.25rem 0;
-  border-top: 1px solid var(--ifm-color-emphasis-200);
-  padding-left: var(--ifm-menu-link-padding-horizontal);
+  border-left: 3px solid var(--ifm-color-primary);
+  padding-left: calc(var(--ifm-menu-link-padding-horizontal) - 3px);
 }
 
 .sidebar-section-header:first-of-type {
   margin-top: 0.75rem;
-  border-top: none;
 }
 
 [data-theme='dark'] .sidebar-section-header {
-  color: var(--ifm-color-emphasis-500);
-  border-top-color: var(--ifm-color-emphasis-300);
+  color: var(--ifm-color-emphasis-1000);
 }

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -294,6 +294,8 @@ html[data-theme='dark'] .navbar--github-link:before {
 
 /* Sidebar section headers */
 .sidebar-section-header {
+  --sidebar-section-accent-width: 3px;
+
   font-weight: 700;
   font-size: 0.78rem;
   text-transform: uppercase;
@@ -301,8 +303,9 @@ html[data-theme='dark'] .navbar--github-link:before {
   color: var(--ifm-color-emphasis-900); /* near-foreground, high contrast, stays neutral */
   margin: 1.5rem 0 0.5rem 0;
   padding: 0.25rem 0;
-  border-left: 3px solid var(--ifm-color-primary);
-  padding-left: calc(var(--ifm-menu-link-padding-horizontal) - 3px);
+  border-left: var(--sidebar-section-accent-width) solid var(--ifm-color-primary);
+  /* keep heading text aligned with the links below by subtracting the bar width */
+  padding-left: calc(var(--ifm-menu-link-padding-horizontal) - var(--sidebar-section-accent-width));
 }
 
 .sidebar-section-header:first-of-type {


### PR DESCRIPTION
## Summary

The sidebar section headings (COMMON TOPICS, CORE PRODUCTS, etc.) were styled in muted gray with only a thin top border, so they blended into the nav links below and didn't clearly signal a new section.

This change gives them **bold, high-contrast text plus a 3px brand-orange left accent bar**:

- Heading text is darkened to `--ifm-color-emphasis-900`/`-1000` and bumped to weight 700 so it reads as a strong label.
- A 3px orange left bar (`--ifm-color-primary`) adds brand emphasis and visually caps each group. `padding-left` subtracts the bar width so heading text stays aligned with the links beneath it.
- The heading **text stays neutral** — orange text remains exclusive to the active/current item, so there's no clash with the active-state highlight.
- The bar uses `--ifm-color-primary`, which is already retuned to a lighter orange in dark mode, so it adapts to both themes with no dark-mode override.

Several treatments (background band, hairline rule, accent bar, plain high-contrast) were mocked up side by side and compared in light + dark mode; the orange accent bar was chosen.

## Test plan

- `npm run develop` and confirm headings clearly stand out from the nav links, each with an orange left accent bar.
- Toggle dark mode and confirm the lighter orange bar and bright text stay legible.
- Confirm the active/current item's orange highlight is still the only orange *text* in the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)