### PR TITLE
docs: correct pc-material metalness default to 0

### DIFF
--- a/docs/user-manual/web-components/tags/pc-material.md
+++ b/docs/user-manual/web-components/tags/pc-material.md
@@ -11,7 +11,7 @@ The `<pc-material>` tag is used to define a material that can be applied to [`<p
 
 :::
 
-The element wraps the engine's [StandardMaterial](https://api.playcanvas.com/engine/classes/StandardMaterial.html) and is metal/rough by default: unlike a bare `StandardMaterial`, the metalness workflow is enabled (`use-metalness` defaults to `"true"`), which is what the `metalness-*` attributes assume and what glTF and other PBR tools mean by PBR.
+The element wraps the engine's [StandardMaterial](https://api.playcanvas.com/engine/classes/StandardMaterial.html) and is metal/rough by default: unlike a bare `StandardMaterial`, the metalness workflow is enabled (`use-metalness` defaults to `"true"`), which is what the `metalness-*` attributes assume and what glTF and other PBR tools mean by PBR. As a companion to that default, `metalness` starts at `0` (dielectric) rather than the engine's `1`, so a material with just a `diffuse` color renders as that color rather than as a fully metallic surface. Set `metalness="1"` for a metal.
 
 :::warning[Gloss vs roughness]
 
@@ -48,7 +48,7 @@ The `roughness` and `roughness-map` attributes are aliases for `gloss` and `glos
 | `height-map` | String | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the height map |
 | `height-map-factor` | Number | `"1"` | Strength of the parallax effect driven by the height map |
 | `id` | String | - | Unique identifier used by other tags to reference this material |
-| `metalness` | Number | `"1"` | How metallic the surface is, from 0 (dielectric) to 1 (metal) |
+| `metalness` | Number | `"0"` | How metallic the surface is, from 0 (dielectric) to 1 (metal) |
 | `metalness-map` | String | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the metalness map |
 | `normal-map` | String | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the normal map |
 | `occlude-direct` | Boolean | `"false"` | Whether ambient occlusion also attenuates direct lighting |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-material.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-material.md
@@ -11,7 +11,7 @@ description: "pc-material要素のリファレンス: カラー、メタルネ�
 
 :::
 
-この要素はエンジンの[StandardMaterial](https://api.playcanvas.com/engine/classes/StandardMaterial.html)をラップし、デフォルトでメタル/ラフネスのワークフローを使用します。素の`StandardMaterial`とは異なり、メタルネスワークフローが有効化されており（`use-metalness`のデフォルトは`"true"`）、これは`metalness-*`属性が前提とする動作であり、glTFをはじめとするPBRツールが「PBR」と呼ぶものです。
+この要素はエンジンの[StandardMaterial](https://api.playcanvas.com/engine/classes/StandardMaterial.html)をラップし、デフォルトでメタル/ラフネスのワークフローを使用します。素の`StandardMaterial`とは異なり、メタルネスワークフローが有効化されており（`use-metalness`のデフォルトは`"true"`）、これは`metalness-*`属性が前提とする動作であり、glTFをはじめとするPBRツールが「PBR」と呼ぶものです。この既定と対になるように、`metalness`はエンジンの`1`ではなく`0`（誘電体）から始まるため、`diffuse`カラーだけを指定したマテリアルは完全な金属面としてではなく、そのカラーとして描画されます。金属にする場合は`metalness="1"`を設定してください。
 
 :::warning[グロスとラフネス]
 
@@ -48,7 +48,7 @@ description: "pc-material要素のリファレンス: カラー、メタルネ�
 | `height-map` | String | - | ハイトマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
 | `height-map-factor` | Number | `"1"` | ハイトマップによる視差効果の強さ |
 | `id` | String | - | 他のタグがこのマテリアルを参照するために使用する一意の識別子 |
-| `metalness` | Number | `"1"` | 表面の金属度。0（誘電体）から1（金属）まで |
+| `metalness` | Number | `"0"` | 表面の金属度。0（誘電体）から1（金属）まで |
 | `metalness-map` | String | - | メタルネスマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
 | `normal-map` | String | - | ノーマルマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
 | `occlude-direct` | Boolean | `"false"` | アンビエントオクルージョンが直接光も減衰させるかどうか |


### PR DESCRIPTION
## Summary

`@playcanvas/web-components` defaults `metalness` to `0` since 0.10.1 (playcanvas/web-components#334), but the `<pc-material>` attribute table still said `"1"`.

- Fix the `metalness` default in the attribute table: `"1"` → `"0"`
- Extend the metal/rough intro paragraph to explain the companion default — the metalness workflow is enabled but `metalness` starts at `0` (dielectric), so a material with just a `diffuse` color renders as that color rather than as a fully metallic surface, with `metalness="1"` one attribute away (mirrors the rationale in the library's `MaterialElement` JSDoc at v0.11.0)

English and Japanese pages updated in lockstep.

## Verification

- Verified against `~/Dev/web-components` at tag `v0.11.0`: `_metalness = 0`, `_useMetalness = true`
- Grepped site-wide: no other page states the `<pc-material>` metalness default
- `npm run lint`: 0 issues
- `npm run build`: both locales green (the two ja broken-anchor warnings are pre-existing on main, in pages untouched here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)