### PR TITLE
Update Reddit crosspost label to match current UI

### DIFF
--- a/docs/user-manual/getting-started/community.md
+++ b/docs/user-manual/getting-started/community.md
@@ -28,7 +28,7 @@ To join:
 :::tip[tips for posting]
 
 * An **Image & Video** post will perform much better than a **Text** post.
-* Try **crossposting** your PlayCanvas posts to related subreddits such as [WebGL](https://www.reddit.com/r/webgl/), [WebGPU](https://www.reddit.com/r/webgpu/) and [WebXR](https://www.reddit.com/r/WebXR/) - but always read each subreddit's rules first! To crosspost, select **Share** > **Crosspost** underneath your post.
+* Try **crossposting** your PlayCanvas posts to related subreddits such as [WebGL](https://www.reddit.com/r/webgl/), [WebGPU](https://www.reddit.com/r/webgpu/) and [WebXR](https://www.reddit.com/r/WebXR/) - but always read each subreddit's rules first! To crosspost, select **Share** > **Repost** underneath your post, then choose the target community.
 
 :::
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/getting-started/community.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/getting-started/community.md
@@ -28,7 +28,7 @@ Redditは、PlayCanvasの作品を共有したり、質問したり、PlayCanvas
 :::tip[投稿のヒント]
 
 * **画像と動画**の投稿は、**テキスト**の投稿よりもはるかに良いパフォーマンスを発揮します。
-* [WebGL](https://www.reddit.com/r/webgl/)、[WebGPU](https://www.reddit.com/r/webgpu/)、[WebXR](https://www.reddit.com/r/WebXR/)などの関連subredditにPlayCanvasの投稿を**クロスポスト**してみてください。ただし、常に各subredditのルールを最初に読んでください！クロスポストするには、投稿の下にある**共有** > **クロスポスト**を選択します。
+* [WebGL](https://www.reddit.com/r/webgl/)、[WebGPU](https://www.reddit.com/r/webgpu/)、[WebXR](https://www.reddit.com/r/WebXR/)などの関連subredditにPlayCanvasの投稿を**クロスポスト**してみてください。ただし、常に各subredditのルールを最初に読んでください！クロスポストするには、投稿の下にある**共有** > **リポスト**を選択し、投稿先のコミュニティを選びます。
 
 :::
 


### PR DESCRIPTION
## Summary

Reddit renamed the **Crosspost** option in the Share menu to **Repost**. This updates the Join the Community page to match the current UI and adds a short clarification that you then pick the target community.

## Changes

- `docs/user-manual/getting-started/community.md` — `Share > Crosspost` → `Share > Repost`, plus "then choose the target community".
- Mirrored the same change into the Japanese translation (`クロスポスト` → `リポスト`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
