### PR TITLE
docs: link Screen and Element API pages from the Fonts page

### DIFF
--- a/docs/user-manual/user-interface/fonts.md
+++ b/docs/user-manual/user-interface/fonts.md
@@ -77,7 +77,7 @@ No loading code is required. Drag the Font asset onto the **Font** slot of a Tex
 </TabItem>
 <TabItem value="react" label="React">
 
-In [PlayCanvas React](/user-manual/react), font-tools is the standalone alternative to the build-time `?sdf` conversion offered by the [`@playcanvas/rollup`](https://www.npmjs.com/package/@playcanvas/plugin) plugin. Load the generated `.json` with [`useFont`](/user-manual/react/api/hooks/use-asset#usefont), then assign it to a text `<Element>` inside a `<Screen>`:
+In [PlayCanvas React](/user-manual/react), font-tools is the standalone alternative to the build-time `?sdf` conversion offered by the [`@playcanvas/rollup`](https://www.npmjs.com/package/@playcanvas/plugin) plugin. Load the generated `.json` with [`useFont`](/user-manual/react/api/hooks/use-asset#usefont), then assign it to a text [`<Element>`](/user-manual/react/api/element) inside a [`<Screen>`](/user-manual/react/api/screen):
 
 ```tsx
 import { Entity } from '@playcanvas/react';

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/user-interface/fonts.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/user-interface/fonts.md
@@ -77,7 +77,7 @@ app.assets.load(asset);
 </TabItem>
 <TabItem value="react" label="React">
 
-[PlayCanvas React](/user-manual/react) では、font-tools は [`@playcanvas/rollup`](https://www.npmjs.com/package/@playcanvas/plugin) プラグインが提供するビルド時の `?sdf` 変換に対する、スタンドアロンの代替手段です。生成された `.json` を [`useFont`](/user-manual/react/api/hooks/use-asset#usefont) で読み込み、`<Screen>` 内のテキスト `<Element>` に割り当てます。
+[PlayCanvas React](/user-manual/react) では、font-tools は [`@playcanvas/rollup`](https://www.npmjs.com/package/@playcanvas/plugin) プラグインが提供するビルド時の `?sdf` 変換に対する、スタンドアロンの代替手段です。生成された `.json` を [`useFont`](/user-manual/react/api/hooks/use-asset#usefont) で読み込み、[`<Screen>`](/user-manual/react/api/screen) 内のテキスト [`<Element>`](/user-manual/react/api/element) に割り当てます。
 
 ```tsx
 import { Entity } from '@playcanvas/react';


### PR DESCRIPTION
## Overview

Small follow-up to #1065, which added the React `<Screen/>` and `<Element/>` API reference pages.

The Fonts page's **React** tab names `<Element>` and `<Screen>` in prose but didn't link them — there were no API pages to link to until #1065 merged. This adds those cross-links, matching how the same tab already links `useFont`.

## What changed

- `docs/user-manual/user-interface/fonts.md` (+ Japanese mirror): in the React tab, link `<Element>` → `/user-manual/react/api/element` and `<Screen>` → `/user-manual/react/api/screen`.

## Scope

Intentionally limited to the React tab. The Web Components tab's `<pc-screen>` is a separate tag system, and the Engine/Editor tabs already link appropriately — so neither was touched.

## Verification

Reloaded the Fonts page in the Docusaurus dev server: both links render in the React tab and resolve to the new API pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
