### PR TITLE
Pin playcanvas to ~2.19.7 to fix broken build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "js-yaml": "^5.2.0",
         "leva": "^0.10.1",
         "motion": "^12.42.2",
-        "playcanvas": "^2.20.4",
+        "playcanvas": "~2.19.7",
         "prism-react-renderer": "^2.4.1",
         "raw-loader": "^4.0.2",
         "react": "^19.2.7",
@@ -17849,13 +17849,13 @@
       }
     },
     "node_modules/playcanvas": {
-      "version": "2.20.4",
-      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.20.4.tgz",
-      "integrity": "sha512-w7rUGAyUn8ImUjF536OC13FaE3chcRJXoiiivGbxoPiupRnCY69lKBw5a2u+ZNmhOeaZiqlcOq2ZQpWV4X1GFQ==",
+      "version": "2.19.7",
+      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.19.7.tgz",
+      "integrity": "sha512-AuGy5CuCj03FAEBE1qbhgA7ibvBjzG07j4MneT4nd3FEhfvW9IgUbdhRYZ8G6obXcdaIvHezEAhr7qjq0FkxHw==",
       "license": "MIT",
       "dependencies": {
         "@types/webxr": "^0.5.24",
-        "@webgpu/types": "^0.1.70"
+        "@webgpu/types": "^0.1.66"
       },
       "engines": {
         "node": ">=18.3.0"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "js-yaml": "^5.2.0",
     "leva": "^0.10.1",
     "motion": "^12.42.2",
-    "playcanvas": "^2.20.4",
+    "playcanvas": "~2.19.7",
     "prism-react-renderer": "^2.4.1",
     "raw-loader": "^4.0.2",
     "react": "^19.2.7",


### PR DESCRIPTION
## What changed

Pins `playcanvas` to `~2.19.7` in `package.json` (with the matching `package-lock.json` update), reverting the bump to 2.20.4 from f6039fa.

## Why

`npm run build` has been failing on `main` since the dependency update (CI and the GitHub Pages deploy are both red). Static site generation crashes on all 639 doc pages.

Root cause: engine 2.20.0 includes playcanvas/engine#8950, which moved `updateClientRect()` into the base `GraphicsDevice` constructor. That calls `this.canvas.getBoundingClientRect()`. `@playcanvas/react` creates a `NullGraphicsDevice` for SSR using a bare mock object (`{ id: 'pc-react-mock-canvas' }`) as the canvas — and does so at module scope — so merely importing `@playcanvas/react` during SSG throws `getBoundingClientRect is not a function`. The crash corrupts the shared doc-page chunk, which is why every page then fails with the misleading `Cannot read properties of undefined (reading 'A')` error.

## Notes for reviewers

* The pin uses a tilde range on purpose: `^2.19.7` would immediately re-resolve to 2.20.4 and break again.
* This is a stopgap. The real fixes are upstream: guard the constructor-time `getBoundingClientRect()` call in the engine, and/or give `@playcanvas/react`'s SSR mock canvas a `getBoundingClientRect` stub (and make its module-scope null application lazy). Once either ships, this pin can be relaxed back to `^2.20.x`.
* Verified locally: full `npm run build` (en + ja) passes with 2.19.7 and fails with 2.20.0 through 2.20.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
