### PR TITLE
docs(shaders): add v2.20 msdfPS chunk migration entry

### DIFF
--- a/docs/user-manual/graphics/shaders/migrations.md
+++ b/docs/user-manual/graphics/shaders/migrations.md
@@ -29,6 +29,23 @@ By doing this you will no longer see warning messages in the console.
 
 The following tables break down the chunk changes by Engine release.
 
+### *Engine v2.20*
+
+#### MSDF text rendering reworked
+
+The `msdfPS` chunk used by `ElementComponent` text was reworked to render glyphs at their true (designer-intended) edge and to anti-alias from the gradient of the distance field, fixing a fixed inward erosion that broke thin junctions (e.g. the crossbar of an `f`). See [PR #8935](https://github.com/playcanvas/engine/pull/8935) for details.
+
+As part of this, the engine no longer sets the `font_pxrange` and `font_textureWidth` uniforms, and the `map()` helper was removed from the chunk. A custom `msdfPS` override copied from an earlier release that still references these uniforms will no longer receive their values (they default to `0`, producing a divide-by-zero in the old smoothing calculation), resulting in broken or invisible text.
+
+Affected chunks:
+
+- `src/scene/shader-lib/glsl/chunks/common/frag/msdf.js`
+- `src/scene/shader-lib/wgsl/chunks/common/frag/msdf.js`
+
+**Migration:** Update any custom `msdfPS` override against the latest chunk — remove references to `font_pxrange`, `font_textureWidth` and `map()`, and adopt the new edge/anti-aliasing logic. Deliberate weight adjustments should use the per-font `font_sdfIntensity` (or `outlineThickness`) rather than a global threshold bias.
+
+---
+
 ### *Engine v2.16*
 
 #### Gaussian Splat Accessor Function Renames

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/migrations.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/migrations.md
@@ -28,6 +28,21 @@ material.chunks.APIVersion = pc.CHUNKAPI_1_55;
 
 次の表は、Engine リリースごとのチャンクの変更点をまとめたものです。
 
+### *Engine v2.20*
+
+#### MSDF テキストレンダリングの刷新
+
+`ElementComponent` のテキストで使用される `msdfPS` チャンクが刷新され、グリフを本来の(デザイナーが意図した)エッジでレンダリングし、距離フィールドの勾配からアンチエイリアスを行うようになりました。これにより、`f` の横棒など細い接合部を崩していた固定的な内側への収縮(erosion)が修正されました。詳細は [PR #8935](https://github.com/playcanvas/engine/pull/8935) を参照してください。
+
+この変更に伴い、エンジンは `font_pxrange` および `font_textureWidth` ユニフォームを設定しなくなり、`map()` ヘルパーがチャンクから削除されました。以前のリリースからコピーしたカスタムの `msdfPS` オーバーライドがこれらのユニフォームを参照している場合、それらの値が渡されなくなり(既定値の `0` となり、従来のスムージング計算でゼロ除算が発生します)、テキストが壊れたり表示されなくなったりします。
+
+影響を受けるチャンク:
+
+- `src/scene/shader-lib/glsl/chunks/common/frag/msdf.js`
+- `src/scene/shader-lib/wgsl/chunks/common/frag/msdf.js`
+
+**移行方法:** カスタムの `msdfPS` オーバーライドを最新のチャンクに合わせて更新してください。`font_pxrange`、`font_textureWidth`、`map()` への参照を削除し、新しいエッジ/アンチエイリアスのロジックを採用します。意図的なウェイト調整は、グローバルなしきい値のバイアスではなく、フォントごとの `font_sdfIntensity`(または `outlineThickness`)を使用してください。
+
 ### *Engine v2.6*
 
 #### Internal engine chunks

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/migrations.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/migrations.md
@@ -43,6 +43,104 @@ material.chunks.APIVersion = pc.CHUNKAPI_1_55;
 
 **移行方法:** カスタムの `msdfPS` オーバーライドを最新のチャンクに合わせて更新してください。`font_pxrange`、`font_textureWidth`、`map()` への参照を削除し、新しいエッジ/アンチエイリアスのロジックを採用します。意図的なウェイト調整は、グローバルなしきい値のバイアスではなく、フォントごとの `font_sdfIntensity`(または `outlineThickness`)を使用してください。
 
+---
+
+### *Engine v2.16*
+
+#### Gaussian Splat アクセサ関数の名称変更
+
+gsplat シェーダーのアクセサ関数が、API の一貫性のために名称変更されました。すべての関数が `getXXX()` という命名パターンを使用するようになりました。
+
+| 旧 | 新 |
+| --- | --- |
+| `readCenter(source)` | `getCenter()` |
+| `readColor(source)` | `getColor()` |
+
+**注意:** `getCenter()` は、他の関数が使用する共有データを読み込むため、`getRotation()`、`getScale()`、`getColor()` よりも先に呼び出す必要があります。`source` パラメータは不要になりました。
+
+影響を受けるチャンク:
+
+- `src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplat.js`
+- `src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js`
+
+#### gsplatCustomizeVS チャンクの削除
+
+`gsplatCustomizeVS` シェーダーチャンクは v2.16 で削除されました。これは v2.15 で `gsplatModifyVS` の導入に伴い非推奨となっていたものです。`gsplatCustomizeVS` を引き続き使用しているコードは、チャンクが削除されたという警告が表示されるようになります。
+
+旧来の共分散ベースのヘルパー関数（`gsplatExtractSize`、`gsplatApplyUniformScale`、`gsplatMakeRound`）も `gsplatHelpers.js` から削除されました。
+
+**移行方法:**
+
+下記の v2.15 移行ガイドに記載されているとおり、`gsplatModifyVS` へ移行する必要があります。完全な移行手順については [v2.15 移行ガイド](#engine-v215) を参照してください。
+
+---
+
+### *Engine v2.15*
+
+#### Gaussian Splat シェーダーのカスタマイズ
+
+`gsplatCustomizeVS` シェーダーチャンクは非推奨となり、`gsplatModifyVS` に置き換えられました。新しいチャンクは、共分散行列の代わりに回転クォータニオンとスケールベクトルを使用する、より効率的な API を提供します。詳細は [PR #8246](https://github.com/playcanvas/engine/pull/8246) を参照してください。
+
+| 旧 (`gsplatCustomizeVS`) | 新 (`gsplatModifyVS`) |
+| --- | --- |
+| `modifyCenter(inout vec3 center)` | `modifySplatCenter(inout vec3 center)` |
+| `modifyCovariance(originalCenter, modifiedCenter, inout covA, inout covB)` | `modifySplatRotationScale(originalCenter, modifiedCenter, inout rotation, inout scale)` |
+| `modifyColor(center, inout color)` | `modifySplatColor(center, inout color)` |
+
+ヘルパー関数の変更:
+
+| 旧 | 新 |
+| --- | --- |
+| `gsplatApplyUniformScale(covA, covB, scale)` | `scale *= factor`（直接乗算） |
+| `gsplatExtractSize(covA, covB)` | `gsplatGetSizeFromScale(scale)` |
+| `gsplatMakeRound(covA, covB, radius)` | `gsplatMakeSpherical(scale, radius)` |
+
+**移行例 (GLSL):**
+
+変更前:
+
+```glsl
+void modifyCenter(inout vec3 center) {
+    center.y += 1.0;
+}
+
+void modifyCovariance(vec3 originalCenter, vec3 modifiedCenter, inout vec3 covA, inout vec3 covB) {
+    gsplatApplyUniformScale(covA, covB, 2.0);
+}
+
+void modifyColor(vec3 center, inout vec4 color) {
+    color.rgb *= 0.5;
+}
+```
+
+変更後:
+
+```glsl
+void modifySplatCenter(inout vec3 center) {
+    center.y += 1.0;
+}
+
+void modifySplatRotationScale(vec3 originalCenter, vec3 modifiedCenter, inout vec4 rotation, inout vec3 scale) {
+    scale *= 2.0;
+}
+
+void modifySplatColor(vec3 center, inout vec4 color) {
+    color.rgb *= 0.5;
+}
+```
+
+**JavaScript での使用例:**
+
+```javascript
+// 変更前
+gsplatMaterial.getShaderChunks(shaderLanguage).set('gsplatCustomizeVS', customShader);
+
+// 変更後
+gsplatMaterial.getShaderChunks(shaderLanguage).set('gsplatModifyVS', customShader);
+```
+
+---
+
 ### *Engine v2.6*
 
 #### Internal engine chunks


### PR DESCRIPTION
!!!!!!!! MERGE WHEN engine v2.20.0 is out !!!!!!!!!

## Summary

Updates the shader chunk migrations page (English + Japanese):

1. **Adds an Engine v2.20 entry** documenting the `msdfPS` chunk rework, companion to engine PR playcanvas/engine#8935 (will be merged shortly).
2. **Backfills the Japanese page** with the v2.16 and v2.15 entries it was missing, so it structurally matches the English page.

### v2.20 entry

The engine PR:
- Reworks `msdfPS` to render text at the true glyph edge and anti-alias from the distance-field gradient.
- Removes the `font_pxrange` and `font_textureWidth` uniforms (no longer set by the engine) and the `map()` helper.
- Registers `msdfPS` in the chunk-version table at API `2.20`, so a custom override of the chunk is flagged by the chunk validator.

The migration note warns that a custom `msdfPS` override copied from an earlier release that still references the removed uniforms will no longer receive their values — the old smoothing calculation then hits a divide-by-zero, breaking text — and points users to update their override and bump `shaderChunksVersion` to `2.20`.

### Japanese backfill

The JA page lagged the English one, with its newest entry at v2.6. Added translated **v2.16** (gsplat accessor renames, `gsplatCustomizeVS` removal) and **v2.15** (gsplat shader customization) entries so the two pages list the same releases.

## Changes

- `docs/user-manual/graphics/shaders/migrations.md` — English v2.20 entry.
- `i18n/ja/.../graphics/shaders/migrations.md` — Japanese v2.20 entry + backfilled v2.16 / v2.15.

## Notes

- Links the engine PR, which is open but expected to merge shortly.
