### PR TITLE
docs: replace Tutorials header link with an Examples menu

### DIFF
--- a/docs/user-manual/react/examples/index.md
+++ b/docs/user-manual/react/examples/index.md
@@ -2,3 +2,24 @@
 title: Examples
 description: Live, editable PlayCanvas React examples you can run and modify directly in the documentation.
 ---
+
+Less talking, more doing. Each example below runs live on the page and is fully editable — change the code and the scene updates instantly. Together they show how components, hooks, asset loading and physics come together in a real PlayCanvas React app.
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '20px', margin: '24px 0 40px' }}>
+  <a className="card padding--md shadow--md" href="/user-manual/react/examples/model-viewer" style={{ color: 'inherit', textDecoration: 'none' }}>
+    <div style={{ fontWeight: 700, fontSize: '1.1rem', marginBottom: '6px' }}>Model Viewer</div>
+    <div style={{ opacity: 0.8 }}>Load a glb model with environment lighting, a shadow catcher and auto-rotating orbit controls.</div>
+  </a>
+  <a className="card padding--md shadow--md" href="/user-manual/react/examples/motion" style={{ color: 'inherit', textDecoration: 'none' }}>
+    <div style={{ fontWeight: 700, fontSize: '1.1rem', marginBottom: '6px' }}>Motion</div>
+    <div style={{ opacity: 0.8 }}>Animate entities and lights with springs from the Motion animation library.</div>
+  </a>
+  <a className="card padding--md shadow--md" href="/user-manual/react/examples/physics" style={{ color: 'inherit', textDecoration: 'none' }}>
+    <div style={{ fontWeight: 700, fontSize: '1.1rem', marginBottom: '6px' }}>Physics</div>
+    <div style={{ opacity: 0.8 }}>Disturb a cluster of rigid bodies in zero gravity with the pointer.</div>
+  </a>
+</div>
+
+Want to build something of your own? Spin up a full project in seconds with the [StackBlitz template](https://playcanvas-react.vercel.app/new), or browse the [interactive playground](https://playcanvas-react.vercel.app/examples) for more live examples.
+
+New to PlayCanvas React? Start with the [Guide](/user-manual/react/guide) to see how scenes are composed, then explore the [API reference](/user-manual/react/api).

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -316,9 +316,15 @@ const config = {
             path: '/user-manual',
           },
           {
-            to: '/tutorials/',
-            label: 'Tutorials',
+            type: 'dropdown',
+            label: 'Examples',
             position: 'left',
+            items: [
+              { label: 'Engine Examples', href: 'https://playcanvas.com/examples' },
+              { label: 'Editor Tutorials', to: '/tutorials/' },
+              { label: 'React Examples', to: '/user-manual/react/examples' },
+              { label: 'Web Components Examples', href: 'https://playcanvas.github.io/web-components/examples/' },
+            ],
           },
           {
             href: 'https://api.playcanvas.com',

--- a/i18n/ja/docusaurus-plugin-content-docs/current.json
+++ b/i18n/ja/docusaurus-plugin-content-docs/current.json
@@ -275,6 +275,14 @@
     "message": "例",
     "description": "The label for category Examples in sidebar userManualSidebar"
   },
+  "sidebar.userManualSidebar.link.Examples": {
+    "message": "例",
+    "description": "The label for link Examples in sidebar userManualSidebar"
+  },
+  "sidebar.userManualSidebar.link.Tutorials": {
+    "message": "チュートリアル",
+    "description": "The label for link Tutorials in sidebar userManualSidebar"
+  },
   "sidebar.userManualSidebar.category.PCUI Graph": {
     "message": "PCUIグラフ",
     "description": "The label for category PCUI Graph in sidebar userManualSidebar"

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/react/examples/index.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/react/examples/index.md
@@ -2,3 +2,24 @@
 title: 例
 description: ドキュメント内で直接実行・編集できる、ライブのPlayCanvas Reactサンプル集です。
 ---
+
+百聞は一見にしかず。以下の各サンプルはページ上でライブに動作し、自由に編集できます。コードを変更すると、シーンが即座に更新されます。コンポーネント、フック、アセットの読み込み、物理が、実際の PlayCanvas React アプリでどのように組み合わさるのかを確認できます。
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '20px', margin: '24px 0 40px' }}>
+  <a className="card padding--md shadow--md" href="/user-manual/react/examples/model-viewer" style={{ color: 'inherit', textDecoration: 'none' }}>
+    <div style={{ fontWeight: 700, fontSize: '1.1rem', marginBottom: '6px' }}>モデルビューア</div>
+    <div style={{ opacity: 0.8 }}>環境ライティング、シャドウキャッチャー、自動回転するオービットコントロールを備えた glb モデルを読み込みます。</div>
+  </a>
+  <a className="card padding--md shadow--md" href="/user-manual/react/examples/motion" style={{ color: 'inherit', textDecoration: 'none' }}>
+    <div style={{ fontWeight: 700, fontSize: '1.1rem', marginBottom: '6px' }}>モーション</div>
+    <div style={{ opacity: 0.8 }}>Motion アニメーションライブラリのスプリングを使って、エンティティとライトをアニメーションさせます。</div>
+  </a>
+  <a className="card padding--md shadow--md" href="/user-manual/react/examples/physics" style={{ color: 'inherit', textDecoration: 'none' }}>
+    <div style={{ fontWeight: 700, fontSize: '1.1rem', marginBottom: '6px' }}>物理</div>
+    <div style={{ opacity: 0.8 }}>ポインターを動かして、無重力空間にある剛体の集まりをかき乱します。</div>
+  </a>
+</div>
+
+自分でも作ってみたいですか？[StackBlitz テンプレート](https://playcanvas-react.vercel.app/new)を使えば、数秒でプロジェクトを立ち上げられます。さらに多くのライブサンプルは、[インタラクティブなプレイグラウンド](https://playcanvas-react.vercel.app/examples)で確認できます。
+
+PlayCanvas React は初めてですか？まずは[ガイド](/user-manual/react/guide)でシーンの構成方法を学び、その後[API リファレンス](/user-manual/react/api)を確認してみましょう。

--- a/i18n/ja/docusaurus-theme-classic/navbar.json
+++ b/i18n/ja/docusaurus-theme-classic/navbar.json
@@ -11,9 +11,25 @@
     "message": "ユーザーマニュアル",
     "description": "Navbar item with label User Manual"
   },
