### PR TITLE
docs: add Programmatic Access page for Web Components

### DIFF
--- a/docs/user-manual/web-components/programmatic-access.md
+++ b/docs/user-manual/web-components/programmatic-access.md
@@ -1,0 +1,83 @@
+---
+title: Programmatic Access
+description: "Drive the engine from JavaScript: await element initialization with whenReady, access engine objects like AppBase and Entity, and target specific apps."
+---
+
+PlayCanvas Web Components let you build rich 3D scenes with nothing but HTML. Sooner or later, though, you may want to reach into the running app from JavaScript: tweaking scene settings, firing events or reacting to UI that lives outside the 3D canvas. This page shows you how to do that safely.
+
+## Element Readiness
+
+Elements like `<pc-app>` initialize asynchronously. Behind the scenes, the app has to create a graphics device, preload assets and build the entity hierarchy before its underlying engine objects exist. If your script queries an element as soon as the page loads, the engine object you are after (such as the app's [`AppBase`](https://api.playcanvas.com/engine/classes/AppBase.html)) may not have been created yet.
+
+The `whenReady` function is the easiest way to wait for the right moment. First, extend your import map so the browser can resolve the package by name:
+
+```html {5}
+<script type="importmap">
+    {
+        "imports": {
+            "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas@latest/build/playcanvas.mjs",
+            "@playcanvas/web-components": "https://cdn.jsdelivr.net/npm/@playcanvas/web-components@latest/dist/pwc.mjs"
+        }
+    }
+</script>
+```
+
+Then import it and await the element you need:
+
+```html
+<script type="module">
+    import { whenReady } from '@playcanvas/web-components';
+
+    const { app } = await whenReady('pc-app'); // app is the engine's AppBase
+    app.scene.exposure = 0.5;
+</script>
+```
+
+`whenReady` resolves with the element once its engine object has been created. If the element is already initialized by the time you call it, it resolves immediately. There is no need to wait for `DOMContentLoaded` or listen for events.
+
+## Reaching Engine Objects
+
+`whenReady` accepts a tag name, any CSS selector or a direct element reference, so it works for every asynchronously initializing element — not just `<pc-app>`:
+
+```javascript
+const { scene } = await whenReady('pc-scene');
+const camera = (await whenReady('pc-camera')).component;
+const { entity } = await whenReady('pc-entity[name="player"]');
+```
+
+Each element exposes its engine counterpart through a property:
+
+| Element | Property | Engine Type |
+| --- | --- | --- |
+| [`<pc-app>`](./tags/pc-app.md) | `app` | [`AppBase`](https://api.playcanvas.com/engine/classes/AppBase.html) |
+| [`<pc-entity>`](./tags/pc-entity.md) | `entity` | [`Entity`](https://api.playcanvas.com/engine/classes/Entity.html) |
+| [`<pc-scene>`](./tags/pc-scene.md) | `scene` | [`Scene`](https://api.playcanvas.com/engine/classes/Scene.html) |
+| Component tags (`<pc-camera>`, `<pc-light>`, ...) | `component` | The corresponding [`Component`](https://api.playcanvas.com/engine/classes/Component.html) |
+
+## Targeting a Specific App
+
+Most pages contain a single `<pc-app>`, and `whenReady('pc-app')` finds it (the first one in document order). If your page hosts several apps, pass a selector to pick one:
+
+```javascript
+const left = await whenReady('#left');
+const right = await whenReady('#right');
+```
+
+## Waiting on an Element You Already Hold
+
+Every asynchronously initializing element also has a `ready()` method that returns a promise resolving with the element itself. This is the primitive that `whenReady` builds on, and it is handy when you already hold a reference — for example, an element you just created:
+
+```javascript
+const appElement = document.createElement('pc-app');
+document.body.appendChild(appElement);
+
+await appElement.ready();
+```
+
+## TypeScript
+
+The package registers all of its tags with TypeScript's `HTMLElementTagNameMap`, so element queries are fully typed: `document.querySelector('pc-app')` is an `AppElement | null`, and `whenReady('pc-camera')` resolves a `CameraComponentElement`. Passing the tag of an element that does not initialize asynchronously (such as `pc-asset`) is a compile-time error.
+
+## When to Use Scripts Instead
+
+`whenReady` is ideal for page-level glue: connecting DOM UI to the app, tweaking settings, firing events. For substantial or reusable behavior — anything with an update loop or per-entity logic — write a script and attach it with `<pc-script>` instead. Scripts receive a fully initialized entity, so no readiness check is ever needed. See [Adding Behavior with Scripts](scripting.md).

--- a/docs/user-manual/web-components/programmatic-access.md
+++ b/docs/user-manual/web-components/programmatic-access.md
@@ -54,6 +54,8 @@ Each element exposes its engine counterpart through a property:
 | [`<pc-scene>`](./tags/pc-scene.md) | `scene` | [`Scene`](https://api.playcanvas.com/engine/classes/Scene.html) |
 | Component tags (`<pc-camera>`, `<pc-light>`, ...) | `component` | The corresponding [`Component`](https://api.playcanvas.com/engine/classes/Component.html) |
 
+These properties are typed non-null: once the element is ready, its engine object is guaranteed to exist.
+
 ## Targeting a Specific App
 
 Most pages contain a single `<pc-app>`, and `whenReady('pc-app')` finds it (the first one in document order). If your page hosts several apps, pass a selector to pick one:
@@ -65,14 +67,16 @@ const right = await whenReady('#right');
 
 ## Waiting on an Element You Already Hold
 
-Every asynchronously initializing element also has a `ready()` method that returns a promise resolving with the element itself. This is the primitive that `whenReady` builds on, and it is handy when you already hold a reference — for example, an element you just created:
+`whenReady` also accepts an element reference directly, which is handy when you already hold one — for example, an element you just created:
 
 ```javascript
 const appElement = document.createElement('pc-app');
 document.body.appendChild(appElement);
 
-await appElement.ready();
+const { app } = await whenReady(appElement);
 ```
+
+(Under the hood, every asynchronously initializing element has a `ready()` method that returns a promise resolving with the element itself — `whenReady` is a convenience wrapper around it.)
 
 ## TypeScript
 

--- a/docs/user-manual/web-components/xr.md
+++ b/docs/user-manual/web-components/xr.md
@@ -68,27 +68,32 @@ Finally, you'll need to add some UI controls to allow the user to enter and exit
 Let's add event listeners to the buttons to trigger an XR session when the user clicks them.
 
 ```javascript
-document.addEventListener('DOMContentLoaded', async () => {
-    const appElement = await document.querySelector('pc-app').ready();
-    const app = appElement.app;
-    const xr = app.xr;
-    const camera = app.root.findComponent('camera');
+import { whenReady } from '@playcanvas/web-components';
 
-    document.getElementById('enterAR').addEventListener('click', () => {
-        xr.start(camera, 'immersive-ar', 'local-floor')
-    });
+const { app } = await whenReady('pc-app');
+const xr = app.xr;
+const camera = app.root.findComponent('camera');
 
-    document.getElementById('enterVR').addEventListener('click', () => {
-        xr.start(camera, 'immersive-vr', 'local-floor')
-    });
+document.getElementById('enterAR').addEventListener('click', () => {
+    xr.start(camera, 'immersive-ar', 'local-floor')
+});
 
-    window.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape' && xr.active) {
-            xr.end();
-        }
-    });
+document.getElementById('enterVR').addEventListener('click', () => {
+    xr.start(camera, 'immersive-vr', 'local-floor')
+});
+
+window.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && xr.active) {
+        xr.end();
+    }
 });
 ```
+
+:::note
+
+This snippet imports `whenReady` by package name, which requires `@playcanvas/web-components` to be listed in your page's import map. See [Programmatic Access](programmatic-access.md) for details.
+
+:::
 
 Most of the [Web Component examples](https://playcanvas.github.io/web-components/examples/) have integrated support for XR. Consult their source code to see how it's done.
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/programmatic-access.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/programmatic-access.md
@@ -54,6 +54,8 @@ const { entity } = await whenReady('pc-entity[name="player"]');
 | [`<pc-scene>`](./tags/pc-scene.md) | `scene` | [`Scene`](https://api.playcanvas.com/engine/classes/Scene.html) |
 | コンポーネントタグ (`<pc-camera>`、`<pc-light>` など) | `component` | 対応する [`Component`](https://api.playcanvas.com/engine/classes/Component.html) |
 
+これらのプロパティは非 null として型付けされています。要素の準備が完了すれば、エンジンオブジェクトの存在が保証されます。
+
 ## 特定のアプリを対象にする
 
 ほとんどのページには `<pc-app>` が1つだけ含まれており、`whenReady('pc-app')` はそれ(ドキュメント順で最初のもの)を見つけます。ページに複数のアプリがある場合は、セレクターを渡して選択します。
@@ -65,14 +67,16 @@ const right = await whenReady('#right');
 
 ## すでに保持している要素を待つ
 
-非同期に初期化されるすべての要素には、要素自身とともに解決される Promise を返す `ready()` メソッドもあります。これは `whenReady` の基盤となるプリミティブであり、作成したばかりの要素など、すでに参照を保持している場合に便利です。
+`whenReady` には要素への参照を直接渡すこともできます。作成したばかりの要素など、すでに参照を保持している場合に便利です。
 
 ```javascript
 const appElement = document.createElement('pc-app');
 document.body.appendChild(appElement);
 
-await appElement.ready();
+const { app } = await whenReady(appElement);
 ```
+
+(内部的には、非同期に初期化されるすべての要素が、要素自身とともに解決される Promise を返す `ready()` メソッドを持っており、`whenReady` はその便利なラッパーです。)
 
 ## TypeScript
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/programmatic-access.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/programmatic-access.md
@@ -1,0 +1,83 @@
+---
+title: プログラムによるアクセス
+description: "JavaScriptからエンジンを操作: whenReadyで要素の初期化を待ち、AppBaseやEntityなどのエンジンオブジェクトへアクセスし、特定のアプリを対象にします。"
+---
+
+PlayCanvas Web Components を使えば、HTML だけでリッチな 3D シーンを構築できます。しかし、シーン設定の調整、イベントの発火、3D キャンバスの外にある UI への反応など、JavaScript から実行中のアプリを操作したくなる場面もあるでしょう。このページでは、それを安全に行う方法を紹介します。
+
+## 要素の準備完了
+
+`<pc-app>` のような要素は非同期に初期化されます。内部では、グラフィックスデバイスの作成、アセットのプリロード、エンティティ階層の構築が完了して初めて、対応するエンジンオブジェクトが存在するようになります。ページの読み込み直後にスクリプトで要素を取得しても、目的のエンジンオブジェクト(たとえばアプリの [`AppBase`](https://api.playcanvas.com/engine/classes/AppBase.html))はまだ作成されていない可能性があります。
+
+`whenReady` 関数は、その瞬間を待つ最も簡単な方法です。まず、ブラウザがパッケージ名を解決できるようにインポートマップを拡張します。
+
+```html {5}
+<script type="importmap">
+    {
+        "imports": {
+            "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas@latest/build/playcanvas.mjs",
+            "@playcanvas/web-components": "https://cdn.jsdelivr.net/npm/@playcanvas/web-components@latest/dist/pwc.mjs"
+        }
+    }
+</script>
+```
+
+次に、インポートして必要な要素を待ちます。
+
+```html
+<script type="module">
+    import { whenReady } from '@playcanvas/web-components';
+
+    const { app } = await whenReady('pc-app'); // app はエンジンの AppBase
+    app.scene.exposure = 0.5;
+</script>
+```
+
+`whenReady` は、エンジンオブジェクトが作成された時点で要素とともに解決されます。呼び出した時点で要素がすでに初期化されていれば、即座に解決されます。`DOMContentLoaded` を待ったり、イベントをリッスンしたりする必要はありません。
+
+## エンジンオブジェクトへのアクセス
+
+`whenReady` はタグ名、任意の CSS セレクター、または要素への参照を受け取ります。そのため、`<pc-app>` に限らず、非同期に初期化されるすべての要素で利用できます。
+
+```javascript
+const { scene } = await whenReady('pc-scene');
+const camera = (await whenReady('pc-camera')).component;
+const { entity } = await whenReady('pc-entity[name="player"]');
+```
+
+各要素は、対応するエンジンオブジェクトをプロパティとして公開しています。
+
+| 要素 | プロパティ | エンジンの型 |
+| --- | --- | --- |
+| [`<pc-app>`](./tags/pc-app.md) | `app` | [`AppBase`](https://api.playcanvas.com/engine/classes/AppBase.html) |
+| [`<pc-entity>`](./tags/pc-entity.md) | `entity` | [`Entity`](https://api.playcanvas.com/engine/classes/Entity.html) |
+| [`<pc-scene>`](./tags/pc-scene.md) | `scene` | [`Scene`](https://api.playcanvas.com/engine/classes/Scene.html) |
+| コンポーネントタグ (`<pc-camera>`、`<pc-light>` など) | `component` | 対応する [`Component`](https://api.playcanvas.com/engine/classes/Component.html) |
+
+## 特定のアプリを対象にする
+
+ほとんどのページには `<pc-app>` が1つだけ含まれており、`whenReady('pc-app')` はそれ(ドキュメント順で最初のもの)を見つけます。ページに複数のアプリがある場合は、セレクターを渡して選択します。
+
+```javascript
+const left = await whenReady('#left');
+const right = await whenReady('#right');
+```
+
+## すでに保持している要素を待つ
+
+非同期に初期化されるすべての要素には、要素自身とともに解決される Promise を返す `ready()` メソッドもあります。これは `whenReady` の基盤となるプリミティブであり、作成したばかりの要素など、すでに参照を保持している場合に便利です。
+
+```javascript
+const appElement = document.createElement('pc-app');
+document.body.appendChild(appElement);
+
+await appElement.ready();
+```
+
+## TypeScript
+
+このパッケージはすべてのタグを TypeScript の `HTMLElementTagNameMap` に登録しているため、要素のクエリは完全に型付けされます。`document.querySelector('pc-app')` は `AppElement | null` となり、`whenReady('pc-camera')` は `CameraComponentElement` に解決されます。非同期に初期化されない要素のタグ(`pc-asset` など)を渡すと、コンパイル時エラーになります。
+
+## スクリプトを使うべき場面
+
+`whenReady` は、DOM の UI とアプリの接続、設定の調整、イベントの発火といったページレベルのグルーコードに最適です。更新ループやエンティティごとのロジックを持つような本格的で再利用可能な動作には、代わりにスクリプトを書いて `<pc-script>` でアタッチしてください。スクリプトは完全に初期化されたエンティティを受け取るため、準備完了の確認は一切不要です。[スクリプトで動作を追加する](scripting.md) を参照してください。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/xr.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/xr.md
@@ -68,27 +68,32 @@ XR スクリプトは、シーンのカメラを次のようにセットアッ�
 ユーザーがボタンをクリックしたときに XR セッションをトリガーするように、ボタンにイベントリスナーを追加しましょう。
 
 ```javascript
-document.addEventListener('DOMContentLoaded', async () => {
-    const appElement = await document.querySelector('pc-app').ready();
-    const app = appElement.app;
-    const xr = app.xr;
-    const camera = app.root.findComponent('camera');
+import { whenReady } from '@playcanvas/web-components';
 
-    document.getElementById('enterAR').addEventListener('click', () => {
-        xr.start(camera, 'immersive-ar', 'local-floor')
-    });
+const { app } = await whenReady('pc-app');
+const xr = app.xr;
+const camera = app.root.findComponent('camera');
 
-    document.getElementById('enterVR').addEventListener('click', () => {
-        xr.start(camera, 'immersive-vr', 'local-floor')
-    });
+document.getElementById('enterAR').addEventListener('click', () => {
+    xr.start(camera, 'immersive-ar', 'local-floor')
+});
 
-    window.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape' && xr.active) {
-            xr.end();
-        }
-    });
+document.getElementById('enterVR').addEventListener('click', () => {
+    xr.start(camera, 'immersive-vr', 'local-floor')
+});
+
+window.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && xr.active) {
+        xr.end();
+    }
 });
 ```
+
+:::note
+
+このスニペットはパッケージ名で `whenReady` をインポートしています。そのため、ページのインポートマップに `@playcanvas/web-components` を登録しておく必要があります。詳細は [プログラムによるアクセス](programmatic-access.md) を参照してください。
+
+:::
 
 ほとんどの [Web Component の例](https://playcanvas.github.io/web-components/examples/) には、XR のサポートが統合されています。それらのソースコードを参照して、どのように行われているかを確認してください。
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -504,6 +504,7 @@ const sidebars = {
         'user-manual/web-components/getting-started',
         'user-manual/web-components/building-a-scene',
         'user-manual/web-components/scripting',
+        'user-manual/web-components/programmatic-access',
         'user-manual/web-components/xr',
         {
           type: 'category',


### PR DESCRIPTION
## What

Adds a **Programmatic Access** page to the Web Components user manual (between *Adding Behavior with Scripts* and *XR* in the sidebar), documenting the new `whenReady()` API:

- Why elements initialize asynchronously and what that means for page scripts
- The import-map setup and the `const { app } = await whenReady('pc-app')` pattern
- A table mapping elements to their engine objects (`app`, `entity`, `scene`, `component`)
- Targeting a specific app on multi-app pages via selectors
- The `ready()` primitive for elements you already hold
- TypeScript support (`HTMLElementTagNameMap` typing)
- Guidance on when to prefer `<pc-script>` over page-level glue

Also modernizes the XR page's UI snippet, which used the old `document.querySelector('pc-app').ready()` pattern wrapped in `DOMContentLoaded` (redundant for module scripts). Japanese translations of both pages are included.

## Dependencies

Documents `whenReady`, which lands in `@playcanvas/web-components` via playcanvas/web-components#264 — this PR should merge once that ships in an npm release (the CDN snippets reference `@latest`).

## Testing

- `npm run lint` (markdownlint): 0 issues in 1302 files
- Full `docusaurus build` passes for both `en` and `ja` locales (broken-link checking enabled)
- Rendered site verified locally: page renders in both locales with correct breadcrumbs, all six sections, code blocks and the engine-object table

🤖 Generated with [Claude Code](https://claude.com/claude-code)