### PR TITLE
Drop the pc-scrollview horizontal/vertical toggles note

### DIFF
--- a/docs/user-manual/web-components/tags/pc-scrollview.md
+++ b/docs/user-manual/web-components/tags/pc-scrollview.md
@@ -36,15 +36,6 @@ The `<pc-scrollview>` tag is used to define a scroll view component, which lets 
 
 </div>
 
-:::note[`horizontal` and `vertical` are toggles here]
-
-They enable scrolling on an axis, and take `"true"` or `"false"`. This is not the same as the
-`orientation` attribute on [`<pc-scrollbar>`](../pc-scrollbar) and
-[`<pc-layoutgroup>`](../pc-layoutgroup), for which `"horizontal"` and `"vertical"` are the accepted
-*values*.
-
-:::
-
 ## Example
 
 ```html

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scrollview.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scrollview.md
@@ -36,12 +36,6 @@ description: "pc-scrollview要素のリファレンス: コンテンツ、スク
 
 </div>
 
-:::note[ここでの`horizontal`と`vertical`は切り替えスイッチです]
-
-これらは各軸のスクロールを有効にするもので、`"true"`または`"false"`を取ります。[`<pc-scrollbar>`](../pc-scrollbar) や [`<pc-layoutgroup>`](../pc-layoutgroup) の`orientation`属性とは異なります。そちらでは`"horizontal"`と`"vertical"`が受け取る*値*です。
-
-:::
-
 ## 例
 
 ```html


### PR DESCRIPTION
Follow-up to #1135.

Removes the `pc-scrollview` note that distinguished the `horizontal`/`vertical` toggles from the `orientation` attribute's `"horizontal"`/`"vertical"` values. On reflection it wasn't necessary — the attribute-table descriptions already convey that these are on/off toggles. Removed from both the English and Japanese reference pages.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer-site/blob/main/.github/CONTRIBUTING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
