### PR TITLE
docs: update the renamed Web Components example links

### DIFF
--- a/docs/user-manual/web-components/loading-models.md
+++ b/docs/user-manual/web-components/loading-models.md
@@ -294,4 +294,4 @@ entity.anim.baseLayer.pause();
 * [`<pc-model>`](tags/pc-model.md) and [`<pc-node>`](tags/pc-node.md) — the full attribute and method reference for both tags.
 * [Adding Behavior with Scripts](scripting.md) — for logic that outgrows markup, such as sweeping materials across a whole model.
 * [Programmatic Access](programmatic-access.md) — reaching the engine objects behind these elements.
-* [Examples](https://playcanvas.github.io/web-components/examples/) — see [GLB](https://playcanvas.github.io/web-components/examples/glb.html), [Animation](https://playcanvas.github.io/web-components/examples/animation.html) and [Car Configurator](https://playcanvas.github.io/web-components/examples/car-configurator.html).
+* [Examples](https://playcanvas.github.io/web-components/examples/) — see [GLB Loader](https://playcanvas.github.io/web-components/examples/glb-loader.html), [GLB Animation](https://playcanvas.github.io/web-components/examples/glb-animation.html) and [Car Configurator](https://playcanvas.github.io/web-components/examples/car-configurator.html).

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/loading-models.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/loading-models.md
@@ -294,4 +294,4 @@ entity.anim.baseLayer.pause();
 * [`<pc-model>`](tags/pc-model.md)と[`<pc-node>`](tags/pc-node.md) — 両タグの完全な属性・メソッドリファレンス。
 * [スクリプトによる振る舞いの追加](scripting.md) — モデル全体のマテリアルを一括処理するなど、マークアップでは収まらないロジック向け。
 * [プログラムによるアクセス](programmatic-access.md) — これらの要素の背後にあるエンジンオブジェクトへの到達方法。
-* [サンプル](https://playcanvas.github.io/web-components/examples/) — [GLB](https://playcanvas.github.io/web-components/examples/glb.html)、[Animation](https://playcanvas.github.io/web-components/examples/animation.html)、[Car Configurator](https://playcanvas.github.io/web-components/examples/car-configurator.html)をご覧ください。
+* [サンプル](https://playcanvas.github.io/web-components/examples/) — [GLB Loader](https://playcanvas.github.io/web-components/examples/glb-loader.html)、[GLB Animation](https://playcanvas.github.io/web-components/examples/glb-animation.html)、[Car Configurator](https://playcanvas.github.io/web-components/examples/car-configurator.html)をご覧ください。


### PR DESCRIPTION
Companion to [playcanvas/web-components#380](https://github.com/playcanvas/web-components/pull/380), which derives every Web Components example filename from its display name. Two of the pages the Loading Models guide links directly have moved:

```
examples/glb.html        ->  examples/glb-loader.html
examples/animation.html  ->  examples/glb-animation.html
```

The link text had followed the old filenames rather than the examples, so `[GLB]` and `[Animation]` are now `[GLB Loader]` and `[GLB Animation]` — what the pages are actually titled once you land on them.

Car Configurator did not move.

## Scope

These are the only published links pointing at a renamed example. Checked all 13 renames against `docs`, `i18n`, `src`, `static`, `sidebars.js` and `docusaurus.config.js`:

```
$ git grep -hoE "web-components/examples/[a-z0-9.-]+\.html" | sort | uniq -c
      6 web-components/examples/car-configurator.html
      4 web-components/examples/basic-shapes.html
      2 web-components/examples/glb-loader.html     <- was glb.html
      2 web-components/examples/glb-animation.html  <- was animation.html
```

`car-configurator.html` and `basic-shapes.html` (including the iframe embed on the Web Components index) point at examples that did not move, and every link to the examples index is unaffected.

Mirrored into the Japanese translation.

## Sequencing

**Land web-components#380 first** — these URLs 404 until it does. The old URLs 404 the moment it merges, so the gap should be short either way.

## Verification

- `npm run lint` (markdownlint) clean on both changed files
- Grepped all 13 renamed filenames repo-wide: no old references remain
- Confirmed `glb-loader.html` and `glb-animation.html` exist on the web-components rename branch, and that both serve a 200 with the expected `<title>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