-  "item.label.Tutorials": {
-    "message": "チュートリアル",
-    "description": "Navbar item with label Tutorials"
+  "item.label.Examples": {
+    "message": "例",
+    "description": "Navbar item with label Examples"
+  },
+  "item.label.Engine Examples": {
+    "message": "エンジンの例",
+    "description": "Navbar item with label Engine Examples"
+  },
+  "item.label.Editor Tutorials": {
+    "message": "エディターのチュートリアル",
+    "description": "Navbar item with label Editor Tutorials"
+  },
+  "item.label.React Examples": {
+    "message": "React の例",
+    "description": "Navbar item with label React Examples"
+  },
+  "item.label.Web Components Examples": {
+    "message": "Web Components の例",
+    "description": "Navbar item with label Web Components Examples"
   },
   "item.label.API": {
     "message": "API",

--- a/sidebars.js
+++ b/sidebars.js
@@ -86,6 +86,7 @@ const sidebars = {
         'user-manual/engine/standalone',
         'user-manual/engine/running-in-node',
         'user-manual/engine/migrations',
+        { type: 'link', label: 'Examples', href: 'https://playcanvas.com/examples' },
       ],
     },
     {
@@ -385,6 +386,7 @@ const sidebars = {
         'user-manual/editor/engine-compatibility',
         'user-manual/editor/faq',
         'user-manual/editor/troubleshooting',
+        { type: 'link', label: 'Tutorials', href: '/tutorials/' },
       ],
     },
     {
@@ -531,6 +533,7 @@ const sidebars = {
             'user-manual/web-components/tags/pc-sounds',
           ],
         },
+        { type: 'link', label: 'Examples', href: 'https://playcanvas.github.io/web-components/examples/' },
       ],
     },
     {


### PR DESCRIPTION
## What

Replaces the global **Tutorials** header link with an **Examples** dropdown, and standardizes how each PlayCanvas development product surfaces its examples.

- **Header:** `Tutorials` → `Examples` dropdown with one entry per product:
  - Engine Examples → `https://playcanvas.com/examples`
  - Editor Tutorials → `/tutorials/`
  - React Examples → `/user-manual/react/examples`
  - Web Components Examples → `https://playcanvas.github.io/web-components/examples/`
- **Sidebars:** each development product now exposes its learn-by-example resource in its own User Manual section — *Examples* for Engine and Web Components, *Tutorials* for the Editor (React already had an *Examples* category).
- **React examples landing page:** previously just a title; now has an intro, a card grid linking to the three live examples (Model Viewer, Motion, Physics), and links to the StackBlitz template, interactive playground, Guide and API reference.
- **Japanese locale** mirrored throughout (navbar dropdown + child labels, sidebar link labels, and the examples landing page).

## Why

The header (`User Manual | Tutorials | API`) predates the reorganization of the docs around 6 products. Every one of the 4 development products (Engine, Editor, React, Web Components) has a "learn-by-example" resource, but only the Editor's Tutorials was promoted to the global header — and labelled so generically ("Tutorials" for *what*?) that it read as site-wide. An Examples menu with one item per product answers that question and surfaces the previously scattered collections in one place.

The `/tutorials/` page, its URL, content and tag filter are untouched — only where it is linked from has changed, so there is no discoverability loss on the page itself.

## Verified

Ran the dev server (`npm run start`) and confirmed:
- The **Examples** dropdown renders with all four items and each target resolves (two external, two internal).
- Each product's sidebar shows its new entry (Engine → Examples, Editor → Tutorials, Web Components → Examples, React → Examples) and all links resolve.
- The React examples landing page renders the intro + card grid; all internal links resolve to real routes.
- No new console errors or server/build errors; the Japanese translation JSON files parse and carry the expected keys.

> `docusaurus start` only serves the default locale, so the Japanese strings were validated by inspecting the parsed JSON and the mirrored landing page; CI builds all locales.

## Left unchanged (out of scope)

The footer's `Tutorials → /tutorials/` link and the homepage "Tutorials" card still point to the (unchanged) `/tutorials/` page. Happy to realign those in a follow-up if wanted.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer-site/blob/main/.github/CONTRIBUTING.md).
