### PR TITLE
docs: document the ready event and remaining JS API surface

### DIFF
--- a/docs/user-manual/web-components/programmatic-access.md
+++ b/docs/user-manual/web-components/programmatic-access.md
@@ -35,6 +35,8 @@ Then import it and await the element you need:
 
 `whenReady` resolves with the element once its engine object has been created. If the element is already initialized by the time you call it, it resolves immediately. There is no need to wait for `DOMContentLoaded` or listen for events.
 
+`whenReady` rejects rather than waiting in three cases: the string is not a valid CSS selector, no element in the document matches it, or the matched element does not initialize asynchronously (`<pc-material>` or `<pc-module>`). A selector is evaluated once — after the document finishes parsing, if called while it is still loading — so it finds elements present in the markup, not elements added later. To wait on a dynamically created element, pass the element reference itself (see [below](#waiting-on-an-element-you-already-hold)).
+
 :::note[Misplaced Elements]
 
 The promise never settles if the element cannot finish initializing — for example, a `<pc-script>` that is not a direct child of `<pc-scripts>`. A component element outside a `<pc-entity>` is the exception: it still becomes ready, but its `component` is `null`. Either way, a misplaced element logs a console warning naming the parent it requires.
@@ -51,6 +53,8 @@ const camera = (await whenReady('pc-camera')).component;
 const { entity } = await whenReady('pc-entity[name="player"]');
 ```
 
+Readiness is per element: an entity element becomes ready when its `Entity` exists, which is *before* its child component elements have initialized. To reach a component, await the component element itself — as the `pc-camera` line above does — rather than awaiting the entity and reading the component off it.
+
 Each element exposes its engine counterpart through a property:
 
 | Element | Property | Engine Type |
@@ -60,7 +64,9 @@ Each element exposes its engine counterpart through a property:
 | [`<pc-scene>`](./tags/pc-scene.md) | `scene` | [`Scene`](https://api.playcanvas.com/engine/classes/Scene.html) |
 | Component tags (`<pc-camera>`, `<pc-light>`, ...) | `component` | The corresponding [`Component`](https://api.playcanvas.com/engine/classes/Component.html) |
 
-These properties are typed non-null: once the element is ready, its engine object is guaranteed to exist.
+These accessors are typed nullable: they return `null` before the element is ready and after it is torn down. Awaiting readiness first is what guarantees a non-null result. The exception is [`<pc-model>`](./tags/pc-model.md), which currently becomes ready before its GLB has loaded — its `entity` remains `null` until the model instantiates.
+
+Every asynchronously initializing element also exposes `closestApp` and `closestEntity` getters, returning its nearest `<pc-app>` or `<pc-entity>` *ancestor* element (or `null` if there is none) — handy when you hold a component element and need its owning entity or app.
 
 ## Targeting a Specific App
 
@@ -83,6 +89,37 @@ const { app } = await whenReady(appElement);
 ```
 
 (Under the hood, every asynchronously initializing element has a `ready()` method that returns a promise resolving with the element itself — `whenReady` is a convenience wrapper around it.)
+
+## The `ready` Event
+
+Alongside the promise API, every asynchronously initializing element dispatches a `ready` event at the moment its engine object is created. The event bubbles and is composed, so a single listener on `document` observes every element as it comes up:
+
+```javascript
+document.addEventListener('ready', (event) => {
+    console.log(`${event.target.tagName.toLowerCase()} is ready`);
+});
+```
+
+Use whichever fits the job: `whenReady` *awaits a specific element* and resolves even if that element became ready long ago, while the `ready` event *reacts to elements as they initialize* — including elements added to the page after load, which `whenReady`'s selector form cannot see. The event fires once per element, so attach the listener before the elements you care about initialize; an element that became ready earlier will not fire it again.
+
+## Assets, Materials and Modules
+
+Resources declared in markup have their own JavaScript routes. [`<pc-asset>`](./tags/pc-asset.md) and [`<pc-material>`](./tags/pc-material.md) expose static lookups that resolve an `id` to the engine object:
+
+```javascript
+import { AssetElement, MaterialElement } from '@playcanvas/web-components';
+
+const asset = AssetElement.get('car');        // the engine Asset declared by <pc-asset id="car">
+const material = MaterialElement.get('gold'); // the material declared by <pc-material id="gold">
+```
+
+`AssetElement.get` returns the registered [`Asset`](https://api.playcanvas.com/engine/classes/Asset.html), which may not have finished loading yet — check `asset.loaded`, or subscribe to its `load` event, before using `asset.resource`.
+
+[`<pc-module>`](./tags/pc-module.md) does not initialize asynchronously, so it cannot be awaited with `whenReady`. Instead, it exposes `getLoadPromise()`, which resolves once the WebAssembly module is ready:
+
+```javascript
+await document.querySelector('pc-module[name="Ammo"]').getLoadPromise();
+```
 
 ## TypeScript
 

--- a/docs/user-manual/web-components/xr.md
+++ b/docs/user-manual/web-components/xr.md
@@ -122,6 +122,25 @@ This snippet imports `whenReady` by package name, which requires `@playcanvas/we
 
 :::
 
+### The Camera Element API
+
+For minimal cases, [`<pc-camera>`](tags/pc-camera.md)'s element API can start and end XR sessions directly — no scripts required:
+
+```javascript
+import { whenReady } from '@playcanvas/web-components';
+
+const camera = await whenReady('pc-camera');
+
+if (camera.xrAvailable) {
+    camera.startXr('immersive-vr', 'local-floor');
+}
+
+// ...and later, to leave the session:
+camera.endXr();
+```
+
+`startXr(type, space)` takes the session type (`'immersive-ar'` or `'immersive-vr'`) and a reference space (`'viewer'`, `'local'`, `'local-floor'`, `'bounded-floor'` or `'unbounded'`). The `xrAvailable` getter reports whether an immersive session can be started; `startXr` does nothing while it is `false`. Note that the `xrSession` script also manages the camera rig transforms, AR transparency and session cleanup for you — prefer it for full experiences, and the element API for quick tests and simple viewers.
+
 Most of the [Web Component examples](https://playcanvas.github.io/web-components/examples/) have integrated support for XR. Consult their source code to see how it's done.
 
 ## Next Steps

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/programmatic-access.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/programmatic-access.md
@@ -35,6 +35,8 @@ PlayCanvas Web Components を使えば、HTML だけでリッチな 3D シーン
 
 `whenReady` は、エンジンオブジェクトが作成された時点で要素とともに解決されます。呼び出した時点で要素がすでに初期化されていれば、即座に解決されます。`DOMContentLoaded` を待ったり、イベントをリッスンしたりする必要はありません。
 
+`whenReady` は、次の3つの場合には待機せずに拒否（reject）されます: 文字列が有効なCSSセレクターでない場合、ドキュメント内に一致する要素がない場合、一致した要素が非同期に初期化されない要素（`<pc-material>` または `<pc-module>`）である場合です。セレクターは一度だけ評価されます（ドキュメントの解析中に呼び出された場合は、解析の完了後に評価されます）。そのため、マークアップに存在する要素は見つかりますが、後から追加される要素は見つかりません。動的に作成した要素を待つには、要素への参照をそのまま渡してください（[下記](#すでに保持している要素を待つ)参照）。
+
 :::note[誤配置された要素]
 
 要素が初期化を完了できない場合（たとえば、`<pc-scripts>` の直接の子ではない `<pc-script>`）、Promiseは決して解決されません。例外は `<pc-entity>` の外にあるコンポーネント要素で、この場合はready状態にはなりますが、`component` は `null` になります。いずれの場合も、誤った場所に配置された要素は、必要な親要素の名前を含むコンソール警告をログに出力します。
@@ -51,6 +53,8 @@ const camera = (await whenReady('pc-camera')).component;
 const { entity } = await whenReady('pc-entity[name="player"]');
 ```
 
+準備完了（ready）は要素ごとの状態です。エンティティ要素は、その `Entity` が存在した時点で準備完了になります。これは、子のコンポーネント要素が初期化される*前*です。コンポーネントにアクセスするには、エンティティを待ってからコンポーネントを読み取るのではなく、上の `pc-camera` の行のように、コンポーネント要素自体を待ってください。
+
 各要素は、対応するエンジンオブジェクトをプロパティとして公開しています。
 
 | 要素 | プロパティ | エンジンの型 |
@@ -60,7 +64,9 @@ const { entity } = await whenReady('pc-entity[name="player"]');
 | [`<pc-scene>`](./tags/pc-scene.md) | `scene` | [`Scene`](https://api.playcanvas.com/engine/classes/Scene.html) |
 | コンポーネントタグ (`<pc-camera>`、`<pc-light>` など) | `component` | 対応する [`Component`](https://api.playcanvas.com/engine/classes/Component.html) |
 
-これらのプロパティは非 null として型付けされています。要素の準備が完了すれば、エンジンオブジェクトの存在が保証されます。
+これらのアクセサーはnull許容として型付けされています。要素の準備が完了する前と、破棄された後には `null` を返します。先に準備完了を待つことが、非nullの結果を保証します。例外は [`<pc-model>`](./tags/pc-model.md) で、現時点ではGLBの読み込みが完了する前に準備完了となるため、モデルがインスタンス化されるまで `entity` は `null` のままです。
+
+非同期に初期化されるすべての要素は、`closestApp` と `closestEntity` ゲッターも公開しています。これらは、最も近い*祖先*の `<pc-app>` または `<pc-entity>` 要素（存在しない場合は `null`）を返します。コンポーネント要素を保持していて、それが属するエンティティやアプリが必要な場合に便利です。
 
 ## 特定のアプリを対象にする
 
@@ -83,6 +89,37 @@ const { app } = await whenReady(appElement);
 ```
 
 (内部的には、非同期に初期化されるすべての要素が、要素自身とともに解決される Promise を返す `ready()` メソッドを持っており、`whenReady` はその便利なラッパーです。)
+
+## `ready` イベント
+
+Promise APIに加えて、非同期に初期化されるすべての要素は、エンジンオブジェクトが作成された時点で `ready` イベントをディスパッチします。このイベントはバブリングし、composedであるため、`document` に1つリスナーを付けるだけで、すべての要素の準備完了を監視できます。
+
+```javascript
+document.addEventListener('ready', (event) => {
+    console.log(`${event.target.tagName.toLowerCase()} is ready`);
+});
+```
+
+用途に応じて使い分けてください。`whenReady` は*特定の要素を待つ*ためのもので、その要素がずっと前に準備完了していても解決されます。一方 `ready` イベントは、*要素が初期化されるのに反応する*ためのものです — `whenReady` のセレクター形式では見つけられない、読み込み後にページへ追加された要素も含まれます。イベントは要素ごとに1回だけ発火するため、対象の要素が初期化される前にリスナーを登録してください。すでに準備完了となった要素が再度発火することはありません。
+
+## アセット、マテリアル、モジュール
+
+マークアップで宣言したリソースには、専用のJavaScriptルートがあります。[`<pc-asset>`](./tags/pc-asset.md) と [`<pc-material>`](./tags/pc-material.md) は、`id` からエンジンオブジェクトを解決する静的なルックアップを公開しています。
+
+```javascript
+import { AssetElement, MaterialElement } from '@playcanvas/web-components';
+
+const asset = AssetElement.get('car');        // <pc-asset id="car"> が宣言したエンジンのAsset
+const material = MaterialElement.get('gold'); // <pc-material id="gold"> が宣言したマテリアル
+```
+
+`AssetElement.get` は登録済みの [`Asset`](https://api.playcanvas.com/engine/classes/Asset.html) を返しますが、読み込みが完了していない場合があります。`asset.resource` を使用する前に、`asset.loaded` を確認するか、`load` イベントを購読してください。
+
+[`<pc-module>`](./tags/pc-module.md) は非同期に初期化されないため、`whenReady` では待てません。代わりに、WebAssemblyモジュールの準備が完了すると解決される `getLoadPromise()` を公開しています。
+
+```javascript
+await document.querySelector('pc-module[name="Ammo"]').getLoadPromise();
+```
 
 ## TypeScript
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/xr.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/xr.md
@@ -122,6 +122,25 @@ app.xr.on('available', (type, available) => {
 
 :::
 
+### カメラ要素のAPI
+
+最小限のケースでは、[`<pc-camera>`](tags/pc-camera.md) の要素APIを使って、スクリプトなしでXRセッションを直接開始・終了できます。
+
+```javascript
+import { whenReady } from '@playcanvas/web-components';
+
+const camera = await whenReady('pc-camera');
+
+if (camera.xrAvailable) {
+    camera.startXr('immersive-vr', 'local-floor');
+}
+
+// ...後でセッションを終了するには:
+camera.endXr();
+```
+
+`startXr(type, space)` は、セッションタイプ（`'immersive-ar'` または `'immersive-vr'`）と参照空間（`'viewer'`、`'local'`、`'local-floor'`、`'bounded-floor'`、`'unbounded'`）を受け取ります。`xrAvailable` ゲッターは、イマーシブセッションを開始できるかどうかを返します。`false` の間、`startXr` は何もしません。なお、`xrSession` スクリプトはカメラリグのトランスフォーム、ARの透過、セッションのクリーンアップも管理してくれるため、本格的な体験にはスクリプトを、簡単なテストやシンプルなビューアーには要素APIを使うのがおすすめです。
+
 ほとんどの [Web Component の例](https://playcanvas.github.io/web-components/examples/) には、XR のサポートが統合されています。それらのソースコードを参照して、どのように行われているかを確認してください。
 
 ## 次のステップ


### PR DESCRIPTION
Roadmap item 1.2 from the Web Components docs improvement plan. The library's JS surface had four undocumented pieces that the audit ranked as the top coverage gap after guides; this PR closes them on **Programmatic Access** and adds the script-free XR route to the **XR** page. English and Japanese land together. Everything is verified against `main` @ 7140979 (v0.10.1) and the key patterns were exercised live in a browser.

## Programmatic Access

- **New "The `ready` Event" section** — every async element dispatches a bubbling, composed `ready` event, so one `document`-level listener observes the whole app coming up. Documents when to prefer it over `whenReady` (reacting vs awaiting; it also covers dynamically added elements that `whenReady`'s selector form can't see) and the attach-early caveat (fires once per element).
- **New "Assets, Materials and Modules" section** — `AssetElement.get(id)` / `MaterialElement.get(id)` as the supported routes from a markup `id` to the engine `Asset`/material (with the may-still-be-loading caveat), and `ModuleElement.getLoadPromise()` as the only way to await a `pc-module`.
- **`whenReady` reject semantics** — invalid selector, no match, or a non-async element; plus the evaluate-once nature of the selector form and the element-reference alternative for dynamic elements.
- **Per-element readiness nuance** — an entity element is ready *before* its child component elements, so component access should await the component element itself. (This is the race the pc-button snippet fix in #1125 avoided; now the principle is documented where readers look for it.)
- **`closestApp` / `closestEntity`** ancestor getters.
- **Correction:** the "properties are typed non-null" sentence predates upstream [#325](https://github.com/playcanvas/web-components/pull/325) (0.10.1), which deliberately made the accessors nullable. Rewritten to state the actual contract — awaiting readiness guarantees a non-null result — with `<pc-model>` noted as the current exception ([playcanvas/web-components#338](https://github.com/playcanvas/web-components/issues/338)).

## XR

- **New "The Camera Element API" section** — `startXr(type, space)`, `endXr()` and `xrAvailable` on `<pc-camera>`, with the full type/reference-space vocabularies, the does-nothing-while-unavailable behavior, and guidance that the `xrSession` script remains preferable for full experiences (rig transforms, AR transparency, cleanup).

## Verification

- `npm run lint` clean; full two-locale build passes (only the two pre-existing broken anchors on unrelated pages — the new intra-page anchors resolve in both locales).
- Live against 0.10.1 in a browser: `AssetElement.get('car')` → loaded container `Asset`; `MaterialElement.get('gold')` → `StandardMaterial`; both documented reject cases fire with exactly the quoted messages; a single document-level listener captured 22 `ready` events across 13 distinct tags, including `pc-model`'s connect-time event (which is what the attach-early caveat is about).

🤖 Generated with [Claude Code](https://claude.com/claude-code)