### PR TITLE
fix: resolve duplicate ja sidebar translation keys for Examples links

### DIFF
--- a/i18n/ja/docusaurus-plugin-content-docs/current.json
+++ b/i18n/ja/docusaurus-plugin-content-docs/current.json
@@ -275,9 +275,13 @@
     "message": "例",
     "description": "The label for category Examples in sidebar userManualSidebar"
   },
-  "sidebar.userManualSidebar.link.Examples": {
+  "sidebar.userManualSidebar.link.engine-examples": {
     "message": "例",
-    "description": "The label for link Examples in sidebar userManualSidebar"
+    "description": "The label for link 'Examples' in sidebar 'userManualSidebar' (item 'engine-examples')"
+  },
+  "sidebar.userManualSidebar.link.web-components-examples": {
+    "message": "例",
+    "description": "The label for link 'Examples' in sidebar 'userManualSidebar' (item 'web-components-examples')"
   },
   "sidebar.userManualSidebar.link.Tutorials": {
     "message": "チュートリアル",

--- a/sidebars.js
+++ b/sidebars.js
@@ -86,7 +86,7 @@ const sidebars = {
         'user-manual/engine/standalone',
         'user-manual/engine/running-in-node',
         'user-manual/engine/migrations',
-        { type: 'link', label: 'Examples', href: 'https://playcanvas.com/examples' },
+        { type: 'link', label: 'Examples', key: 'engine-examples', href: 'https://playcanvas.com/examples' },
       ],
     },
     {
@@ -533,7 +533,7 @@ const sidebars = {
             'user-manual/web-components/tags/pc-sounds',
           ],
         },
-        { type: 'link', label: 'Examples', href: 'https://playcanvas.github.io/web-components/examples/' },
+        { type: 'link', label: 'Examples', key: 'web-components-examples', href: 'https://playcanvas.github.io/web-components/examples/' },
       ],
     },
     {


### PR DESCRIPTION
## Summary
- Fixes production build failure for the `ja` locale caused by two sidebar links both labeled "Examples" mapping to the same Docusaurus translation key (`sidebar.userManualSidebar.link.Examples`).
- Adds unique `key` attributes on the Engine and Web Components external Examples links in `sidebars.js` and updates the matching Japanese translation entries in `current.json`.

## Test plan
- [x] `npm run build` completes successfully for both `en` and `ja`


Made with [Cursor](https://cursor.com)