### PR TITLE
fix(i18n): skip static duplication in ja builds (#880)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,20 @@ jobs:
     - name: Build
       run: npm run build
 
+    - name: Check build size and static deduplication
+      run: |
+        SIZE_MB=$(du -sm build | cut -f1)
+        echo "Total build size: ${SIZE_MB} MB"
+        for dir in img video downloads; do
+          if [ -d "build/ja/${dir}" ]; then
+            echo "::error::build/ja/${dir} should not exist (static assets must not be duplicated per locale)"
+            exit 1
+          fi
+        done
+        if [ "$SIZE_MB" -gt 950 ]; then
+          echo "::warning::Build size ${SIZE_MB} MB exceeds 950 MB GitHub Pages safety target (see issue #880)"
+        fi
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -6,16 +6,19 @@
 
 import {themes as prismThemes} from 'prism-react-renderer';
 import remarkTypedoc from './utils/plugins/remark-typedoc.mjs';
+import remarkPathnameStatic, { remarkRootStaticLinks } from './utils/plugins/remark-pathname-static.mjs';
 import pluginLlms from './utils/plugins/docusaurus-plugin-llms.mjs';
+
+const siteUrl = process.env.SITE_URL ?? 'https://developer.playcanvas.com';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'PlayCanvas Developer Site',
   tagline: 'Start learning PlayCanvas today!',
-  favicon: 'img/favicon.ico',
+  favicon: `${siteUrl}/img/favicon.ico`,
 
   // Set the production url of your site here
-  url: 'https://developer.playcanvas.com',
+  url: siteUrl,
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',
@@ -33,6 +36,15 @@ const config = {
     defaultLocale: 'en',
     locales: ['en', 'ja']
   },
+
+  // Shared static/ is copied only for the default locale in production builds.
+  // remark-pathname-static prefixes shared doc asset URLs at compile time for ja pages.
+  // themeConfig favicon/image/logo use absolute URLs so useBaseUrl skips the /ja/ prefix.
+  staticDirectories:
+    process.env.NODE_ENV === 'development' ||
+    (process.env.DOCUSAURUS_CURRENT_LOCALE ?? 'en') === 'en'
+      ? ['static']
+      : [],
 
   future: {
     faster: true,
@@ -251,7 +263,9 @@ const config = {
         docs: {
           routeBasePath: '/', // Serve the docs at the site's root
           sidebarPath: './sidebars.js',
+          beforeDefaultRemarkPlugins: [remarkPathnameStatic],
           remarkPlugins: [
+            remarkRootStaticLinks,
             [remarkTypedoc, {
                typeResolver: ({ displayName, types, tags }) => {
 
@@ -300,12 +314,12 @@ const config = {
         indexName: 'developer-playcanvas',
         contextualSearch: true,
       },
-      image: 'img/playcanvas-social-card.jpg',
+      image: `${siteUrl}/img/playcanvas-social-card.jpg`,
       navbar: {
         title: 'PlayCanvas Docs',
         logo: {
           alt: 'PlayCanvas Logo',
-          src: 'img/playcanvas.webp',
+          src: `${siteUrl}/img/playcanvas.webp`,
         },
         items: [
           {

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -8,7 +8,7 @@
   text-align: center;
   position: relative;
   overflow: hidden;
-  background-image: url('/img/playcanvas-background.png');
+  background-image: url('@site/static/img/playcanvas-background.png');
   background-size: cover;
   background-repeat: no-repeat;
   background-attachment: fixed;

--- a/utils/plugins/remark-pathname-static.mjs
+++ b/utils/plugins/remark-pathname-static.mjs
@@ -1,0 +1,101 @@
+import { visit } from 'unist-util-visit';
+
+/** @typedef {import('unist').Node} Node */
+
+/**
+ * Shared static asset path prefixes emitted once under build/ (site root).
+ *
+ * @see https://github.com/playcanvas/developer-site/issues/880
+ */
+const STATIC_RE = /^\/(?:img|video|downloads|assets)\//;
+const PATHNAME_STATIC_RE = /^pathname:\/\/\/(?:img|video|downloads|assets)\//;
+
+/**
+ * @param {string} name
+ * @param {boolean} value
+ */
+function jsxBooleanAttribute(name, value) {
+    return {
+        type: 'mdxJsxAttribute',
+        name,
+        value: {
+            type: 'mdxJsxAttributeValueExpression',
+            value: String(value),
+            data: {
+                estree: {
+                    type: 'Program',
+                    body: [
+                        {
+                            type: 'ExpressionStatement',
+                            expression: {
+                                type: 'Literal',
+                                value,
+                                raw: String(value),
+                            },
+                        },
+                    ],
+                    sourceType: 'module',
+                    comments: [],
+                },
+            },
+        },
+    };
+}
+
+/**
+ * Prefix shared static asset URLs with pathname:// at MDX compile time so
+ * Docusaurus serves them as literal site-root paths instead of webpack-bundling
+ * them or requiring a per-locale static/ copy.
+ *
+ * Runs as a beforeDefaultRemarkPlugin, ahead of transformImage/transformLinks.
+ */
+export default function remarkPathnameStatic() {
+    return (/** @type {Node} */ tree) => {
+        visit(tree, ['image', 'link'], (node) => {
+            if (node.url && STATIC_RE.test(node.url)) {
+                node.url = `pathname://${node.url}`;
+            }
+        });
+    };
+}
+
+/**
+ * Convert pathname:// static links to JSX anchors that bypass locale baseUrl
+ * and trailingSlash (see @docusaurus/Link — pathname:// is not "internal").
+ *
+ * Runs in remarkPlugins, after transformImage/transformLinks.
+ */
+export function remarkRootStaticLinks() {
+    return (/** @type {Node} */ tree) => {
+        visit(tree, 'link', (node) => {
+            if (!node.url || !PATHNAME_STATIC_RE.test(node.url)) {
+                return;
+            }
+
+            /** @type {import('unist').Node[]} */
+            const attributes = [
+                // Keep pathname:// so Link skips /ja/ prefix and trailingSlash.
+                { type: 'mdxJsxAttribute', name: 'href', value: node.url },
+                jsxBooleanAttribute('autoAddBaseUrl', false),
+                { type: 'mdxJsxAttribute', name: 'target', value: '_blank' },
+                { type: 'mdxJsxAttribute', name: 'rel', value: 'noopener noreferrer' },
+                jsxBooleanAttribute('data-noBrokenLinkCheck', true),
+            ];
+
+            if (node.title) {
+                attributes.push({
+                    type: 'mdxJsxAttribute',
+                    name: 'title',
+                    value: node.title,
+                });
+            }
+
+            Object.assign(node, {
+                type: 'mdxJsxTextElement',
+                name: 'a',
+                attributes,
+                children: node.children,
+            });
+        });
+    };
+}


### PR DESCRIPTION
Fixes #880

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer-site/blob/main/.github/CONTRIBUTING.md).

Fixes #880

## Summary

- Copy `static/` only for the default locale (`en`) in production builds
- Add remark plugins to rewrite doc asset URLs (`/img/`, `/video/`, `/downloads/`) to site-root paths for `ja` pages
- Use `${siteUrl}/img/...` for favicon, og:image, and navbar logo
- CI: fail if `build/ja/{img,video,downloads}` exist

No documentation content changes.

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `build/ja/img`, `build/ja/video`, `build/ja/downloads` do not exist
- [x] `/ja/user-manual/` — logo and inline images load correctly
