### PR TITLE
Bump playcanvas to ^2.20.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "js-yaml": "^5.2.0",
         "leva": "^0.10.1",
         "motion": "^12.42.2",
-        "playcanvas": "~2.19.7",
+        "playcanvas": "^2.20.5",
         "prism-react-renderer": "^2.4.1",
         "raw-loader": "^4.0.2",
         "react": "^19.2.7",
@@ -17849,13 +17849,13 @@
       }
     },
     "node_modules/playcanvas": {
-      "version": "2.19.7",
-      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.19.7.tgz",
-      "integrity": "sha512-AuGy5CuCj03FAEBE1qbhgA7ibvBjzG07j4MneT4nd3FEhfvW9IgUbdhRYZ8G6obXcdaIvHezEAhr7qjq0FkxHw==",
+      "version": "2.20.5",
+      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.20.5.tgz",
+      "integrity": "sha512-mvW19ozUL6URXaDdw4s1a2MOIByo1zGmE/yIK/s2KBhdsouetOyaI2zch1qazGh/3LZk1pxvjgbz77PwNZ6sYg==",
       "license": "MIT",
       "dependencies": {
         "@types/webxr": "^0.5.24",
-        "@webgpu/types": "^0.1.66"
+        "@webgpu/types": "^0.1.70"
       },
       "engines": {
         "node": ">=18.3.0"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "js-yaml": "^5.2.0",
     "leva": "^0.10.1",
     "motion": "^12.42.2",
-    "playcanvas": "~2.19.7",
+    "playcanvas": "^2.20.5",
     "prism-react-renderer": "^2.4.1",
     "raw-loader": "^4.0.2",
     "react": "^19.2.7",


### PR DESCRIPTION
## What changed

Bumps `playcanvas` from the temporary `~2.19.7` pin back to `^2.20.5`.

## Why

Engine [v2.20.5](https://github.com/playcanvas/engine/releases/tag/v2.20.5) fixes the `NullGraphicsDevice` constructor crash on mock canvases (playcanvas/engine#8999) that broke static site generation for every doc page. That regression was the reason #1074 pinned the engine to 2.19.x — the pin is no longer needed.

## Notes for reviewers

Verified locally: full `npm run build` (en + ja) passes with 2.20.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
