### PR TITLE
fix: stop 'PlayCanvas Web Components' sidebar label wrapping

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -488,6 +488,7 @@ const sidebars = {
     {
       type: 'category',
       label: 'PlayCanvas Web Components',
+      className: 'sidebar-item-nowrap',
       link: {
         type: 'doc',
         id: 'user-manual/web-components/index',

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -315,3 +315,8 @@ html[data-theme='dark'] .navbar--github-link:before {
 [data-theme='dark'] .sidebar-section-header {
   color: var(--ifm-color-emphasis-1000);
 }
+
+/* Keep long sidebar labels on a single line regardless of OS/browser font metrics */
+.sidebar-item-nowrap > .menu__list-item-collapsible > .menu__link {
+  white-space: nowrap;
+}


### PR DESCRIPTION
## What changed

- Added `className: 'sidebar-item-nowrap'` to the **PlayCanvas Web Components** category in `sidebars.js`
- Added a matching CSS rule in `src/css/custom.scss` that applies `white-space: nowrap` to that item's sidebar link

## Why

The 'PlayCanvas Web Components' sidebar label is borderline at the 310px sidebar width, so depending on OS/browser font metrics it sometimes rendered on one line and sometimes wrapped 'Components' onto a second line. This pins it to a single line everywhere.

## Notes for reviewers

- The fix is scoped to this one item rather than all sidebar links, to avoid clipping risk on deeply nested labels. The class is reusable if other labels develop the same issue.
- There's comfortably enough horizontal room for the label on one line (~185px of text in ~240px of space), so `nowrap` won't overflow into the collapse caret.
- The CSS targets the rendered `menu__link` element, so the Japanese locale (shared sidebar structure) is covered too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)