### PR TITLE
feat: overhaul llms.txt generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "faq": "node faq.js",
     "faq-to-json": "node faq_to_json.js --dir faq --out ../editor/static/json/howdoi.json",
     "generate-tutorial-data": "node utils/generate-tutorial-data.mjs",
-    "lint": "markdownlint-cli2 docs i18n .github/CONTRIBUTING.md README.md"
+    "lint": "markdownlint-cli2 docs i18n .github/CONTRIBUTING.md README.md",
+    "preview-llms": "node utils/plugins/llms/preview.mjs"
   },
   "dependencies": {
     "@docusaurus/core": "^3.10.1",

--- a/utils/plugins/docusaurus-plugin-llms.mjs
+++ b/utils/plugins/docusaurus-plugin-llms.mjs
@@ -267,7 +267,8 @@ function getCategoryFromPath(urlPath) {
 // that consumers can skip when a shorter context is needed)
 const OPTIONAL_SUBCATEGORIES = ['account-management', 'glossary', 'press-pack', 'security'];
 
-// User Manual subcategory order, matching sidebars.js
+// User Manual subcategory order, following sidebars.js (minus the
+// subcategories in OPTIONAL_SUBCATEGORIES, which render under '## Optional')
 const USER_MANUAL_ORDER = [
     'Overview',
     'getting-started',

--- a/utils/plugins/docusaurus-plugin-llms.mjs
+++ b/utils/plugins/docusaurus-plugin-llms.mjs
@@ -1,6 +1,7 @@
 // utils/plugins/docusaurus-plugin-llms.mjs
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import yaml from 'js-yaml';
 
 /**
@@ -12,8 +13,8 @@ import yaml from 'js-yaml';
  * @param {Object} context - Docusaurus context
  * @param {Object} options - Plugin options
  * @param {string} [options.docsDir='docs'] - Path to docs directory relative to site root
- * @param {string[]} [options.excludeDirs=['shader-editor']] - Directories to exclude from
- *   LLM file generation (e.g., private or unlisted documentation sections)
+ * @param {string[]} [options.excludeDirs=['shader-editor', 'tutorials']] - Directories to exclude
+ *   from LLM file generation (e.g., private or unlisted documentation sections)
  * @param {boolean} [options.failOnError=false] - If true, build will fail when LLM file
  *   generation encounters an error. If false (default), errors are logged as warnings
  *   and the build continues. Set to true if LLM files are critical to your deployment.
@@ -22,7 +23,7 @@ export default function pluginLlms(context, options = {}) {
     const { siteDir, siteConfig } = context;
     const docsDir = path.join(siteDir, options.docsDir || 'docs');
     const baseUrl = siteConfig.url;
-    const excludeDirs = options.excludeDirs ?? ['shader-editor'];
+    const excludeDirs = options.excludeDirs ?? ['shader-editor', 'tutorials'];
     const failOnError = options.failOnError ?? false;
 
     return {
@@ -50,7 +51,8 @@ export default function pluginLlms(context, options = {}) {
                 processedDocs.sort((a, b) => a.urlPath.localeCompare(b.urlPath));
 
                 // Generate llms.txt (structured overview)
-                const llmsTxt = generateLlmsTxt(processedDocs, baseUrl);
+                const engineVersion = resolveEngineVersion(siteDir);
+                const llmsTxt = generateLlmsTxt(processedDocs, baseUrl, engineVersion);
                 const llmsTxtPath = path.join(outDir, 'llms.txt');
                 fs.writeFileSync(llmsTxtPath, llmsTxt, 'utf-8');
                 console.log(`[LLMs Plugin] Generated ${llmsTxtPath}`);
@@ -261,36 +263,141 @@ function getCategoryFromPath(urlPath) {
     return categoryMap[parts[0]] || parts[0];
 }
 
+// Subcategories rendered under '## Optional' (per the llms.txt spec, a section
+// that consumers can skip when a shorter context is needed)
+const OPTIONAL_SUBCATEGORIES = ['account-management', 'glossary', 'press-pack', 'security'];
+
+// User Manual subcategory order, matching sidebars.js
+const USER_MANUAL_ORDER = [
+    'Overview',
+    'getting-started',
+    'engine', 'editor', 'react', 'web-components',
+    'supersplat', 'splat-transform',
+    'ecs', 'assets', 'scripting', 'graphics', 'gaussian-splatting',
+    'animation', 'physics', '2D', 'user-interface', 'xr',
+    'optimization', 'api', 'pcui'
+];
+
+/**
+ * Resolve the installed PlayCanvas engine version, or null if unavailable
+ */
+function resolveEngineVersion(siteDir) {
+    try {
+        const pkgPath = path.join(siteDir, 'node_modules', 'playcanvas', 'package.json');
+        return JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version || null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Load the hand-written llms.txt header partial
+ */
+function loadHeaderTemplate() {
+    const templatePath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'llms', 'llms-header.md');
+    return fs.readFileSync(templatePath, 'utf-8').replace(/\r\n/g, '\n');
+}
+
+/**
+ * Substitute {{NAME}} placeholders, then drop any line with an unresolved
+ * placeholder (e.g. the engine version line when resolution failed)
+ */
+function applyTemplate(template, vars) {
+    const substituted = template.replace(/\{\{(\w+)\}\}/g, (match, name) => {
+        const value = vars[name];
+        return (value === null || value === undefined) ? match : String(value);
+    });
+    return substituted
+        .split('\n')
+        .filter(line => !/\{\{\w+\}\}/.test(line))
+        .join('\n');
+}
+
+/**
+ * Format a doc as an llms.txt list entry: - [Title](url): description
+ * (If per-page markdown variants are published later, the link target changes here.)
+ */
+function formatDocEntry(doc, baseUrl) {
+    const title = doc.title.replace(/\s+/g, ' ').replace(/[[\]]/g, '\\$&').trim();
+    let description = (doc.description || '').replace(/\s+/g, ' ').trim();
+    if (description.length > 300) {
+        description = `${description.slice(0, 300)}...`;
+    }
+    const link = `- [${title}](${baseUrl}${doc.urlPath})`;
+    return description ? `${link}: ${description}` : link;
+}
+
+/**
+ * Format a subcategory slug as a display name
+ */
+function formatSubcategoryName(subcat) {
+    // Acronyms that should be fully uppercased
+    const acronyms = new Set(['api', 'xr', '2d', 'ui', 'ecs', 'pcui']);
+    // Brand names with specific capitalization
+    const brandNames = { 'playcanvas': 'PlayCanvas', 'supersplat': 'SuperSplat' };
+    return subcat
+        .split('-')
+        .map((word) => {
+            const lower = word.toLowerCase();
+            if (acronyms.has(lower)) return word.toUpperCase();
+            if (brandNames[lower]) return brandNames[lower];
+            return word.charAt(0).toUpperCase() + word.slice(1);
+        })
+        .join(' ');
+}
+
+/**
+ * Render subcategory groups as lines: an H3 heading when a subcategory has
+ * multiple docs, then one list entry per doc
+ */
+function renderSubcategorySections(subcategories, order, baseUrl) {
+    const lines = [];
+
+    // Sort subcategories: use defined order if available, otherwise alphabetical
+    const sortedSubcats = Object.keys(subcategories).sort((a, b) => {
+        if (order) {
+            const indexA = order.indexOf(a);
+            const indexB = order.indexOf(b);
+            // Items in order come first, in their defined order
+            if (indexA !== -1 && indexB !== -1) return indexA - indexB;
+            if (indexA !== -1) return -1;
+            if (indexB !== -1) return 1;
+        }
+        // Fallback to alphabetical
+        return a.localeCompare(b);
+    });
+
+    for (const subcat of sortedSubcats) {
+        const subcatDocs = subcategories[subcat];
+
+        if (subcatDocs.length > 1) {
+            lines.push(`### ${formatSubcategoryName(subcat)}`);
+        }
+
+        for (const doc of subcatDocs) {
+            lines.push(formatDocEntry(doc, baseUrl));
+        }
+
+        if (subcatDocs.length > 1) {
+            lines.push('');
+        }
+    }
+
+    return lines;
+}
+
 /**
  * Generate the llms.txt file (structured overview)
  */
-function generateLlmsTxt(docs, baseUrl) {
+function generateLlmsTxt(docs, baseUrl, engineVersion) {
     const lines = [];
 
-    lines.push(`# PlayCanvas Developer Documentation
-
-> PlayCanvas is an open-source WebGL/WebGPU 3D game engine for creating interactive experiences and games that run in the browser.
-
-This file provides a structured overview of the PlayCanvas documentation.
-For the complete documentation content, see: ${baseUrl}/llms-full.txt
-
-Base URL: ${baseUrl}
-Total Documents: ${docs.length}
-Generated: ${new Date().toISOString().split('T')[0]}
-
-## Recommended Entry Points
-
-- Getting Started: ${baseUrl}/user-manual/getting-started/
-- PlayCanvas Editor: ${baseUrl}/user-manual/editor/
-- PlayCanvas Engine: ${baseUrl}/user-manual/engine/
-- PlayCanvas React: ${baseUrl}/user-manual/react/
-- Web Components: ${baseUrl}/user-manual/web-components/
-- Scripting: ${baseUrl}/user-manual/scripting/
-- Gaussian Splatting: ${baseUrl}/user-manual/gaussian-splatting/
-- Graphics: ${baseUrl}/user-manual/graphics/
-- Physics: ${baseUrl}/user-manual/physics/
-- XR (VR/AR): ${baseUrl}/user-manual/xr/
-`);
+    lines.push(applyTemplate(loadHeaderTemplate(), {
+        BASE_URL: baseUrl,
+        ENGINE_VERSION: engineVersion,
+        TOTAL_DOCS: String(docs.length),
+        DATE: new Date().toISOString().split('T')[0]
+    }));
 
     // Group by category
     const categories = {};
@@ -301,96 +408,41 @@ Generated: ${new Date().toISOString().split('T')[0]}
         categories[doc.category].push(doc);
     }
 
-    // Define category order
-    const categoryOrder = ['User Manual', 'Tutorials'];
-
-    // Define subcategory order to match sidebars.js
-    const subcategoryOrder = {
-        'User Manual': [
-            'index', 'getting-started', 'account-management',
-            'engine', 'editor', 'react', 'web-components',
-            'ecs', 'assets', 'scripting', 'graphics', 'gaussian-splatting',
-            'animation', 'physics', '2D', 'user-interface', 'xr',
-            'optimization', 'api', 'pcui', 'glossary', 'press-pack'
-        ]
-    };
-
-    // Output each category
-    for (const category of categoryOrder) {
-        if (!categories[category]) continue;
-
-        lines.push(`## ${category}\n`);
-
-        // Group by subcategory (second level path)
-        const subcategories = {};
-        for (const doc of categories[category]) {
-            const parts = doc.urlPath.split('/').filter(Boolean);
-            const subcat = parts.length > 1 ? parts[1] : 'Overview';
-            if (!subcategories[subcat]) {
-                subcategories[subcat] = [];
-            }
-            subcategories[subcat].push(doc);
+    // User Manual: group by subcategory (second level path), holding back
+    // secondary subcategories for the '## Optional' section
+    const mainSubcats = {};
+    const optionalSubcats = {};
+    for (const doc of categories['User Manual'] ?? []) {
+        const parts = doc.urlPath.split('/').filter(Boolean);
+        const subcat = parts.length > 1 ? parts[1] : 'Overview';
+        const target = OPTIONAL_SUBCATEGORIES.includes(subcat) ? optionalSubcats : mainSubcats;
+        if (!target[subcat]) {
+            target[subcat] = [];
         }
-
-        // Sort subcategories: use defined order if available, otherwise alphabetical
-        const order = subcategoryOrder[category];
-        const sortedSubcats = Object.keys(subcategories).sort((a, b) => {
-            if (order) {
-                const indexA = order.indexOf(a);
-                const indexB = order.indexOf(b);
-                // Items in order come first, in their defined order
-                if (indexA !== -1 && indexB !== -1) return indexA - indexB;
-                if (indexA !== -1) return -1;
-                if (indexB !== -1) return 1;
-            }
-            // Fallback to alphabetical
-            return a.localeCompare(b);
-        });
-
-        for (const subcat of sortedSubcats) {
-            const subcatDocs = subcategories[subcat];
-
-            // Format subcategory name
-            // Acronyms that should be fully uppercased
-            const acronyms = new Set(['api', 'xr', '2d', 'ui', 'ecs', 'pcui']);
-            // Brand names with specific capitalization
-            const brandNames = { 'playcanvas': 'PlayCanvas' };
-            const subcatName = subcat
-                .split('-')
-                .map((word) => {
-                    const lower = word.toLowerCase();
-                    if (acronyms.has(lower)) return word.toUpperCase();
-                    if (brandNames[lower]) return brandNames[lower];
-                    return word.charAt(0).toUpperCase() + word.slice(1);
-                })
-                .join(' ');
-
-            if (subcatDocs.length > 1) {
-                lines.push(`### ${subcatName}`);
-            }
-
-            for (const doc of subcatDocs) {
-                lines.push(`- ${baseUrl}${doc.urlPath} - ${doc.title}`);
-            }
-
-            if (subcatDocs.length > 1) {
-                lines.push('');
-            }
-        }
+        target[subcat].push(doc);
     }
+
+    lines.push('## User Manual\n');
+    lines.push(...renderSubcategorySections(mainSubcats, USER_MANUAL_ORDER, baseUrl));
 
     // Add any remaining categories
     for (const category of Object.keys(categories)) {
-        if (categoryOrder.includes(category)) continue;
+        if (category === 'User Manual') continue;
 
         const docLinks = categories[category]
-            .map(doc => `- ${baseUrl}${doc.urlPath} - ${doc.title}`)
+            .map(doc => formatDocEntry(doc, baseUrl))
             .join('\n');
 
         lines.push(`## ${category}\n\n${docLinks}\n`);
     }
 
-    return lines.join('\n');
+    if (Object.keys(optionalSubcats).length > 0) {
+        lines.push('## Optional\n');
+        lines.push('Secondary content that most coding tasks will not need.\n');
+        lines.push(...renderSubcategorySections(optionalSubcats, OPTIONAL_SUBCATEGORIES, baseUrl));
+    }
+
+    return `${lines.join('\n').trimEnd()}\n`;
 }
 
 /**

--- a/utils/plugins/llms/llms-header.md
+++ b/utils/plugins/llms/llms-header.md
@@ -153,7 +153,7 @@ Custom scripts attach to an entity via a `<pc-scripts>` element wrapping one `<p
 
 ### 6. Versions
 
-The current stable engine version is shown in the metadata at the top of this file. PlayCanvas Engine 2.x is the current major version; prefer current API names from https://api.playcanvas.com/engine/ over deprecated 1.x-era patterns.
+If the metadata at the top of this file includes an Engine Version line, generate code against that release. PlayCanvas Engine 2.x is the current major version; prefer current API names from https://api.playcanvas.com/engine/ over deprecated 1.x-era patterns.
 
 ## Recommended Entry Points
 

--- a/utils/plugins/llms/llms-header.md
+++ b/utils/plugins/llms/llms-header.md
@@ -1,0 +1,226 @@
+# PlayCanvas Developer Documentation
+
+> PlayCanvas is an open-source WebGL/WebGPU 3D engine for building games, configurators, and interactive 3D experiences that run in any browser. It can be used via the browser-based PlayCanvas Editor, as a standalone engine from npm/CDN, through React components, or through Web Components.
+
+This file is a structured overview of the PlayCanvas developer documentation.
+Complete documentation content: {{BASE_URL}}/llms-full.txt
+Full API reference: https://api.playcanvas.com
+
+Base URL: {{BASE_URL}}
+Engine Version: {{ENGINE_VERSION}}
+Total Documents: {{TOTAL_DOCS}}
+Generated: {{DATE}}
+
+## Instructions for Large Language Models
+
+When generating PlayCanvas code, follow these guidelines:
+
+### 1. Identify Which of the Four Workflows the User Is In
+
+PlayCanvas is used in four distinct ways. Do not mix patterns between them:
+
+1. **PlayCanvas Editor** (browser-based editor at https://playcanvas.com): gameplay code is written as scripts attached to entities. See {{BASE_URL}}/user-manual/editor/
+2. **Engine only** (code-first): `npm install playcanvas` or load from a CDN, then build the scene programmatically. See {{BASE_URL}}/user-manual/engine/
+3. **React**: `npm install @playcanvas/react playcanvas` for declarative scenes in JSX. See {{BASE_URL}}/user-manual/react/
+4. **Web Components**: `npm install playcanvas @playcanvas/web-components` for declarative scenes in plain HTML. See {{BASE_URL}}/user-manual/web-components/
+
+### 2. Editor Scripting: ESM Scripts vs Classic Scripts
+
+There are two script formats. ESM scripts are the modern, recommended format. Never blend the two syntaxes in one file.
+
+WRONG - mixing classic and ESM patterns:
+
+```javascript
+import { Script } from 'playcanvas';
+
+export class Rotate extends Script {
+    // WRONG: classic-style attribute declaration does not exist on ESM scripts
+    static attributes = { speed: { type: 'number', default: 10 } };
+
+    initialize() {
+        // WRONG: classic 'attr:' change events are NOT supported by ESM scripts
+        this.on('attr:speed', () => {});
+    }
+}
+```
+
+CORRECT - ESM script (file extension MUST be `.mjs` for the Editor to recognize it):
+
+```javascript
+import { Script } from 'playcanvas';
+
+export class Rotate extends Script {
+    static scriptName = 'rotate';
+
+    /** @attribute */
+    speed = 10;
+
+    initialize() {
+        // setup
+    }
+
+    update(dt) {
+        this.entity.rotate(0, this.speed * dt, 0);
+    }
+}
+```
+
+CORRECT - classic script (legacy but fully supported, plain `.js` files):
+
+```javascript
+var Rotate = pc.createScript('rotate');
+
+Rotate.attributes.add('speed', { type: 'number', default: 10 });
+
+Rotate.prototype.initialize = function () {
+    // setup
+};
+
+Rotate.prototype.update = function (dt) {
+    this.entity.rotate(0, this.speed * dt, 0);
+};
+```
+
+Key rules:
+
+- ESM scripts require the `.mjs` file extension and a `static scriptName` property.
+- ESM script attributes are class fields tagged with a `/** @attribute */` JSDoc comment, not `attributes.add()`.
+- ESM scripts do not support classic `attr:[name]` change events.
+
+### 3. Engine-Only Usage (npm or CDN)
+
+CORRECT - ES Modules with an import map (no build step):
+
+```html
+<script type="importmap">
+    {
+        "imports": {
+            "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas/+esm"
+        }
+    }
+</script>
+<script type="module">
+    import * as pc from 'playcanvas';
+
+    // create graphics device, app, entities...
+</script>
+```
+
+Or with a bundler: `npm install playcanvas` then `import * as pc from 'playcanvas'`.
+
+### 4. React Usage
+
+```jsx
+import { Application, Entity } from '@playcanvas/react';
+import { Camera, Light, Render } from '@playcanvas/react/components';
+
+const App = () => (
+    <Application>
+        <Entity name="camera" position={[4, 1, 4]}>
+            <Camera />
+        </Entity>
+        <Entity name="light" rotation={[45, 45, 0]}>
+            <Light type="directional" />
+        </Entity>
+        <Entity name="ball">
+            <Render type="sphere" />
+        </Entity>
+    </Application>
+);
+```
+
+Hooks (e.g. `useModel`, `useEnvAtlas`) are imported from `@playcanvas/react/hooks`.
+
+### 5. Web Components Usage
+
+```html
+<pc-app>
+    <pc-scene>
+        <pc-entity name="camera" position="0 0 3">
+            <pc-camera></pc-camera>
+        </pc-entity>
+        <pc-entity name="light" rotation="45 45 0">
+            <pc-light type="directional"></pc-light>
+        </pc-entity>
+        <pc-entity name="ball">
+            <pc-render type="sphere"></pc-render>
+        </pc-entity>
+    </pc-scene>
+</pc-app>
+```
+
+Custom scripts attach to an entity via a `<pc-scripts>` element wrapping one `<pc-script>` element per script.
+
+### 6. Versions
+
+The current stable engine version is shown in the metadata at the top of this file. PlayCanvas Engine 2.x is the current major version; prefer current API names from https://api.playcanvas.com/engine/ over deprecated 1.x-era patterns.
+
+## Recommended Entry Points
+
+- [Getting Started]({{BASE_URL}}/user-manual/getting-started/): Learn the platform, make a first project, and find your workflow.
+- [PlayCanvas Editor]({{BASE_URL}}/user-manual/editor/): The collaborative browser-based editor for building scenes, assets, and games.
+- [PlayCanvas Engine]({{BASE_URL}}/user-manual/engine/): Using the open-source engine standalone from npm or a CDN.
+- [PlayCanvas React]({{BASE_URL}}/user-manual/react/): Declarative 3D scenes with @playcanvas/react components and hooks.
+- [Web Components]({{BASE_URL}}/user-manual/web-components/): Declarative 3D scenes in plain HTML with @playcanvas/web-components.
+- [Scripting]({{BASE_URL}}/user-manual/scripting/): Script lifecycle, attributes, events, and the ESM vs classic script formats.
+- [Gaussian Splatting]({{BASE_URL}}/user-manual/gaussian-splatting/): Rendering 3D Gaussian splats, formats, and building splat applications.
+- [Graphics]({{BASE_URL}}/user-manual/graphics/): Cameras, lighting, materials, shaders, and post effects.
+- [Physics]({{BASE_URL}}/user-manual/physics/): Rigid bodies, collision, triggers, and forces with the ammo.js integration.
+- [XR (VR/AR)]({{BASE_URL}}/user-manual/xr/): WebXR-based virtual and augmented reality.
+
+## Essential API
+
+The full API reference lives at https://api.playcanvas.com. Engine classes follow the pattern `https://api.playcanvas.com/engine/classes/<ClassName>.html`.
+
+### Application & Scene
+
+- [AppBase](https://api.playcanvas.com/engine/classes/AppBase.html): Base application class - manages the update loop, component systems, and asset registry.
+- [Application](https://api.playcanvas.com/engine/classes/Application.html): Convenience application class for engine-only (standalone) projects.
+- [Entity](https://api.playcanvas.com/engine/classes/Entity.html): Scene-graph node that components attach to; provides transform methods.
+- [Scene](https://api.playcanvas.com/engine/classes/Scene.html): Scene-level rendering settings such as skybox, fog, and ambient light.
+
+### Scripting
+
+- [Script](https://api.playcanvas.com/engine/classes/Script.html): Base class for ESM scripts with initialize/update lifecycle methods.
+- [ScriptComponent](https://api.playcanvas.com/engine/classes/ScriptComponent.html): Manages the scripts attached to an entity.
+
+### Components
+
+- [CameraComponent](https://api.playcanvas.com/engine/classes/CameraComponent.html): Renders the scene from the entity's viewpoint.
+- [LightComponent](https://api.playcanvas.com/engine/classes/LightComponent.html): Directional, omni, or spot light source.
+- [RenderComponent](https://api.playcanvas.com/engine/classes/RenderComponent.html): Renders meshes, including primitive shapes and imported models.
+- [CollisionComponent](https://api.playcanvas.com/engine/classes/CollisionComponent.html): Collision volume for physics and trigger events.
+- [RigidBodyComponent](https://api.playcanvas.com/engine/classes/RigidBodyComponent.html): Static, dynamic, or kinematic physics body.
+- [AnimComponent](https://api.playcanvas.com/engine/classes/AnimComponent.html): Animation state graph playback and blending.
+- [ScreenComponent](https://api.playcanvas.com/engine/classes/ScreenComponent.html): Root of a 2D screen-space or world-space UI hierarchy.
+- [ElementComponent](https://api.playcanvas.com/engine/classes/ElementComponent.html): UI image, text, or group element.
+- [SoundComponent](https://api.playcanvas.com/engine/classes/SoundComponent.html): Positional and non-positional audio playback.
+- [GSplatComponent](https://api.playcanvas.com/engine/classes/GSplatComponent.html): Renders 3D Gaussian splats.
+
+### Graphics & Assets
+
+- [StandardMaterial](https://api.playcanvas.com/engine/classes/StandardMaterial.html): The default PBR material with diffuse, metalness, gloss, and emissive channels.
+- [Texture](https://api.playcanvas.com/engine/classes/Texture.html): GPU texture resource.
+- [GraphicsDevice](https://api.playcanvas.com/engine/classes/GraphicsDevice.html): WebGL/WebGPU rendering interface.
+- [Asset](https://api.playcanvas.com/engine/classes/Asset.html): A reference to a loadable resource such as a model, texture, or audio file.
+- [AssetRegistry](https://api.playcanvas.com/engine/classes/AssetRegistry.html): Loads and looks up assets at runtime (available as app.assets).
+
+### Math
+
+- [Vec3](https://api.playcanvas.com/engine/classes/Vec3.html): 3-dimensional vector.
+- [Quat](https://api.playcanvas.com/engine/classes/Quat.html): Quaternion rotation.
+- [Color](https://api.playcanvas.com/engine/classes/Color.html): RGBA color.
+
+### Input
+
+- [Keyboard](https://api.playcanvas.com/engine/classes/Keyboard.html): Keyboard input (available as app.keyboard).
+- [Mouse](https://api.playcanvas.com/engine/classes/Mouse.html): Mouse input (available as app.mouse).
+
+### Other API References
+
+- [Engine API](https://api.playcanvas.com/engine/): Full engine reference - rendering, physics, animation, sound, XR.
+- [Editor API](https://api.playcanvas.com/editor/): Scripting the PlayCanvas Editor itself.
+- [Web Components API](https://api.playcanvas.com/web-components/): Custom element reference.
+- [PCUI](https://api.playcanvas.com/pcui/) / [PCUI Graph](https://api.playcanvas.com/pcui-graph/): UI component library for tools and node-based editors.
+- [Observer](https://api.playcanvas.com/observer/): Reactive data observation and binding.
+- [SplatTransform](https://api.playcanvas.com/splat-transform/): Library and CLI for converting and editing Gaussian splats.

--- a/utils/plugins/llms/preview.mjs
+++ b/utils/plugins/llms/preview.mjs
@@ -1,0 +1,19 @@
+// Usage: node utils/plugins/llms/preview.mjs [outDir]
+// Generates llms.txt + llms-full.txt without a full Docusaurus build.
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import pluginLlms from '../docusaurus-plugin-llms.mjs';
+
+const siteDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const outDir = process.argv[2] ?? fs.mkdtempSync(path.join(os.tmpdir(), 'llms-preview-'));
+fs.mkdirSync(outDir, { recursive: true });
+
+const plugin = pluginLlms(
+    { siteDir, siteConfig: { url: 'https://developer.playcanvas.com' } },
+    { failOnError: true }
+);
+await plugin.postBuild({ outDir });
+console.log(`\nPreview written to: ${outDir}`);


### PR DESCRIPTION
## What

Overhauls the generated [llms.txt](https://developer.playcanvas.com/llms.txt) so it actively steers LLMs and coding agents toward correct PlayCanvas code, instead of being a flat link dump.

### New llms.txt structure

```
# PlayCanvas Developer Documentation
> blockquote + metadata (Base URL, Engine Version, Total Documents, Generated)
## Instructions for Large Language Models   <- NEW: WRONG/CORRECT code patterns
## Recommended Entry Points                  <- now spec-format links with descriptions
## Essential API                             <- NEW: 26 curated engine classes + all API ref sections
## User Manual                               <- entries now `- [Title](url): description`
## Optional                                  <- NEW: account management, glossary, press pack, security
```

### Changes

- **Instructions section**: hand-written guidance covering the four PlayCanvas workflows (Editor, engine-only, React, Web Components), ESM vs classic script syntax with explicit WRONG/CORRECT examples, and npm/CDN setup. All snippets verified against the engine, react, and web-components repos.
- **Spec-compliant entries**: the llms.txt spec format is `- [Title](url): description`. The plugin already extracted per-page descriptions (100% of docs have hand-written frontmatter descriptions) but never used them — they're now wired in.
- **Essential API section**: api.playcanvas.com was previously absent from the file entirely. Adds 26 curated engine class links (all verified 200) plus the other API reference sections.
- **`## Optional` section**: spec mechanism for content consumers can skip — account management, glossary, press pack, security.
- **Tutorials excluded from both generated files**: many are dated or are bare project links; removing them avoids feeding stale patterns to LLMs. One-line `excludeDirs` change, easy to revert after a tutorial refresh.
- **Engine version in metadata**: read from the installed `playcanvas` package at build time; the line is dropped gracefully if resolution fails.
- **Subcategory ordering fixes**: dead `'index'` entry replaced with `'Overview'`; `supersplat`, `splat-transform`, `security` were missing from the order list and now match `sidebars.js`.
- **Preview harness**: `npm run preview-llms [outDir]` generates both files in ~2 seconds without a full Docusaurus build, for fast iteration on the curated content.

The hand-written header lives in `utils/plugins/llms/llms-header.md` (placeholder-substituted at build time), so content edits don't touch plugin code. `llms-full.txt` generation logic is unchanged.

## Verification

- Baseline/after comparison via the preview harness: `llms-full.txt` URL set differs from baseline by exactly the 147 tutorial docs — zero User Manual docs lost, zero additions.
- New `llms.txt`: 452 docs + 42 curated entries, all in `- [Title](url): description` format; zero old-format lines; zero unresolved `{{placeholders}}`; `Engine Version: 2.19.6` present; balanced code fences; Optional partition verified.
- All 33 curated api.playcanvas.com URLs and spot-checked developer-site URLs return 200.
- `npm run lint` passes (1248 files, 0 errors).

## Follow-ups (separate PRs)

- Emit a per-page `.md` next to each built HTML page and link those from llms.txt (link construction is isolated in `formatDocEntry` for this).
- An llms.txt for api.playcanvas.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
